### PR TITLE
Adds elasticsearch dependency and error handler plugin

### DIFF
--- a/.corc.template
+++ b/.corc.template
@@ -2,7 +2,6 @@
   "port": 8000,
   "elasticsearch": {
     "apiVersion": "1.7",
-    "host": "",
-    "path": ""
+    "host": ""
   }
 }

--- a/.corc.template
+++ b/.corc.template
@@ -1,3 +1,8 @@
 {
-  "port": 8000
+  "port": 8000,
+  "elasticsearch": {
+    "apiVersion": "1.7",
+    "host": "",
+    "path": ""
+  }
 }

--- a/bin/server.js
+++ b/bin/server.js
@@ -1,7 +1,10 @@
+const Client = require('elasticsearch').Client;
 const config = require('../config');
 const createServer = require('../server');
 
-createServer(config, (err, server) => {
+const elastic = new Client(config.elasticsearch);
+
+createServer({ elastic, config }, (err, { server }) => {
   if (err) {
     throw err;
   }

--- a/config.js
+++ b/config.js
@@ -1,3 +1,7 @@
 module.exports = require('rc')('co', {
-  port: 8000
+  port: 8000,
+  elasticsearch: {
+    host: '',
+    path: ''
+  }
 });

--- a/config.js
+++ b/config.js
@@ -1,7 +1,6 @@
 module.exports = require('rc')('co', {
   port: 8000,
   elasticsearch: {
-    host: '',
-    path: ''
+    host: ''
   }
 });

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "postcss-cli": "^2.5.2",
     "pre-commit": "^1.1.3",
     "semistandard": "^8.0.0",
+    "sinon": "^1.17.4",
     "svg-sprite": "^1.3.1",
     "tape": "^4.5.1",
     "uglify-js": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "test"
   },
   "dependencies": {
+    "elasticsearch": "^11.0.1",
     "good": "^7.0.1",
     "good-console": "^6.1.2",
     "handlebars": "^4.0.5",

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,6 +1,6 @@
-module.exports = () => ([
+module.exports = ({ elastic }) => ([
   require('./home')(),
-  require('./search')(),
+  require('./search')({ elastic }),
   require('./public')(),
   require('./archive')(),
   require('./archivedoc')(),

--- a/routes/plugins/error.js
+++ b/routes/plugins/error.js
@@ -10,7 +10,9 @@ exports.register = (server, options, next) => {
     const error = Boom.wrap(request.response);
     const accept = request.headers.accept || '';
 
-    request.server.log(['error'], error.stack);
+    if (error.status >= 500) {
+      request.server.log(['error'], error.stack);
+    }
 
     if (accept.indexOf('text/html') === 0) {
       // Respond with an error template

--- a/routes/plugins/error.js
+++ b/routes/plugins/error.js
@@ -1,0 +1,37 @@
+const Boom = require('boom');
+
+// Heavily based on the excellent https://github.com/dwyl/hapi-error
+// and https://gist.github.com/wraithgar/231ee3717b4d2da54044
+exports.register = (server, options, next) => {
+  server.ext('onPreResponse', (request, reply) => {
+    // Only interested in errors
+    if (!(request.response instanceof Error)) return reply.continue();
+
+    const error = Boom.wrap(request.response);
+    const accept = request.headers.accept || '';
+
+    request.server.log(['error'], error.stack);
+
+    if (accept.indexOf('text/html') === 0) {
+      // Respond with an error template
+      return reply.view(options.template || 'error', error).code(error.output.statusCode);
+    }
+
+    if (accept.indexOf('application/vnd.api+json') === 0) {
+      // Simply reformat the payload http://jsonapi.org/format/#errors
+      request.response.output.payload = {
+        errors: [{
+          title: error.output.payload.error,
+          status: error.output.statusCode,
+          detail: error.output.payload.message
+        }]
+      };
+    }
+
+    reply.continue(); // Whatever Hapi wants to do...
+  });
+
+  next();
+};
+
+exports.register.attributes = { name: 'hapi-co-error', version: '0.0.0' };

--- a/routes/plugins/error.js
+++ b/routes/plugins/error.js
@@ -3,6 +3,8 @@ const Boom = require('boom');
 // Heavily based on the excellent https://github.com/dwyl/hapi-error
 // and https://gist.github.com/wraithgar/231ee3717b4d2da54044
 exports.register = (server, options, next) => {
+  options = options || {};
+
   server.ext('onPreResponse', (request, reply) => {
     // Only interested in errors
     if (!(request.response instanceof Error)) return reply.continue();

--- a/routes/search.js
+++ b/routes/search.js
@@ -3,7 +3,7 @@ const filterSchema = require('../schemas/filter');
 const fs = require('fs');
 const exampleData = JSON.parse(fs.readFileSync('./src/data/searchresults.json'));
 
-module.exports = () => ({
+module.exports = ({ elastic }) => ({
   method: 'GET',
   path: '/search/{resource?}',
   handler: (request, reply) => reply(),
@@ -13,6 +13,7 @@ module.exports = () => ({
         resource: Joi.string().valid('objects', 'people', 'documents')
       },
       query: filterSchema.keys({
+        q: Joi.string().required(),
         'page[number]': Joi.number().integer().min(0),
         'page[size]': Joi.number().integer().min(1),
         'fields[objects]': Joi.string(),
@@ -24,13 +25,18 @@ module.exports = () => ({
       'hapi-negotiator': {
         mediaTypes: {
           'text/html' (request, reply) {
-            const data = {
-              searchresults: exampleData,
-              page: 'index',
-              title: 'Search Results'
-            };
+            elastic.search({ q: request.query.q }, (err, result) => {
+              if (err) return reply(err);
+              console.log(result);
 
-            reply.view('index', data);
+              const data = {
+                searchresults: exampleData,
+                page: 'index',
+                title: 'Search Results'
+              };
+
+              reply.view('index', data);
+            });
           },
           'application/vnd.api+json' (req, reply) {
             reply('"{"response": "JSONAPI"}"').header('content-type', 'application/vnd.api+json');

--- a/routes/search.js
+++ b/routes/search.js
@@ -26,8 +26,8 @@ module.exports = ({ elastic }) => ({
         mediaTypes: {
           'text/html' (request, reply) {
             elastic.search({ q: request.query.q }, (err, result) => {
+              console.log(err, result);
               if (err) return reply(err);
-              console.log(result);
 
               const data = {
                 searchresults: exampleData,
@@ -35,11 +35,17 @@ module.exports = ({ elastic }) => ({
                 title: 'Search Results'
               };
 
+              // TODO: Transform for templates
               reply.view('index', data);
             });
           },
-          'application/vnd.api+json' (req, reply) {
-            reply('"{"response": "JSONAPI"}"').header('content-type', 'application/vnd.api+json');
+          'application/vnd.api+json' (request, reply) {
+            elastic.search({ q: request.query.q }, (err, result) => {
+              console.log(err, result);
+              if (err) return reply(err);
+              // TODO: Transform to jsonapi
+              reply(result).header('content-type', 'application/vnd.api+json');
+            });
           }
         }
       }

--- a/server.js
+++ b/server.js
@@ -1,12 +1,12 @@
 const Hapi = require('hapi');
 const routes = require('./routes');
 
-module.exports = (config, cb) => {
+module.exports = ({ elastic, config }, cb) => {
   const server = new Hapi.Server();
 
   server.connection({ port: config.port });
 
-  server.route(routes());
+  server.route(routes({ elastic, config }));
 
   server.register([
     {
@@ -19,7 +19,8 @@ module.exports = (config, cb) => {
     },
     require('inert'),
     require('hapi-negotiator'),
-    require('vision')
+    require('vision'),
+    require('./routes/plugins/error')
   ], (err) => {
     if (err) {
       return cb(err);
@@ -35,6 +36,6 @@ module.exports = (config, cb) => {
       helpersPath: './templates/helpers'
     });
 
-    cb(null, server);
+    cb(null, { server, elastic });
   });
 };

--- a/templates/pages/error.html
+++ b/templates/pages/error.html
@@ -1,0 +1,4 @@
+<h1>{{output.payload.status}} {{output.payload.error}}</h1>
+{{#if output.payload.message}}
+<p>{{output.payload.message}}</p>
+{{/if}}

--- a/test/content-negotiation-test.js
+++ b/test/content-negotiation-test.js
@@ -1,6 +1,6 @@
 const testWithServer = require('./helpers/test-with-server');
 
-testWithServer('Request for HTML Content', (t, server) => {
+testWithServer('Request for HTML Content', (t, { server }) => {
   t.plan(2);
 
   const htmlRequest = {
@@ -16,7 +16,7 @@ testWithServer('Request for HTML Content', (t, server) => {
   });
 });
 
-testWithServer('Request for JSONAPI Content', (t, server) => {
+testWithServer('Request for JSONAPI Content', (t, { server }) => {
   // http://jsonapi.org/format/#content-negotiation-servers
   //
   // Servers MUST send all JSON API data in response documents with the header
@@ -36,7 +36,7 @@ testWithServer('Request for JSONAPI Content', (t, server) => {
   });
 });
 
-testWithServer('Request for JSONAPI Content with parameters', (t, server) => {
+testWithServer('Request for JSONAPI Content with parameters', (t, { server }) => {
   // http://jsonapi.org/format/#content-negotiation-servers
   //
   // Servers MUST respond with a 406 Not Acceptable status code if a request’s
@@ -56,7 +56,7 @@ testWithServer('Request for JSONAPI Content with parameters', (t, server) => {
   });
 });
 
-testWithServer('Request with multiple instances of JSONAPI media type, one without parameters', (t, server) => {
+testWithServer('Request with multiple instances of JSONAPI media type, one without parameters', (t, { server }) => {
   t.plan(1);
 
   const acceptableJSONRequest = {
@@ -70,12 +70,12 @@ testWithServer('Request with multiple instances of JSONAPI media type, one witho
   });
 });
 
-testWithServer('Request to /search requesting JSON', (t, server) => {
+testWithServer('Request to /search requesting JSON', (t, { server }) => {
   t.plan(1);
 
   const acceptableJSONRequest = {
     method: 'GET',
-    url: '/search',
+    url: '/search?q=test',
     headers: {'Accept': 'application/vnd.api+json'}
   };
   server.inject(acceptableJSONRequest, (res) => {

--- a/test/error-plugin.js
+++ b/test/error-plugin.js
@@ -1,0 +1,31 @@
+const test = require('tape');
+const errorPlugin = require('../routes/plugins/error');
+
+test('Should only care about error responses', (t) => {
+  t.plan(2);
+
+  const mockServer = {
+    ext (hook, onPreResponse) {
+      if (hook === 'onPreResponse') {
+        this.onPreResponse = onPreResponse;
+      }
+    }
+  };
+
+  errorPlugin.register(mockServer, null, () => 0);
+
+  t.ok(mockServer.onPreResponse, 'onPreResponse hander registered');
+
+  const mockRequest = {
+    response: 'NOT AN ERROR'
+  };
+
+  const mockReply = {
+    continue: () => {
+      t.pass('Continue called on non error');
+      t.end();
+    }
+  };
+
+  mockServer.onPreResponse(mockRequest, mockReply);
+});

--- a/test/error-plugin.js
+++ b/test/error-plugin.js
@@ -1,31 +1,85 @@
 const test = require('tape');
+const Boom = require('boom');
+const Sinon = require('sinon');
 const errorPlugin = require('../routes/plugins/error');
 
 test('Should only care about error responses', (t) => {
   t.plan(2);
 
-  const mockServer = {
+  const mockServer = createMockServer();
+  errorPlugin.register(mockServer, null, () => 0);
+
+  t.ok(mockServer.onPreResponse, 'onPreResponse hander registered');
+
+  const mockRequest = { response: 'NOT AN ERROR' };
+  const mockReply = { continue: Sinon.spy() };
+
+  mockServer.onPreResponse(mockRequest, mockReply);
+
+  t.ok(mockReply.continue.called, 'Continue called on non error');
+  t.end();
+});
+
+test('Should reply with error page for text/html accepted requests', (t) => {
+  t.plan(6);
+
+  const mockServer = createMockServer();
+  errorPlugin.register(mockServer, null, () => 0);
+
+  t.ok(mockServer.onPreResponse, 'onPreResponse hander registered');
+
+  const errMessage = 'BOOM!';
+
+  const mockRequest = {
+    response: new Error(errMessage),
+    headers: { accept: 'text/html' }
+  };
+
+  const mockReply = { view: Sinon.stub(), code: Sinon.spy() };
+  mockReply.view.returns(mockReply);
+
+  mockServer.onPreResponse(mockRequest, mockReply);
+
+  t.ok(mockReply.view.called, 'Render function was called');
+  t.equal(mockReply.view.firstCall.args[0], 'error', 'Error template was rendered');
+  t.equal(mockReply.view.firstCall.args[1].message, errMessage, 'Error message was as expected');
+
+  t.ok(mockReply.code.called, 'Code function was called');
+  t.equal(mockReply.code.firstCall.args[0], 500, 'Status code was 500');
+
+  t.end();
+});
+
+test('Should reply with error JSON for application/vnd.api+json accepted requests', (t) => {
+  t.plan(3);
+
+  const mockServer = createMockServer();
+  errorPlugin.register(mockServer, null, () => 0);
+
+  t.ok(mockServer.onPreResponse, 'onPreResponse hander registered');
+
+  const errMessage = 'BOOM!';
+
+  const mockRequest = {
+    response: Boom.create(500, errMessage),
+    headers: { accept: 'application/vnd.api+json' }
+  };
+
+  const mockReply = { continue: Sinon.spy() };
+
+  mockServer.onPreResponse(mockRequest, mockReply);
+
+  t.ok(mockReply.continue.called, 'Continue called');
+  t.ok(Array.isArray(mockRequest.response.output.payload.errors), 'Output was transformed correctly');
+  t.end();
+});
+
+function createMockServer () {
+  return {
     ext (hook, onPreResponse) {
       if (hook === 'onPreResponse') {
         this.onPreResponse = onPreResponse;
       }
     }
   };
-
-  errorPlugin.register(mockServer, null, () => 0);
-
-  t.ok(mockServer.onPreResponse, 'onPreResponse hander registered');
-
-  const mockRequest = {
-    response: 'NOT AN ERROR'
-  };
-
-  const mockReply = {
-    continue: () => {
-      t.pass('Continue called on non error');
-      t.end();
-    }
-  };
-
-  mockServer.onPreResponse(mockRequest, mockReply);
-});
+}

--- a/test/error.plugin.js
+++ b/test/error.plugin.js
@@ -1,5 +1,0 @@
-const test = require('tape');
-
-test('Should only care about error responses', (t) => {
-
-});

--- a/test/error.plugin.js
+++ b/test/error.plugin.js
@@ -1,0 +1,5 @@
+const test = require('tape');
+
+test('Should only care about error responses', (t) => {
+
+});

--- a/test/helpers/mock-elastic.js
+++ b/test/helpers/mock-elastic.js
@@ -1,0 +1,21 @@
+// Create a mock elasticsearch client with noop functions
+module.exports = () => ({
+  search: function () {
+    const cb = arguments[arguments.length - 1];
+
+    cb(null, {
+      took: 0,
+      timed_out: false,
+      _shards: {
+        total: 1,
+        successful: 1,
+        failed: 0
+      },
+      hits: {
+        total: 0,
+        max_score: null,
+        hits: []
+      }
+    });
+  }
+});

--- a/test/helpers/test-with-server.js
+++ b/test/helpers/test-with-server.js
@@ -1,15 +1,19 @@
 const tape = require('tape');
 const createServer = require('../../server');
 const config = require('../../config');
+const createMockElastic = require('./mock-elastic');
 
+// Wrap tape's test function with a function that creates a new server and mocks dependencies
 module.exports = (description, cb) => {
-  createServer(config, (err, server) => {
+  const elastic = createMockElastic();
+
+  createServer({ config, elastic }, (err, ctx) => {
     if (err) {
       throw err;
     }
 
     tape(description, (t) => {
-      cb(t, server);
+      cb(t, ctx);
     });
   });
 };

--- a/test/routes-test.js
+++ b/test/routes-test.js
@@ -1,6 +1,6 @@
 const testWithServer = require('./helpers/test-with-server');
 
-testWithServer('Request for Archive HTML Page', (t, server) => {
+testWithServer('Request for Archive HTML Page', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -15,7 +15,7 @@ testWithServer('Request for Archive HTML Page', (t, server) => {
   });
 });
 
-testWithServer('Request for Archivedoc HTML Page', (t, server) => {
+testWithServer('Request for Archivedoc HTML Page', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -30,7 +30,7 @@ testWithServer('Request for Archivedoc HTML Page', (t, server) => {
   });
 });
 
-testWithServer('Request for Object HTML Page', (t, server) => {
+testWithServer('Request for Object HTML Page', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -45,7 +45,7 @@ testWithServer('Request for Object HTML Page', (t, server) => {
   });
 });
 
-testWithServer('Request for Person HTML Page', (t, server) => {
+testWithServer('Request for Person HTML Page', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -60,7 +60,7 @@ testWithServer('Request for Person HTML Page', (t, server) => {
   });
 });
 
-testWithServer('Request for Archive JSON', (t, server) => {
+testWithServer('Request for Archive JSON', (t, { server }) => {
   t.plan(2);
 
   const htmlRequest = {
@@ -76,7 +76,7 @@ testWithServer('Request for Archive JSON', (t, server) => {
   });
 });
 
-testWithServer('Request for Archivedoc JSON', (t, server) => {
+testWithServer('Request for Archivedoc JSON', (t, { server }) => {
   t.plan(2);
 
   const htmlRequest = {
@@ -92,7 +92,7 @@ testWithServer('Request for Archivedoc JSON', (t, server) => {
   });
 });
 
-testWithServer('Request for Object JSON Page', (t, server) => {
+testWithServer('Request for Object JSON Page', (t, { server }) => {
   t.plan(2);
 
   const htmlRequest = {
@@ -108,7 +108,7 @@ testWithServer('Request for Object JSON Page', (t, server) => {
   });
 });
 
-testWithServer('Request for Person JSON Page', (t, server) => {
+testWithServer('Request for Person JSON Page', (t, { server }) => {
   t.plan(2);
 
   const htmlRequest = {

--- a/test/search-filters.js
+++ b/test/search-filters.js
@@ -1,16 +1,17 @@
 const QueryString = require('querystring');
 const testWithServer = require('./helpers/test-with-server');
 
-testWithServer('Should accept params in filter[PARAM_NAME] format', (t, server) => {
+testWithServer('Should accept params in filter[PARAM_NAME] format', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
     url: '/search?' + QueryString.stringify({
+      q: 'test',
       'filter[date[from]]': '2016',
       'filter[places]': ['London', 'Bath']
     }),
-    headers: {'Accept': 'text/html'}
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -19,13 +20,13 @@ testWithServer('Should accept params in filter[PARAM_NAME] format', (t, server) 
   });
 });
 
-testWithServer('Should accept date[from] in format YYYY', (t, server) => {
+testWithServer('Should accept date[from] in format YYYY', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'date[from]': '2016' }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', 'date[from]': '2016' }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -34,13 +35,13 @@ testWithServer('Should accept date[from] in format YYYY', (t, server) => {
   });
 });
 
-testWithServer('Should accept date[from] in format YYYY-MM', (t, server) => {
+testWithServer('Should accept date[from] in format YYYY-MM', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'date[from]': '2016-12' }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', 'date[from]': '2016-12' }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -49,13 +50,13 @@ testWithServer('Should accept date[from] in format YYYY-MM', (t, server) => {
   });
 });
 
-testWithServer('Should accept date[from] in format YYYY-MM-DD', (t, server) => {
+testWithServer('Should accept date[from] in format YYYY-MM-DD', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'date[from]': '2016-12-12' }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', 'date[from]': '2016-12-12' }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -64,13 +65,13 @@ testWithServer('Should accept date[from] in format YYYY-MM-DD', (t, server) => {
   });
 });
 
-testWithServer('Should not accept invalid date[from]', (t, server) => {
+testWithServer('Should not accept invalid date[from]', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'date[from]': '2016-13-12' }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', 'date[from]': '2016-13-12' }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -79,13 +80,13 @@ testWithServer('Should not accept invalid date[from]', (t, server) => {
   });
 });
 
-testWithServer('Should accept date[to] in format YYYY', (t, server) => {
+testWithServer('Should accept date[to] in format YYYY', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'date[to]': '2012' }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', 'date[to]': '2012' }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -94,13 +95,13 @@ testWithServer('Should accept date[to] in format YYYY', (t, server) => {
   });
 });
 
-testWithServer('Should accept date[to] in format YYYY-MM', (t, server) => {
+testWithServer('Should accept date[to] in format YYYY-MM', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'date[to]': '2013-10' }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', 'date[to]': '2013-10' }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -109,13 +110,13 @@ testWithServer('Should accept date[to] in format YYYY-MM', (t, server) => {
   });
 });
 
-testWithServer('Should accept date[to] in format YYYY-MM-DD', (t, server) => {
+testWithServer('Should accept date[to] in format YYYY-MM-DD', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'date[to]': '2010-05-01' }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', 'date[to]': '2010-05-01' }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -124,13 +125,13 @@ testWithServer('Should accept date[to] in format YYYY-MM-DD', (t, server) => {
   });
 });
 
-testWithServer('Should not accept invalid date[to]', (t, server) => {
+testWithServer('Should not accept invalid date[to]', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'date[to]': '2016-02-31' }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', 'date[to]': '2016-02-31' }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -139,13 +140,13 @@ testWithServer('Should not accept invalid date[to]', (t, server) => {
   });
 });
 
-testWithServer('Should accept single places', (t, server) => {
+testWithServer('Should accept single places', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'places': 'London' }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', places: 'London' }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -154,13 +155,13 @@ testWithServer('Should accept single places', (t, server) => {
   });
 });
 
-testWithServer('Should accept multiple places', (t, server) => {
+testWithServer('Should accept multiple places', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'places': ['London', 'Manchester'] }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', places: ['London', 'Manchester'] }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -169,13 +170,13 @@ testWithServer('Should accept multiple places', (t, server) => {
   });
 });
 
-testWithServer('Should accept single type', (t, server) => {
+testWithServer('Should accept single type', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'type': 'Model locomotive' }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', type: 'Model locomotive' }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -184,13 +185,13 @@ testWithServer('Should accept single type', (t, server) => {
   });
 });
 
-testWithServer('Should not accept multiple type', (t, server) => {
+testWithServer('Should not accept multiple type', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'type': ['Model locomotive', 'Computer'] }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', type: ['Model locomotive', 'Computer'] }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -199,13 +200,13 @@ testWithServer('Should not accept multiple type', (t, server) => {
   });
 });
 
-testWithServer('Should accept single makers', (t, server) => {
+testWithServer('Should accept single makers', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'makers': 'Charles Babbage' }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', makers: 'Charles Babbage' }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -214,13 +215,13 @@ testWithServer('Should accept single makers', (t, server) => {
   });
 });
 
-testWithServer('Should accept multiple makers', (t, server) => {
+testWithServer('Should accept multiple makers', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'makers': ['Robert Stephenson', 'Charles Babbage'] }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', makers: ['Robert Stephenson', 'Charles Babbage'] }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -229,13 +230,13 @@ testWithServer('Should accept multiple makers', (t, server) => {
   });
 });
 
-testWithServer('Should accept single people', (t, server) => {
+testWithServer('Should accept single people', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'makers': 'Charles Babbage' }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', makers: 'Charles Babbage' }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -244,13 +245,13 @@ testWithServer('Should accept single people', (t, server) => {
   });
 });
 
-testWithServer('Should accept multiple people', (t, server) => {
+testWithServer('Should accept multiple people', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'makers': ['Robert Stephenson', 'Charles Babbage'] }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', makers: ['Robert Stephenson', 'Charles Babbage'] }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -259,13 +260,13 @@ testWithServer('Should accept multiple people', (t, server) => {
   });
 });
 
-testWithServer('Should accept single organisations', (t, server) => {
+testWithServer('Should accept single organisations', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'organisations': 'Liverpool & Manchester Railway' }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', organisations: 'Liverpool & Manchester Railway' }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -274,13 +275,13 @@ testWithServer('Should accept single organisations', (t, server) => {
   });
 });
 
-testWithServer('Should accept multiple organisations', (t, server) => {
+testWithServer('Should accept multiple organisations', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'organisations': ['Liverpool & Manchester Railway', 'Aquascutum Group plc'] }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', organisations: ['Liverpool & Manchester Railway', 'Aquascutum Group plc'] }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -289,13 +290,13 @@ testWithServer('Should accept multiple organisations', (t, server) => {
   });
 });
 
-testWithServer('Should accept single categories', (t, server) => {
+testWithServer('Should accept single categories', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'categories': 'Locomotives' }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', categories: 'Locomotives' }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -304,13 +305,13 @@ testWithServer('Should accept single categories', (t, server) => {
   });
 });
 
-testWithServer('Should accept multiple categories', (t, server) => {
+testWithServer('Should accept multiple categories', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'categories': ['Locomotives', 'Rolling Stock'] }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', categories: ['Locomotives', 'Rolling Stock'] }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -319,13 +320,13 @@ testWithServer('Should accept multiple categories', (t, server) => {
   });
 });
 
-testWithServer('Should accept valid museum NRM', (t, server) => {
+testWithServer('Should accept valid museum NRM', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'museum': 'NRM' }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', museum: 'NRM' }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -334,13 +335,13 @@ testWithServer('Should accept valid museum NRM', (t, server) => {
   });
 });
 
-testWithServer('Should accept valid museum SMG', (t, server) => {
+testWithServer('Should accept valid museum SMG', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'museum': 'SMG' }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', museum: 'SMG' }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -349,13 +350,13 @@ testWithServer('Should accept valid museum SMG', (t, server) => {
   });
 });
 
-testWithServer('Should accept valid museum NMeM', (t, server) => {
+testWithServer('Should accept valid museum NMeM', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'museum': 'NMeM' }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', museum: 'NMeM' }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -364,13 +365,13 @@ testWithServer('Should accept valid museum NMeM', (t, server) => {
   });
 });
 
-testWithServer('Should accept valid museum MSI', (t, server) => {
+testWithServer('Should accept valid museum MSI', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'museum': 'MSI' }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', museum: 'MSI' }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -379,13 +380,13 @@ testWithServer('Should accept valid museum MSI', (t, server) => {
   });
 });
 
-testWithServer('Should not accept invalid museum', (t, server) => {
+testWithServer('Should not accept invalid museum', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'museum': 'INVALID' }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', museum: 'INVALID' }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -394,13 +395,13 @@ testWithServer('Should not accept invalid museum', (t, server) => {
   });
 });
 
-testWithServer('Should accept on_display true', (t, server) => {
+testWithServer('Should accept on_display true', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'on_display': true }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', 'on_display': true }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -409,13 +410,13 @@ testWithServer('Should accept on_display true', (t, server) => {
   });
 });
 
-testWithServer('Should accept on_display false', (t, server) => {
+testWithServer('Should accept on_display false', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'on_display': false }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', 'on_display': false }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -424,13 +425,13 @@ testWithServer('Should accept on_display false', (t, server) => {
   });
 });
 
-testWithServer('Should not accept invalid on_display', (t, server) => {
+testWithServer('Should not accept invalid on_display', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'on_display': 'not a bool' }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', 'on_display': 'not a bool' }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -439,13 +440,13 @@ testWithServer('Should not accept invalid on_display', (t, server) => {
   });
 });
 
-testWithServer('Should accept single location', (t, server) => {
+testWithServer('Should accept single location', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'location': 'London' }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', location: 'London' }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -454,13 +455,13 @@ testWithServer('Should accept single location', (t, server) => {
   });
 });
 
-testWithServer('Should not accept multiple location', (t, server) => {
+testWithServer('Should not accept multiple location', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'location': ['London', 'Portsmouth'] }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', location: ['London', 'Portsmouth'] }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -469,13 +470,13 @@ testWithServer('Should not accept multiple location', (t, server) => {
   });
 });
 
-testWithServer('Should accept single birth[place]', (t, server) => {
+testWithServer('Should accept single birth[place]', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'birth[place]': 'London' }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', 'birth[place]': 'London' }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -484,13 +485,13 @@ testWithServer('Should accept single birth[place]', (t, server) => {
   });
 });
 
-testWithServer('Should not accept multiple birth[place]', (t, server) => {
+testWithServer('Should not accept multiple birth[place]', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'birth[place]': ['London', 'Portsmouth'] }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', 'birth[place]': ['London', 'Portsmouth'] }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -499,13 +500,13 @@ testWithServer('Should not accept multiple birth[place]', (t, server) => {
   });
 });
 
-testWithServer('Should accept birth[date] in format YYYY', (t, server) => {
+testWithServer('Should accept birth[date] in format YYYY', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'birth[date]': '2016' }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', 'birth[date]': '2016' }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -514,13 +515,13 @@ testWithServer('Should accept birth[date] in format YYYY', (t, server) => {
   });
 });
 
-testWithServer('Should accept birth[date] in format YYYY-MM', (t, server) => {
+testWithServer('Should accept birth[date] in format YYYY-MM', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'birth[date]': '2016-12' }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', 'birth[date]': '2016-12' }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -529,13 +530,13 @@ testWithServer('Should accept birth[date] in format YYYY-MM', (t, server) => {
   });
 });
 
-testWithServer('Should accept birth[date] in format YYYY-MM-DD', (t, server) => {
+testWithServer('Should accept birth[date] in format YYYY-MM-DD', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'birth[date]': '2016-12-12' }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', 'birth[date]': '2016-12-12' }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -544,13 +545,13 @@ testWithServer('Should accept birth[date] in format YYYY-MM-DD', (t, server) => 
   });
 });
 
-testWithServer('Should not accept invalid birth[date]', (t, server) => {
+testWithServer('Should not accept invalid birth[date]', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'birth[date]': '2016-13-12' }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', 'birth[date]': '2016-13-12' }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -559,13 +560,13 @@ testWithServer('Should not accept invalid birth[date]', (t, server) => {
   });
 });
 
-testWithServer('Should accept death[date] in format YYYY', (t, server) => {
+testWithServer('Should accept death[date] in format YYYY', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'death[date]': '2016' }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', 'death[date]': '2016' }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -574,13 +575,13 @@ testWithServer('Should accept death[date] in format YYYY', (t, server) => {
   });
 });
 
-testWithServer('Should accept death[date] in format YYYY-MM', (t, server) => {
+testWithServer('Should accept death[date] in format YYYY-MM', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'death[date]': '2016-12' }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', 'death[date]': '2016-12' }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -589,13 +590,13 @@ testWithServer('Should accept death[date] in format YYYY-MM', (t, server) => {
   });
 });
 
-testWithServer('Should accept death[date] in format YYYY-MM-DD', (t, server) => {
+testWithServer('Should accept death[date] in format YYYY-MM-DD', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'death[date]': '2016-12-12' }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', 'death[date]': '2016-12-12' }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -604,13 +605,13 @@ testWithServer('Should accept death[date] in format YYYY-MM-DD', (t, server) => 
   });
 });
 
-testWithServer('Should not accept invalid death[date]', (t, server) => {
+testWithServer('Should not accept invalid death[date]', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'death[date]': '2016-13-12' }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', 'death[date]': '2016-13-12' }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -619,13 +620,13 @@ testWithServer('Should not accept invalid death[date]', (t, server) => {
   });
 });
 
-testWithServer('Should accept single occupation', (t, server) => {
+testWithServer('Should accept single occupation', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'occupation': 'Computer Programmer' }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', occupation: 'Computer Programmer' }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -634,13 +635,13 @@ testWithServer('Should accept single occupation', (t, server) => {
   });
 });
 
-testWithServer('Should not accept multiple occupation', (t, server) => {
+testWithServer('Should not accept multiple occupation', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'occupation': ['Scientist', 'Computer Programmer'] }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', occupation: ['Scientist', 'Computer Programmer'] }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -649,13 +650,13 @@ testWithServer('Should not accept multiple occupation', (t, server) => {
   });
 });
 
-testWithServer('Should accept single archive', (t, server) => {
+testWithServer('Should accept single archive', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'archive': 'The Babbage Archive' }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', archive: 'The Babbage Archive' }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -664,13 +665,13 @@ testWithServer('Should accept single archive', (t, server) => {
   });
 });
 
-testWithServer('Should not accept multiple archive', (t, server) => {
+testWithServer('Should not accept multiple archive', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'archive': ['The Babbage Archive', 'The Diplomas etc of Charles Babbage'] }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', archive: ['The Babbage Archive', 'The Diplomas etc of Charles Babbage'] }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -679,13 +680,13 @@ testWithServer('Should not accept multiple archive', (t, server) => {
   });
 });
 
-testWithServer('Should accept single formats', (t, server) => {
+testWithServer('Should accept single formats', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'formats': 'bound volume' }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', formats: 'bound volume' }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -694,13 +695,13 @@ testWithServer('Should accept single formats', (t, server) => {
   });
 });
 
-testWithServer('Should accept multiple formats', (t, server) => {
+testWithServer('Should accept multiple formats', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'formats': ['bound volume', 'large format document', 'photograph'] }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', formats: ['bound volume', 'large format document', 'photograph'] }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -709,13 +710,13 @@ testWithServer('Should accept multiple formats', (t, server) => {
   });
 });
 
-testWithServer('Should accept single image_licences', (t, server) => {
+testWithServer('Should accept single image_licences', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'image_licences': 'CC BY-NC-SA' }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', 'image_licences': 'CC BY-NC-SA' }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {
@@ -724,13 +725,13 @@ testWithServer('Should accept single image_licences', (t, server) => {
   });
 });
 
-testWithServer('Should accept multiple image_licences', (t, server) => {
+testWithServer('Should accept multiple image_licences', (t, { server }) => {
   t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search?' + QueryString.stringify({ 'image_licences': ['CC BY-NC-SA', 'CC BY-SA'] }),
-    headers: {'Accept': 'text/html'}
+    url: '/search?' + QueryString.stringify({ q: 'test', 'image_licences': ['CC BY-NC-SA', 'CC BY-SA'] }),
+    headers: { Accept: 'text/html' }
   };
 
   server.inject(htmlRequest, (res) => {

--- a/test/static-file-test.js
+++ b/test/static-file-test.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const jsFile = fs.readFileSync('public/bundle.js');
 const cssFile = fs.readFileSync('public/bundle.css');
 
-testWithServer('Javascript Files served correctly', (t, server) => {
+testWithServer('Javascript Files served correctly', (t, { server }) => {
   t.plan(1);
 
   const jsRequest = {
@@ -17,7 +17,7 @@ testWithServer('Javascript Files served correctly', (t, server) => {
   });
 });
 
-testWithServer('CSS Files served correctly', (t, server) => {
+testWithServer('CSS Files served correctly', (t, { server }) => {
   t.plan(1);
 
   const cssRequest = {
@@ -31,7 +31,7 @@ testWithServer('CSS Files served correctly', (t, server) => {
   });
 });
 
-testWithServer('Non Existent Files', (t, server) => {
+testWithServer('Non Existent Files', (t, { server }) => {
   t.plan(1);
 
   const badRequest = {


### PR DESCRIPTION
refs #32 

* Adds elasticsearch dependency to the app, creates a new client based on .corc config and passes it to `server.js`
* `testWithServer` now creates and passes a noop mock elasticsearch client to the server which you can use to stub/spy/mock on
* Adds sinon dependency for stubbing/spying/mocking
* Adds error handler plugin for Hapi that responds correctly given the request `Accept` header (sends a nice page for text/html and sends an appropriately formatted JSON response for 'application/vnd.api+json')
* Adds tests for the plugin

For this to work you'll need to add elasticsearch config to your `.corc` file e.g.:

```js
{
  "port": 8000,
  "elasticsearch": {
    "apiVersion": "1.7",
    "host": "http://USERNAME:PASSWORD@DOMAIN/public",
    "log": "trace"
  }
}
```