### PR TITLE
adds buttons for openseadragon 

### DIFF
--- a/client/lib/init-jquery-components.js
+++ b/client/lib/init-jquery-components.js
@@ -1,8 +1,8 @@
 var svg4everybody = require('svg4everybody');
 // var searchBox = require('../lib/search-box');
-var clipboard = require('../lib/clipboard');
-var moreButton = require('../lib/more-button');
-var slickCarousel = require('../lib/slick-carousel');
+var clipboard = require('./clipboard');
+var moreButton = require('./more-button');
+var slickCarousel = require('./slick-carousel');
 
 module.exports = (ctx) => {
   svg4everybody();

--- a/client/lib/openseadragon.js
+++ b/client/lib/openseadragon.js
@@ -1,21 +1,51 @@
 require('openseadragon');
 var $ = require('jquery');
 
-module.exports = function (imgUrl, ctx) {
-  if (!$('#openseadragon').length) return;
+module.exports = {
+  init: function (ctx, imgUrl, cb) {
+    imgUrl = imgUrl || $('.slick-active img')[0].src;
+    if (!$('#openseadragon').length) return;
 
-  ctx.viewer = OpenSeadragon({
-    id: 'openseadragon',
-    // element: $('.record-imgpanel__singleimg'),
-    prefixUrl: '/assets/img/openseadragon/',
-    showZoomControl: true,
-    // just using an example static image, will be swapped for some magic tiles
-    tileSources: {
-      type: 'image',
-      url: imgUrl
+    if (!ctx.viewer) {
+      $('.record-imgpanel__slickwrap').addClass('hidden');
+      $('.record-imgpanel__dragon').removeClass('hidden');
+
+      ctx.viewer = OpenSeadragon({
+        id: 'openseadragon',
+        prefixUrl: '/assets/img/openseadragon/',
+        showZoomControl: true,
+        tileSources: {
+          type: 'image',
+          url: imgUrl
+        },
+        zoomInButton: 'osd-zoomin',
+        zoomOutButton: 'osd-zoomout',
+        fullPageButton: 'osd-fullpage',
+        homeButton: 'osd-home',
+        gestureSettingsMouse: {
+          scrollToZoom: false
+        }
+      });
+
+      ctx.viewer.addHandler('full-screen', function (e) {
+        if (e.fullScreen) {
+          e.eventSource.gestureSettingsMouse.scrollToZoom = true;
+        } else {
+          e.eventSource.gestureSettingsMouse.scrollToZoom = false;
+        }
+      });
+
+      $('#openseadragon .pic').hide();
+
+      ctx.save();
     }
-  });
-  // hide fallback non-zoomable img
-  $('#openseadragon .pic').hide();
-  ctx.save();
+  },
+
+  quit: function (ctx) {
+    ctx.viewer.destroy();
+    ctx.viewer = false;
+    ctx.save();
+    $('.record-imgpanel__slickwrap').removeClass('hidden');
+    $('.record-imgpanel__dragon').addClass('hidden');
+  }
 };

--- a/client/lib/openseadragon.js
+++ b/client/lib/openseadragon.js
@@ -22,6 +22,7 @@ module.exports = {
         zoomOutButton: 'osd-zoomout',
         fullPageButton: 'osd-fullpage',
         homeButton: 'osd-home',
+        toolbar: 'openseadragon-toolbar',
         gestureSettingsMouse: {
           scrollToZoom: false
         }

--- a/client/lib/slick-carousel.js
+++ b/client/lib/slick-carousel.js
@@ -43,26 +43,15 @@ module.exports = function (ctx) {
           $(e.target).addClass('cite__expand--expanded');
         }
       }
-
-      if ($('.record-imgpanel__dragon').hasClass('hidden')) {
-        $('.record-imgpanel__slickwrap').addClass('hidden');
-        $('.record-imgpanel__dragon').removeClass('hidden');
-        openseadragon($('.slick-active img')[0].src, ctx);
-      } else {
-        ctx.viewer.destroy();
-        ctx.viewer = false;
-        ctx.save();
-        $('.record-imgpanel__slickwrap').removeClass('hidden');
-        $('.record-imgpanel__dragon').addClass('hidden');
-      }
     }
   });
 
   $('.record-imgpanel__thumbnav a').on('click', function (e) {
     if (ctx.viewer) {
       ctx.viewer.destroy();
+      ctx.viewer = false;
       ctx.save();
-      openseadragon(e.target.src, ctx);
+      openseadragon.init(ctx, e.target.src);
     }
   });
 

--- a/client/routes/object.js
+++ b/client/routes/object.js
@@ -5,6 +5,7 @@ var getData = require('../lib/get-data.js');
 var JSONToHTML = require('../../lib/transforms/json-to-html-data');
 var searchListener = require('../lib/search-listener');
 var Snackbar = require('snackbarlightjs');
+var openseadragon = require('../lib/openseadragon');
 
 module.exports = function (page) {
   page('/objects/:id', load, render, listeners);
@@ -46,4 +47,12 @@ function render (ctx, next) {
 function listeners (ctx, next) {
   initJqueryComp(ctx);
   searchListener();
+  document.getElementById('openseadragon-toolbar').addEventListener('click', function (e) {
+    openseadragon.init(ctx);
+    if (e.target.id === 'osd-fullpage') {
+      ctx.viewer.setFullScreen(true);
+    } else if (e.target.id === 'osd-home') {
+      openseadragon.quit(ctx);
+    }
+  });
 }

--- a/templates/partials/records/record-imgpanel__controlbar.html
+++ b/templates/partials/records/record-imgpanel__controlbar.html
@@ -19,16 +19,12 @@
 
       <button id="cite__button" class="cite__button" >{{> global/icon i="arrow_right" size="16" }} Use this image</button>
 
-      <button class="cite__expand" aria-label="Expand/contract image size"></button>
-
-      {{#if osd}}
       <div class="osd__toolbar" id="openseadragon-toolbar">
         <button class="osd__button" id="osd-fullpage" aria-label="full screen"></button>
         <button class="osd__button" id="osd-home" aria-label="Original size"></button>
         <button class="osd__button" id="osd-zoomout" aria-label="Zoom out"></button>
         <button class="osd__button" id="osd-zoomin" aria-label="Zoom in"></button>
       </div>
-      {{/if}}
 
       <p class="record-imgpanel__caption">This is the caption for the image<br />
       © This is the copyright of the photographer</p>


### PR DESCRIPTION
ref #278

Adds new openseadragon buttons to bottom of the carousel. Gets rid of old zoom button, as it essentially did nothing except activate the viewer. New buttons all activate deep zoom viewer. 