### PR TITLE
Disable hapi-negotiator plugin on plublic assets route

### DIFF
--- a/routes/public.js
+++ b/routes/public.js
@@ -9,5 +9,10 @@ module.exports = () => ({
     } else {
       reply.file(Path.resolve(__dirname, '..', 'public', req.params.path));
     }
+  },
+  config: {
+    plugins: {
+      'hapi-negotiator': false
+    }
   }
 });


### PR DESCRIPTION
`hapi-negotiator` was stepping in because safari sends a `Accept: image/svg+xml` header. We actually don't want the plugin for this route so this PR explicitly disables it.

Explicitly disabling the plugin might be the intended behaviour, but I suspect not:
https://github.com/felipeleusin/hapi-negotiator/pull/10

fixes #83