### PR TITLE
Add type mapping and test transform relationships

### DIFF
--- a/lib/transforms/search-results-to-jsonapi.js
+++ b/lib/transforms/search-results-to-jsonapi.js
@@ -1,4 +1,5 @@
 const QueryString = require('querystring');
+const TypeMapping = require('../type-mapping');
 
 module.exports = (params, results = {}, config = {}) => {
   const rootUrl = config.rootUrl || '';
@@ -30,7 +31,7 @@ function createData (results, rootUrl) {
 const createResource = {
   object (hit, rootUrl) {
     const type = 'objects';
-    const id = hit._id.replace('-object-', '-objects-');
+    const id = TypeMapping.toExternal(hit._id);
 
     const attributes = [
       'arrangement',
@@ -80,7 +81,7 @@ const createResource = {
 
   agent (hit, rootUrl) {
     const type = 'people';
-    const id = hit._id.replace('-agent-', '-people-');
+    const id = TypeMapping.toExternal(hit._id);
 
     const attributes = [
       'date_of_birth',
@@ -121,7 +122,7 @@ const createResource = {
 
   archive (hit, rootUrl) {
     const type = 'documents';
-    const id = hit._id.replace('-archive-', '-documents-');
+    const id = TypeMapping.toExternal(hit._id);
 
     const attributes = [
       'arrangement',
@@ -162,11 +163,13 @@ function createRelationships (hit, props, rootUrl) {
   // Reference relationships
   const relationships = props.reduce((rels, key) => {
     if (hit._source && hit._source[key] && hit._source[key].length) {
-      rels[key] = {
-        data: hit._source[key].map((r) => ({
-          type: key,  // TODO: Map to external types
-          id: r.admin && r.admin.uid
-        }))
+      const type = TypeMapping.toExternal(key);
+
+      rels[type] = {
+        data: hit._source[key].map((r) => {
+          const id = TypeMapping.toExternal(r.admin && r.admin.uid);
+          return { type, id };
+        })
       };
     }
     return rels;
@@ -175,16 +178,20 @@ function createRelationships (hit, props, rootUrl) {
   // Add included docs
   const included = props.reduce((incs, key) => {
     if (hit._source && hit._source[key] && hit._source[key].length) {
-      incs = incs.concat(hit._source[key].map((r) => ({
-        type: key, // TODO: Map to external types
-        id: r.admin && r.admin.uid,
-        attributes: {
-          summary_title: r.summary_title
-        },
-        links: {
-          self: `${rootUrl}/${key}/${r.admin && r.admin.uid}`
-        }
-      })));
+      const type = TypeMapping.toExternal(key);
+
+      const resources = hit._source[key].map((r) => {
+        const id = TypeMapping.toExternal(r.admin && r.admin.uid);
+
+        return {
+          type,
+          id,
+          attributes: { summary_title: r.summary_title },
+          links: { self: `${rootUrl}/${type}/${id}` }
+        };
+      });
+
+      incs = incs.concat(resources);
     }
     return incs;
   }, []);

--- a/lib/type-mapping.js
+++ b/lib/type-mapping.js
@@ -1,11 +1,11 @@
 // Mapping internal types to external types (plurals first!)
 const inToExMap = {
-  'objects': 'objects',
-  'object': 'objects',
-  'agents': 'people',
-  'agent': 'people',
-  'archives': 'documents',
-  'archive': 'documents'
+  objects: 'objects',
+  object: 'objects',
+  agents: 'people',
+  agent: 'people',
+  archives: 'documents',
+  archive: 'documents'
 };
 
 // Flip for external to internal

--- a/lib/type-mapping.js
+++ b/lib/type-mapping.js
@@ -1,0 +1,21 @@
+// Mapping internal types to external types (plurals first!)
+const inToExMap = {
+  'objects': 'objects',
+  'object': 'objects',
+  'agents': 'people',
+  'agent': 'people',
+  'archives': 'documents',
+  'archive': 'documents'
+};
+
+// Flip for external to internal
+const exToInMap = Object.keys(inToExMap).reduce((map, key) => {
+  map[inToExMap[key]] = key;
+  return map;
+}, {});
+
+const inToExRegx = new RegExp('(' + Object.keys(inToExMap).join('|') + ')');
+const exToInRegx = new RegExp('(' + Object.keys(exToInMap).join('|') + ')');
+
+exports.toExternal = (type) => (type + '').replace(inToExRegx, (match) => inToExMap[match]);
+exports.toInternal = (type) => (type + '').replace(exToInRegx, (match) => exToInMap[match]);

--- a/test/type-mapping.js
+++ b/test/type-mapping.js
@@ -1,0 +1,28 @@
+const test = require('tape');
+const TypeMapping = require('../lib/type-mapping');
+
+test('Should convert to external types', (t) => {
+  t.plan(6);
+  t.equal(TypeMapping.toExternal('agent'), 'people');
+  t.equal(TypeMapping.toExternal('agents'), 'people');
+  t.equal(TypeMapping.toExternal('object'), 'objects');
+  t.equal(TypeMapping.toExternal('objects'), 'objects');
+  t.equal(TypeMapping.toExternal('archive'), 'documents');
+  t.equal(TypeMapping.toExternal('archives'), 'documents');
+  t.end();
+});
+
+test('Should convert to internal types', (t) => {
+  t.plan(3);
+  t.equal(TypeMapping.toInternal('people'), 'agent');
+  t.equal(TypeMapping.toInternal('objects'), 'object');
+  t.equal(TypeMapping.toInternal('documents'), 'archive');
+  t.end();
+});
+
+test('Should leave unknown intact', (t) => {
+  t.plan(2);
+  t.equal(TypeMapping.toExternal('FOOBAR'), 'FOOBAR');
+  t.equal(TypeMapping.toInternal('FOOBAR'), 'FOOBAR');
+  t.end();
+});


### PR DESCRIPTION
The `TypeMapping` util allows us to convert type names and IDs between internal and external representations.

Examples:

```js
TypeMapping.toExternal('agent') // -> people
TypeMapping.toExternal('smg-archive-12345') // -> smg-documents-12345

TypeMapping.toInternal('people') // -> agent
TypeMapping.toInternal('smg-documents-12345') // -> smg-archive-12345
```

Currently the following mappings are supported (and vice versa):

* People => Agent
* Objects => Object
* Documents => Archive

This work was necessary in order to add the test (also included in PR) to ensure relationships from the index were extracted correctly and placed in the appropriate jsonapi `relationships` and `included` properties of the response document.

refs #44