### PR TITLE
Add analytics endpoint for registering result clicks

### DIFF
--- a/client/routes/search.js
+++ b/client/routes/search.js
@@ -1,5 +1,6 @@
 var $ = require('jquery');
 var QueryString = require('querystring');
+var fetch = require('fetch-ponyfill')();
 var initJqueryComp = require('../lib/init-jquery-components');
 var Templates = require('../templates');
 var createQueryParams = require('../../lib/query-params/query-params');
@@ -116,4 +117,23 @@ function listeners (ctx, next) {
   });
 
   initJqueryComp();
+
+  const onResultClick = (e) => {
+    const id = e.currentTarget.getAttribute('href').split('/').pop();
+
+    fetch('/analytics', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/vnd.api+json',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ event: 'RESULT_CLICK', data: id })
+    }).catch((err) => console.error('Failed to send RESULT_CLICK analytics', err));
+  };
+
+  const resultLinks = document.querySelectorAll('#searchresults a');
+
+  for (let i = 0; i < resultLinks.length; i++) {
+    resultLinks[i].addEventListener('click', onResultClick);
+  }
 }

--- a/routes/analytics.js
+++ b/routes/analytics.js
@@ -1,0 +1,25 @@
+const Joi = require('joi');
+
+module.exports = (elastic, config) => ({
+  method: 'POST',
+  path: '/analytics',
+  handler: (request, reply) => reply(),
+  config: {
+    plugins: {
+      'hapi-negotiator': {
+        mediaTypes: {
+          'application/vnd.api+json' (request, reply) {
+            // TODO: Register analytics event
+            reply().code(204);
+          }
+        }
+      }
+    },
+    validate: {
+      payload: {
+        event: Joi.string().valid('RESULT_CLICK').required(),
+        data: Joi.string()
+      }
+    }
+  }
+});

--- a/routes/index.js
+++ b/routes/index.js
@@ -6,5 +6,6 @@ module.exports = (elastic, config) => ([
   require('./object')(elastic, config),
   require('./person')(elastic, config),
   require('./autocomplete')(elastic, config),
-  require('./sitemap')(config)
+  require('./sitemap')(config),
+  require('./analytics')()
 ]);

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -1,0 +1,21 @@
+const testWithServer = require('./helpers/test-with-server');
+const file = require('path').relative(process.cwd(), __filename) + ' > ';
+
+testWithServer(file + 'Should process RESULT_CLICK analytics event', (t, ctx) => {
+  t.plan(1);
+
+  const request = {
+    method: 'POST',
+    url: '/analytics',
+    headers: {
+      Accept: 'application/vnd.api+json',
+      'Content-Type': 'application/json'
+    },
+    payload: JSON.stringify({ event: 'RESULT_CLICK', data: 'smg-objects-12345' })
+  };
+
+  ctx.server.inject(request, (res) => {
+    t.equal(res.statusCode, 204, 'Status was OK');
+    t.end();
+  });
+});


### PR DESCRIPTION
* Adds `POST /analytics` for registering analytics events
* Payload looks like `{ event: 'EVENT_NAME', data: 'misc data' }`
* Currently only one event available `RESULT_CLICK` where `data` is assumed to be the ID of an object in the collection