### PR TITLE
makes text/html default response if no media type given

### DIFF
--- a/routes/archive.js
+++ b/routes/archive.js
@@ -4,7 +4,7 @@ const getArchiveAndChildren = require('../lib/get-archive-and-children');
 module.exports = (elastic, config) => ({
   method: 'GET',
   path: '/documents/{id}/{slug?}',
-  handler: (request, reply) => reply(),
+  handler: (request, reply) => HTMLResponse(request, reply, elastic, config),
   config: {
     validate: {
       query: archiveSchema
@@ -13,11 +13,7 @@ module.exports = (elastic, config) => ({
       'hapi-negotiator': {
         mediaTypes: {
           'text/html' (request, reply) {
-            return getArchiveAndChildren(elastic, config, request, function (err, data) {
-              if (err) return reply(err);
-
-              return reply.view('archive', data.HTMLData);
-            });
+            return HTMLResponse(request, reply, elastic, config);
           },
           'application/vnd.api+json' (request, reply) {
             return getArchiveAndChildren(elastic, config, request, function (err, data) {
@@ -31,3 +27,11 @@ module.exports = (elastic, config) => ({
     }
   }
 });
+
+function HTMLResponse (request, reply, elastic, config) {
+  return getArchiveAndChildren(elastic, config, request, function (err, data) {
+    if (err) return reply(err);
+
+    return reply.view('archive', data.HTMLData);
+  });
+}

--- a/routes/object.js
+++ b/routes/object.js
@@ -8,39 +8,18 @@ const JSONToHTML = require('../lib/transforms/json-to-html-data.js');
 module.exports = (elastic, config) => ({
   method: 'GET',
   path: '/objects/{id}/{slug?}',
-  handler: (request, reply) => reply(),
+  handler: (request, reply) => HTMLResponse(request, reply, elastic, config),
   config: {
     plugins: {
       'hapi-negotiator': {
         mediaTypes: {
           'text/html' (request, reply) {
-            const data = {
-              page: 'object',
-              slides: exampleData.slides
-            };
-
-            elastic.get({index: 'smg', type: 'object', id: TypeMapping.toInternal(request.params.id)}, (err, result) => {
-              if (err) {
-                if (err.status === 404) {
-                  return reply(Boom.notFound());
-                }
-                return reply(Boom.serverUnavailable('unavailable'));
-              }
-
-              const JSONData = buildJSONResponse(result, config);
-              const HTMLData = JSONToHTML(JSONData);
-
-              reply.view('object', Object.assign(HTMLData, data));
-            });
+            return HTMLResponse(request, reply, elastic, config);
           },
           'application/vnd.api+json' (req, reply) {
             elastic.get({index: 'smg', type: 'object', id: TypeMapping.toInternal(req.params.id)}, (err, result) => {
               if (err) {
                 return reply(err);
-              }
-
-              if (!result) {
-                return reply(Boom.notFound('Object not found'));
               }
 
               reply(buildJSONResponse(result, config)).header('content-type', 'application/vnd.api+json');
@@ -51,3 +30,24 @@ module.exports = (elastic, config) => ({
     }
   }
 });
+
+function HTMLResponse (request, reply, elastic, config) {
+  const data = {
+    page: 'object',
+    slides: exampleData.slides
+  };
+
+  elastic.get({index: 'smg', type: 'object', id: TypeMapping.toInternal(request.params.id)}, (err, result) => {
+    if (err) {
+      if (err.status === 404) {
+        return reply(Boom.notFound());
+      }
+      return reply(Boom.serverUnavailable('unavailable'));
+    }
+
+    const JSONData = buildJSONResponse(result, config);
+    const HTMLData = JSONToHTML(JSONData);
+
+    reply.view('object', Object.assign(HTMLData, data));
+  });
+}

--- a/templates/layouts/default.html
+++ b/templates/layouts/default.html
@@ -14,7 +14,7 @@
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="@sciencemuseum" />
     <meta name="twitter:title" content={{titlePage}} />
-    <meta name="twitter:description" content={{description}} />
+    <meta name="twitter:description" content={{description.initialDescription}} />
   </head>
   <body>
     {{{content}}}

--- a/test/fixtures/copy-es-docs.js
+++ b/test/fixtures/copy-es-docs.js
@@ -11,9 +11,9 @@ module.exports = function (elastic, dataToCopy, database, next) {
   database.object[TypeMapping.toInternal('smgc-object-badRequest')] = { error: { 'status': 400, 'displayName': 'BadRequest', 'message': 'Bad Request' } };
 
   // Error fixtures no error but also no result
-  database.archive[TypeMapping.toInternal('smga-documents-noResult')] = {error: null, response: null};
-  database.agent[TypeMapping.toInternal('smgc-people-noResult')] = {error: null, response: null};
-  database.object[TypeMapping.toInternal('smgc-object-noResult')] = {error: null, response: null};
+  database.archive[TypeMapping.toInternal('smga-documents-noResult')] = {error: { status: 404, displayName: 'NotFound', message: 'Not Found' }, response: null};
+  database.agent[TypeMapping.toInternal('smgc-people-noResult')] = {error: { status: 404, displayName: 'NotFound', message: 'Not Found' }, response: null};
+  database.object[TypeMapping.toInternal('smgc-object-noResult')] = {error: { status: 404, displayName: 'NotFound', message: 'Not Found' }, response: null};
 
   var count = 0;
   console.log('copy database to fixtures');

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -288,7 +288,7 @@ testWithServer('Request for Object JSON Page, not found', (t, ctx) => {
 
   ctx.server.inject(htmlRequest, (res) => {
     var response = JSON.parse(res.payload);
-    t.ok(response.errors[0].detail, 404, 'Object not found');
+    t.equal(response.status, 404, 'Object not found');
     t.end();
   });
 });
@@ -337,9 +337,8 @@ testWithServer('Request for Person JSON Page, no result', (t, ctx) => {
   };
 
   ctx.server.inject(htmlRequest, (res) => {
-    // {"errors":[{"title":"Not Found","status":404,"detail":"Person not found"}]}
     var response = JSON.parse(res.payload);
-    t.ok(response.errors[0].detail, 404, 'Person not found');
+    t.equal(response.status, 404, 'Person not found');
     t.end();
   });
 });


### PR DESCRIPTION
If no media type is given we're currently just sending back an empty reply.

The twitter bot that scrapes our site to get the data for the twitter cards has no media type, but expects html as a response, so this sends an html response if no media type is specified.