### PR TITLE
Add transform for search results to jsonapi responses

### DIFF
--- a/.corc.template
+++ b/.corc.template
@@ -1,5 +1,6 @@
 {
   "port": 8000,
+  "rootUrl": "http://localhost:8000",
   "elasticsearch": {
     "apiVersion": "1.7",
     "host": ""

--- a/lib/transforms/search-results-to-jsonapi.js
+++ b/lib/transforms/search-results-to-jsonapi.js
@@ -1,0 +1,226 @@
+const QueryString = require('querystring');
+
+module.exports = (params, results = {}, config = {}) => {
+  const rootUrl = config.rootUrl || '';
+  const { data, included } = createData(results, rootUrl);
+  const links = createLinks(params, results, rootUrl);
+  const meta = createMeta(params, results);
+
+  return { data, included, links, meta };
+};
+
+// Create resources from hits, filter any unknown resource types
+function createData (results, rootUrl) {
+  const hits = (results.hits || {}).hits || [];
+
+  return hits.reduce(({ data, included }, hit) => {
+    // Create a resource if a creator exists for the hit._type
+    const creator = createResource[hit._type];
+
+    if (!creator) {
+      console.warn(`No resource creator for hit ${hit._id}`);
+      return { data, included };
+    }
+
+    const res = creator(hit, rootUrl);
+    return { data: data.concat(res.data), included: included.concat(res.included) };
+  }, { data: [], included: [] });
+}
+
+const createResource = {
+  object (hit, rootUrl) {
+    const type = 'objects';
+    const id = hit._id.replace('-object-', '-objects-');
+
+    const attributes = [
+      'arrangement',
+      'autocomplete',
+      'categories',
+      'component',
+      'condition',
+      'custodial_history',
+      'dates',
+      'description',
+      'identifier',
+      'inscription',
+      'language',
+      'legal',
+      'lifecycle',
+      'location',
+      'materials',
+      'measurements',
+      'name',
+      'note',
+      'numbers',
+      'options',
+      'reference_links',
+      'summary_title',
+      'summary_title_text',
+      'title'
+    ].reduce((attrs, key) => {
+      if (hit._source && hit._source[key]) {
+        attrs[key] = hit._source[key];
+      }
+      return attrs;
+    }, {});
+
+    const { relationships, included } = createRelationships(hit, [
+      'agents',
+      'cultures',
+      'events',
+      'parent',
+      'places',
+      'terms'
+    ], rootUrl);
+
+    const links = { self: `${rootUrl}/objects/${id}` };
+
+    return { data: { type, id, attributes, relationships }, included, links };
+  },
+
+  agent (hit, rootUrl) {
+    const type = 'people';
+    const id = hit._id.replace('-agent-', '-people-');
+
+    const attributes = [
+      'date_of_birth',
+      'date_of_death',
+      'death_date',
+      'description',
+      'gender',
+      'historical',
+      'identifier',
+      'life_dates',
+      'lifecycle',
+      'name',
+      'nationality',
+      'note',
+      'occupation',
+      'reference_links',
+      'summary_title',
+      'summary_title_text',
+      'title',
+      'website'
+    ].reduce((attrs, key) => {
+      if (hit._source && hit._source[key]) {
+        attrs[key] = hit._source[key];
+      }
+      return attrs;
+    }, {});
+
+    const { relationships, included } = createRelationships(hit, [
+      'agents',
+      'places',
+      'terms'
+    ], rootUrl);
+
+    const links = { self: `${rootUrl}/people/${id}` };
+
+    return { data: { type, id, attributes, relationships }, included, links };
+  },
+
+  archive (hit, rootUrl) {
+    const type = 'documents';
+    const id = hit._id.replace('-archive-', '-documents-');
+
+    const attributes = [
+      'arrangement',
+      'description',
+      'identifier',
+      'legal',
+      'level',
+      'measurements',
+      'name',
+      'note',
+      'reference_links',
+      'summary_title',
+      'summary_title_text',
+      'title',
+      'web'
+    ].reduce((attrs, key) => {
+      if (hit._source && hit._source[key]) {
+        attrs[key] = hit._source[key];
+      }
+      return attrs;
+    }, {});
+
+    const { relationships, included } = createRelationships(hit, [
+      'agents',
+      'archives',
+      'fonds',
+      'organisations',
+      'parent'
+    ], rootUrl);
+
+    const links = { self: `${rootUrl}/documents/${id}` };
+
+    return { data: { type, id, attributes, relationships }, included, links };
+  }
+};
+
+function createRelationships (hit, props, rootUrl) {
+  // Reference relationships
+  const relationships = props.reduce((rels, key) => {
+    if (hit._source && hit._source[key] && hit._source[key].length) {
+      rels[key] = {
+        data: hit._source[key].map((r) => ({
+          type: key,  // TODO: Map to external types
+          id: r.admin && r.admin.uid
+        }))
+      };
+    }
+    return rels;
+  }, {});
+
+  // Add included docs
+  const included = props.reduce((incs, key) => {
+    if (hit._source && hit._source[key] && hit._source[key].length) {
+      incs = incs.concat(hit._source[key].map((r) => ({
+        type: key, // TODO: Map to external types
+        id: r.admin && r.admin.uid,
+        attributes: {
+          summary_title: r.summary_title
+        },
+        links: {
+          self: `${rootUrl}/${key}/${r.admin && r.admin.uid}`
+        }
+      })));
+    }
+    return incs;
+  }, []);
+
+  return { relationships, included };
+}
+
+// Creates a top level links object
+function createLinks (params, results = {}, rootUrl) {
+  const totalPages = Math.ceil(results.hits.total / params['page[size]']);
+  const pageNumber = params['page[number]'];
+
+  const self = searchUrl(rootUrl, params);
+  const first = searchUrl(rootUrl, xtend(params, { 'page[number]': 0 }));
+  const last = searchUrl(rootUrl, xtend(params, { 'page[number]': totalPages - 1 }));
+  const prev = pageNumber > 0
+    ? searchUrl(rootUrl, xtend(params, { 'page[number]': pageNumber - 1 }))
+    : null;
+  const next = pageNumber < totalPages - 1
+    ? searchUrl(rootUrl, xtend(params, { 'page[number]': pageNumber + 1 }))
+    : null;
+
+  return { self, first, last, prev, next };
+}
+
+function searchUrl (rootUrl, params) {
+  return `${rootUrl}/search?${QueryString.stringify(params)}`;
+}
+
+function createMeta (params, results) {
+  const total = (results.hits || {}).total || 0;
+  const totalPages = Math.ceil(total / params['page[size]']);
+  // TODO: Map aggregations to filters
+  return { total_pages: totalPages, filters: {} };
+}
+
+function xtend (obj1, obj2) {
+  return Object.assign({}, obj1, obj2);
+}

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "start": "node bin/server.js",
     "test": "run-s test:*",
     "test:lint": "semistandard",
-    "test:unit": "istanbul cover tape 'test/*.js'",
+    "test:unit": "istanbul cover tape 'test/**/*.js'",
     "build": "run-p build:*",
     "build:js": "browserify src/assets/js/*.js -o public/bundle.js",
     "build:css": "node-sass src/assets/scss/main.scss public/bundle.css --include-path bower_components/foundation-sites/scss --include-path bower_components/slick-carousel/slick",

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,6 +1,6 @@
-module.exports = ({ elastic }) => ([
+module.exports = ({ elastic, config }) => ([
   require('./home')(),
-  require('./search')({ elastic }),
+  require('./search')({ elastic, config }),
   require('./public')(),
   require('./archive')(),
   require('./archivedoc')(),

--- a/routes/search.js
+++ b/routes/search.js
@@ -1,9 +1,10 @@
 const Joi = require('joi');
 const filterSchema = require('../schemas/filter');
 const fs = require('fs');
+const searchResultsToJsonApi = require('../lib/transforms/search-results-to-jsonapi');
 const exampleData = JSON.parse(fs.readFileSync('./src/data/searchresults.json'));
 
-module.exports = ({ elastic }) => ({
+module.exports = ({ elastic, config }) => ({
   method: 'GET',
   path: '/search/{resource?}',
   handler: (request, reply) => reply(),
@@ -41,10 +42,10 @@ module.exports = ({ elastic }) => ({
           },
           'application/vnd.api+json' (request, reply) {
             elastic.search({ q: request.query.q }, (err, result) => {
-              console.log(err, result);
               if (err) return reply(err);
-              // TODO: Transform to jsonapi
-              reply(result).header('content-type', 'application/vnd.api+json');
+
+              reply(searchResultsToJsonApi(request.query, result, config))
+                .header('content-type', 'application/vnd.api+json');
             });
           }
         }

--- a/test/transforms/search-results-to-jsonapi.js
+++ b/test/transforms/search-results-to-jsonapi.js
@@ -1,0 +1,153 @@
+const QueryString = require('querystring');
+const test = require('tape');
+const searchResultsToJsonApi = require('../../lib/transforms/search-results-to-jsonapi');
+
+test('Should create valid links on first page', (t) => {
+  t.plan(6);
+
+  const testResult = {
+    took: 0,
+    timed_out: false,
+    _shards: { total: 1, successful: 1, failed: 0 },
+    hits: {
+      total: 5,
+      max_score: null,
+      hits: [
+        { _type: 'object', _id: `smg-object-${Date.now()}` }
+      ]
+    }
+  };
+
+  let obj;
+
+  t.doesNotThrow(() => {
+    obj = searchResultsToJsonApi({ q: 'test', 'page[number]': 0, 'page[size]': 1 }, testResult);
+  }, 'Transform did not throw');
+
+  let qs;
+
+  qs = QueryString.stringify({ q: 'test', 'page[number]': 0, 'page[size]': 1 });
+  t.equal(obj.links.self, '/search?' + qs, 'Self page link was correct');
+
+  qs = QueryString.stringify({ q: 'test', 'page[number]': 0, 'page[size]': 1 });
+  t.equal(obj.links.first, '/search?' + qs, 'First page link was correct');
+
+  qs = QueryString.stringify({ q: 'test', 'page[number]': 4, 'page[size]': 1 });
+  t.equal(obj.links.last, '/search?' + qs, 'Last page link was correct');
+
+  qs = QueryString.stringify({ q: 'test', 'page[number]': 1, 'page[size]': 1 });
+  t.equal(obj.links.next, '/search?' + qs, 'Next page link was correct');
+
+  t.equal(obj.links.prev, null, 'Previous page link was correct');
+
+  t.end();
+});
+
+test('Should create valid links on middle page', (t) => {
+  t.plan(6);
+
+  const testResult = {
+    took: 0,
+    timed_out: false,
+    _shards: { total: 1, successful: 1, failed: 0 },
+    hits: {
+      total: 5,
+      max_score: null,
+      hits: [
+        { _type: 'archive', _id: `smg-archive-${Date.now()}` }
+      ]
+    }
+  };
+
+  let obj;
+
+  t.doesNotThrow(() => {
+    obj = searchResultsToJsonApi({ q: 'test', 'page[number]': 1, 'page[size]': 1 }, testResult);
+  }, 'Transform did not throw');
+
+  let qs;
+
+  qs = QueryString.stringify({ q: 'test', 'page[number]': 1, 'page[size]': 1 });
+  t.equal(obj.links.self, '/search?' + qs, 'Self page link was correct');
+
+  qs = QueryString.stringify({ q: 'test', 'page[number]': 0, 'page[size]': 1 });
+  t.equal(obj.links.first, '/search?' + qs, 'First page link was correct');
+
+  qs = QueryString.stringify({ q: 'test', 'page[number]': 4, 'page[size]': 1 });
+  t.equal(obj.links.last, '/search?' + qs, 'Last page link was correct');
+
+  qs = QueryString.stringify({ q: 'test', 'page[number]': 2, 'page[size]': 1 });
+  t.equal(obj.links.next, '/search?' + qs, 'Next page link was correct');
+
+  qs = QueryString.stringify({ q: 'test', 'page[number]': 0, 'page[size]': 1 });
+  t.equal(obj.links.prev, '/search?' + qs, 'Previous page link was correct');
+
+  t.end();
+});
+
+test('Should create valid links on last page', (t) => {
+  t.plan(6);
+
+  const testResult = {
+    took: 0,
+    timed_out: false,
+    _shards: { total: 1, successful: 1, failed: 0 },
+    hits: {
+      total: 5,
+      max_score: null,
+      hits: [
+        { _type: 'agent', _id: `smg-agent-${Date.now()}` }
+      ]
+    }
+  };
+
+  let obj;
+
+  t.doesNotThrow(() => {
+    obj = searchResultsToJsonApi({ q: 'test', 'page[number]': 4, 'page[size]': 1 }, testResult);
+  }, 'Transform did not throw');
+
+  let qs;
+
+  qs = QueryString.stringify({ q: 'test', 'page[number]': 4, 'page[size]': 1 });
+  t.equal(obj.links.self, '/search?' + qs, 'Self page link was correct');
+
+  qs = QueryString.stringify({ q: 'test', 'page[number]': 0, 'page[size]': 1 });
+  t.equal(obj.links.first, '/search?' + qs, 'First page link was correct');
+
+  qs = QueryString.stringify({ q: 'test', 'page[number]': 4, 'page[size]': 1 });
+  t.equal(obj.links.last, '/search?' + qs, 'Last page link was correct');
+
+  t.equal(obj.links.next, null, 'Next page link was correct');
+
+  qs = QueryString.stringify({ q: 'test', 'page[number]': 3, 'page[size]': 1 });
+  t.equal(obj.links.prev, '/search?' + qs, 'Previous page link was correct');
+
+  t.end();
+});
+
+test('Should ignore unknown object types', (t) => {
+  t.plan(3);
+
+  const testResult = {
+    took: 0,
+    timed_out: false,
+    _shards: { total: 1, successful: 1, failed: 0 },
+    hits: {
+      total: 1,
+      max_score: null,
+      hits: [{ _type: 'UNKNOWN', _id: 'ID' + Date.now() }]
+    }
+  };
+
+  let obj;
+
+  t.doesNotThrow(() => {
+    obj = searchResultsToJsonApi({ q: 'test', 'page[number]': 0, 'page[size]': 50 }, testResult);
+  }, 'Transform did not throw');
+
+  t.equal(obj.data.length, 0, 'No objects were returned');
+  t.equal(obj.meta.total_pages, 1, 'Total pages was correct');
+
+  t.end();
+});


### PR DESCRIPTION
This is a work in progress for #44 but safe to merge as it adds new functionality to just the search JSON endpoint

* Adds module to transform elasticsearch result
* Adds tests for transform
* Wires up transformed doc to endpoint

TODO (in another PR):

* Transform `@linked` docs into `relationships` and `included` for docs not on the object route
* Add test for transforming `relationships` and `included` docs