### PR TITLE
makes cite button work 

### DIFF
--- a/client/lib/slick-carousel.js
+++ b/client/lib/slick-carousel.js
@@ -65,4 +65,9 @@ module.exports = function (ctx) {
       openseadragon(e.target.src, ctx);
     }
   });
+
+  $('#cite__button').on('click', function (e) {
+    $('#cite__menu').toggleClass('cite__menu--active');
+    $('#cite__button').toggleClass('cite__button--active');
+  });
 };

--- a/templates/partials/records/record-imgpanel__controlbar.html
+++ b/templates/partials/records/record-imgpanel__controlbar.html
@@ -1,7 +1,7 @@
     <div class="row columns record-imgpanel__controlbar">
 
       <div class="cite__menu-pos-wrap">
-        <div class="cite__menu /cite__menu--active/" id="cite__menu" data-toggler=".cite__menu--active">
+        <div class="cite__menu" id="cite__menu" >
           <div class="cite__method">
             <p><img src="/assets/img/global/cc-by-nc-4.png" alt="Creative Commons License" width="80" height="15" />This work is licensed under a Creative Commons Attribution-NonCommercial 4.0 International License</p>
             <button class="">{{> global/icon i="download" size="16" }} Download</button>
@@ -17,7 +17,7 @@
         </div>
       </div>
 
-      <button id="cite__button" class="cite__button /cite__button--active/" data-toggle="cite__menu cite__button" data-toggler=".cite__button--active">{{> global/icon i="arrow_right" size="16" }} Use this image</button>
+      <button id="cite__button" class="cite__button /cite__button--active/" >{{> global/icon i="arrow_right" size="16" }} Use this image</button>
 
       <button class="cite__expand" aria-label="Expand/contract image size"></button>
 


### PR DESCRIPTION
ref #270 

Button was using foundation's data toggles. Foundation's jquery function wasn't getting called on re-render. This fixes the button and removes dependency on foundation, for when we decide to get rid of jquery altogether