### PR TITLE
Test Refactoring

### DIFF
--- a/lib/autocomplete.js
+++ b/lib/autocomplete.js
@@ -14,7 +14,6 @@ module.exports = (elastic, queryParams, cb) => {
   }
 
   const searchOpts = {
-    searchName: 'autocomplete',
     index: 'smg',
     size: queryParams.size || 3,
     _source: ['summary_title'],

--- a/lib/get-archive-and-children.js
+++ b/lib/get-archive-and-children.js
@@ -1,4 +1,3 @@
-const Boom = require('boom');
 const TypeMapping = require('../lib/type-mapping');
 const JSONToHTML = require('../lib/transforms/json-to-html-data.js');
 const getChildArchives = require('../lib/get-child-files.js');
@@ -24,10 +23,7 @@ module.exports = (elastic, config, request, callback) => {
 
   elastic.get({index: 'smg', type: 'archive', id: TypeMapping.toInternal(request.params.id)}, (err, result) => {
     if (err) {
-      if (err.status === 404) {
-        return callback(Boom.notFound(), null);
-      }
-      return callback(Boom.serverUnavailable('unavailable'), null);
+      return callback(err);
     }
     if (result._source.parent) {
       parentID = result._source.parent[0].admin.uid;

--- a/lib/get-child-files.js
+++ b/lib/get-child-files.js
@@ -18,7 +18,6 @@ module.exports = (elastic, id, next, count) => {
 
   const searchOpts = {
     index: 'smg',
-    searchName: 'searchChildArchive',
     body: body
   };
 

--- a/lib/get-related-items.js
+++ b/lib/get-related-items.js
@@ -30,7 +30,6 @@ module.exports = (elastic, id, next, count) => {
 
   const searchOpts = {
     index: 'smg',
-    searchName: 'searchRelatedItems',
     body: body
   };
 

--- a/lib/search.js
+++ b/lib/search.js
@@ -151,8 +151,7 @@ module.exports = (elastic, queryParams, next) => {
     index: 'smg',
     from: pageNumber * pageSize,
     size: pageSize,
-    body: body,
-    searchName: 'defaultSearch'
+    body: body
   };
 
   if (!queryParams.q) {

--- a/lib/transforms/json-to-html-data.js
+++ b/lib/transforms/json-to-html-data.js
@@ -302,9 +302,6 @@ function getLegal (data) {
         value = '';
         data.attributes.legal[el].forEach((leg, i, arr) => {
           value += leg.details;
-          if (i < arr.length - 1) {
-            value += '<br>';
-          }
         });
       } else {
         value = data.attributes.legal[el];

--- a/routes/autocomplete.js
+++ b/routes/autocomplete.js
@@ -1,4 +1,5 @@
 const Joi = require('joi');
+const Boom = require('boom');
 const autocomplete = require('../lib/autocomplete');
 const autocompleteResultsToJsonApi = require('../lib/transforms/autocomplete-results-to-jsonapi');
 
@@ -14,7 +15,7 @@ module.exports = (elastic, config) => ({
             const queryParams = Object.assign({}, request.params, request.query);
 
             autocomplete(elastic, queryParams, (err, results) => {
-              if (err) return reply(err);
+              if (err) return reply(Boom.serverUnavailable(err));
               reply(autocompleteResultsToJsonApi(queryParams, results, config));
             });
           }

--- a/routes/object.js
+++ b/routes/object.js
@@ -19,7 +19,10 @@ module.exports = (elastic, config) => ({
           'application/vnd.api+json' (req, reply) {
             elastic.get({index: 'smg', type: 'object', id: TypeMapping.toInternal(req.params.id)}, (err, result) => {
               if (err) {
-                return reply(err);
+                if (err.status === 404) {
+                  return reply(Boom.notFound());
+                }
+                return reply(Boom.serverUnavailable('unavailable'));
               }
 
               reply(buildJSONResponse(result, config)).header('content-type', 'application/vnd.api+json');

--- a/routes/person.js
+++ b/routes/person.js
@@ -19,7 +19,10 @@ module.exports = (elastic, config) => ({
           'application/vnd.api+json' (request, reply) {
             elastic.get({index: 'smg', type: 'agent', id: TypeMapping.toInternal(request.params.id)}, (err, result) => {
               if (err) {
-                return reply(err);
+                if (err.status === 404) {
+                  return reply(Boom.notFound());
+                }
+                return reply(Boom.serverUnavailable('unavailable'));
               }
 
               getRelatedItems(elastic, request.params.id, (err, relatedItems) => {

--- a/routes/search.js
+++ b/routes/search.js
@@ -29,7 +29,7 @@ module.exports = (elastic, config) => ({
                 const query = value.query;
                 const queryParams = createQueryParams('html', {query: query, params: params});
                 search(elastic, queryParams, (err, result) => {
-                  if (err) return reply(Boom.badRequest(err));
+                  if (err) return reply(Boom.serverUnavailable(err));
 
                   const jsonData = searchResultsToJsonApi(queryParams, result, config);
                   const tplData = searchResultsToTemplateData(queryParams, jsonData);
@@ -47,13 +47,13 @@ module.exports = (elastic, config) => ({
                 },
                 query: filterSchema('json').keys(searchSchema)
               }, (err, value) => {
-                if (err) return reply(Boom.badRequest());
+                if (err) return reply(Boom.badRequest(err));
 
                 const params = value.params;
                 const query = value.query;
                 const queryParams = createQueryParams('json', {query: query, params: params});
                 search(elastic, queryParams, (err, result) => {
-                  if (err) return reply(Boom.badRequest(err));
+                  if (err) return reply(Boom.serverUnavailable(err));
                   reply(searchResultsToJsonApi(queryParams, result, config))
                     .header('content-type', 'application/vnd.api+json');
                 });

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -1,7 +1,7 @@
 const testWithServer = require('./helpers/test-with-server');
 const file = require('path').relative(process.cwd(), __filename) + ' > ';
 
-testWithServer(file + 'Should process RESULT_CLICK analytics event', (t, ctx) => {
+testWithServer(file + 'Should process RESULT_CLICK analytics event', {}, (t, ctx) => {
   t.plan(1);
 
   const request = {

--- a/test/approved-description-obj.test.js
+++ b/test/approved-description-obj.test.js
@@ -1,6 +1,6 @@
 const testWithServer = require('./helpers/test-with-server');
 
-testWithServer('Request for Archive HTML Page', (t, ctx) => {
+testWithServer('Request for Archive HTML Page', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {

--- a/test/authentication.test.js
+++ b/test/authentication.test.js
@@ -5,7 +5,7 @@ const JWT = require('jsonwebtoken');
 const jwtSecret = config.JWT_SECRET;
 config.JWT_SECRET = 'enocdethejwt';
 
-testWithServer('Authentication is ok', (t, ctx) => {
+testWithServer('Authentication is ok', {}, (t, ctx) => {
   t.plan(1);
   const token = JWT.sign({valid: true}, config.JWT_SECRET);
   const htmlRequest = {
@@ -20,7 +20,7 @@ testWithServer('Authentication is ok', (t, ctx) => {
   });
 }, true);
 
-testWithServer('Attempt to access a page with a wrong cookie', (t, ctx) => {
+testWithServer('Attempt to access a page with a wrong cookie', {}, (t, ctx) => {
   t.plan(1);
   const token = JWT.sign({valid: 'wrong cookie value'}, config.JWT_SECRET);
   const htmlRequest = {

--- a/test/autocomplete.test.js
+++ b/test/autocomplete.test.js
@@ -33,3 +33,33 @@ testWithServer(file + 'Should disallow < 3 characters', {}, (t, ctx) => {
     t.end();
   });
 });
+
+testWithServer(file + 'Autocomplete with type people', {}, (t, ctx) => {
+  t.plan(1);
+
+  const request = {
+    method: 'GET',
+    url: '/autocomplete/people?' + QueryString.stringify({ q: 'cha' }),
+    headers: { Accept: 'application/vnd.api+json' }
+  };
+
+  ctx.server.inject(request, (res) => {
+    t.equal(res.statusCode, 200, 'Status was OK');
+    t.end();
+  });
+});
+
+testWithServer(file + 'Autocomplete error', {mock: {method: 'search', response: {error: new Error()}}}, (t, ctx) => {
+  t.plan(1);
+
+  const request = {
+    method: 'GET',
+    url: '/autocomplete?' + QueryString.stringify({ q: 'cha' }),
+    headers: { Accept: 'application/vnd.api+json' }
+  };
+
+  ctx.server.inject(request, (res) => {
+    t.equal(res.statusCode, 503, 'Status code was as expected');
+    t.end();
+  });
+});

--- a/test/autocomplete.test.js
+++ b/test/autocomplete.test.js
@@ -2,7 +2,7 @@ const QueryString = require('querystring');
 const testWithServer = require('./helpers/test-with-server');
 const file = require('path').relative(process.cwd(), __filename) + ' > ';
 
-testWithServer(file + 'Should suggest completion', (t, ctx) => {
+testWithServer(file + 'Should suggest completion', {}, (t, ctx) => {
   t.plan(2);
 
   const request = {
@@ -18,7 +18,7 @@ testWithServer(file + 'Should suggest completion', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should disallow < 3 characters', (t, ctx) => {
+testWithServer(file + 'Should disallow < 3 characters', {}, (t, ctx) => {
   t.plan(2);
 
   const request = {

--- a/test/check-purchased.test.js
+++ b/test/check-purchased.test.js
@@ -1,6 +1,6 @@
 const testWithServer = require('./helpers/test-with-server');
 
-testWithServer('Request for Object with "Purchased" in credit line', (t, ctx) => {
+testWithServer('Request for Object with "Purchased" in credit line', {}, (t, ctx) => {
   t.plan(3);
 
   const htmlRequest = {
@@ -17,7 +17,7 @@ testWithServer('Request for Object with "Purchased" in credit line', (t, ctx) =>
   });
 });
 
-testWithServer('Search request for Object with "Purchased" in credit line', (t, ctx) => {
+testWithServer('Search request for Object with "Purchased" in credit line', {}, (t, ctx) => {
   t.plan(3);
 
   const htmlRequest = {

--- a/test/content-negotiation.test.js
+++ b/test/content-negotiation.test.js
@@ -1,6 +1,6 @@
 const testWithServer = require('./helpers/test-with-server');
 
-testWithServer('Request for HTML Content', (t, ctx) => {
+testWithServer('Request for HTML Content', {}, (t, ctx) => {
   t.plan(2);
 
   const htmlRequest = {
@@ -16,7 +16,7 @@ testWithServer('Request for HTML Content', (t, ctx) => {
   });
 });
 
-testWithServer('Request for JSONAPI Content', (t, ctx) => {
+testWithServer('Request for JSONAPI Content', {}, (t, ctx) => {
   // http://jsonapi.org/format/#content-negotiation-servers
   //
   // Servers MUST send all JSON API data in response documents with the header
@@ -35,7 +35,7 @@ testWithServer('Request for JSONAPI Content', (t, ctx) => {
   });
 });
 
-testWithServer('Request for JSONAPI Content with parameters', (t, ctx) => {
+testWithServer('Request for JSONAPI Content with parameters', {}, (t, ctx) => {
   // http://jsonapi.org/format/#content-negotiation-servers
   //
   // Servers MUST respond with a 406 Not Acceptable status code if a request’s
@@ -55,7 +55,7 @@ testWithServer('Request for JSONAPI Content with parameters', (t, ctx) => {
   });
 });
 
-testWithServer('Request with multiple instances of JSONAPI media type, one without parameters', (t, ctx) => {
+testWithServer('Request with multiple instances of JSONAPI media type, one without parameters', {}, (t, ctx) => {
   t.plan(1);
 
   const acceptableJSONRequest = {

--- a/test/error.test.js
+++ b/test/error.test.js
@@ -1,0 +1,156 @@
+const testWithServer = require('./helpers/test-with-server');
+
+testWithServer('Request for Archive HTML Page but receive bad request from es', {mock: {method: 'get', response: {error: true}}}, (t, ctx) => {
+  t.plan(1);
+
+  const htmlRequest = {
+    method: 'GET',
+    url: '/documents/smga-documents-badRequest',
+    headers: {'Accept': 'text/html'}
+  };
+
+  ctx.server.inject(htmlRequest, (res) => {
+    t.equal(res.statusCode, 503, 'Status code was as expected, 503');
+    t.end();
+  });
+});
+
+testWithServer('Request for Archive JSON Page but receive bad request from es', {mock: {method: 'get', response: {error: true}}}, (t, ctx) => {
+  t.plan(1);
+
+  const htmlRequest = {
+    method: 'GET',
+    url: '/documents/smga-documents-badRequest',
+    headers: {'Accept': 'application/vnd.api+json'}
+  };
+
+  ctx.server.inject(htmlRequest, (res) => {
+    t.equal(res.statusCode, 503, 'Status code was as expected, 503');
+    t.end();
+  });
+});
+
+testWithServer('Request for Object HTML Page but receive bad request from es', {mock: {method: 'get', response: {error: true}}}, (t, ctx) => {
+  t.plan(1);
+
+  const htmlRequest = {
+    method: 'GET',
+    url: '/objects/smgc-objects-badRequest',
+    headers: {'Accept': 'text/html'}
+  };
+
+  ctx.server.inject(htmlRequest, (res) => {
+    t.equal(res.statusCode, 503, 'Status code was as expected, 503');
+    t.end();
+  });
+});
+
+testWithServer('Request for Object JSON Page but receive bad request from es', {mock: {method: 'get', response: {error: true}}}, (t, ctx) => {
+  t.plan(1);
+
+  const htmlRequest = {
+    method: 'GET',
+    url: '/objects/smgc-objects-badRequest',
+    headers: {'Accept': 'application/vnd.api+json'}
+  };
+
+  ctx.server.inject(htmlRequest, (res) => {
+    t.equal(res.statusCode, 503, 'Status code was as expected, 503');
+    t.end();
+  });
+});
+
+testWithServer('Request for Person HTML Page but receive bad request from es', {mock: {method: 'get', response: {error: true}}}, (t, ctx) => {
+  t.plan(1);
+
+  const htmlRequest = {
+    method: 'GET',
+    url: '/people/smgc-people-badRequest',
+    headers: {'Accept': 'text/html'}
+  };
+
+  ctx.server.inject(htmlRequest, (res) => {
+    t.equal(res.statusCode, 503, 'Status code was as expected, 503');
+    t.end();
+  });
+});
+
+testWithServer('Request for Person JSON Page but receive bad request from es', {mock: {method: 'get', response: {error: true}}}, (t, ctx) => {
+  t.plan(1);
+
+  const htmlRequest = {
+    method: 'GET',
+    url: '/people/smgc-people-badRequest',
+    headers: {'Accept': 'application/vnd.api+json'}
+  };
+
+  ctx.server.inject(htmlRequest, (res) => {
+    t.equal(res.statusCode, 503, 'Status code was as expected, 503');
+    t.end();
+  });
+});
+
+testWithServer('Request for Person with related items', {mock: {method: 'search', response: {error: true}}}, (t, ctx) => {
+  t.plan(2);
+
+  const htmlRequest = {
+    method: 'GET',
+    url: '/people/smgc-people-36993',
+    headers: {'Accept': 'application/vnd.api+json'}
+  };
+
+  ctx.server.inject(htmlRequest, (res) => {
+    var response = JSON.parse(res.payload);
+    t.equal(res.statusCode, 200, 'Status code was as expected, 200');
+    t.notOk(response.data.relationships.objects, 'Response has no related items');
+    t.end();
+  });
+});
+
+testWithServer('Search for JSON', {mock: {method: 'search', response: {error: true}}}, (t, ctx) => {
+  t.plan(1);
+
+  const htmlRequest = {
+    method: 'GET',
+    url: '/search?q=charles',
+    headers: {'Accept': 'application/vnd.api+json'}
+  };
+
+  ctx.server.inject(htmlRequest, (res) => {
+    t.equal(res.statusCode, 400, 'Status code was as expected, 500');
+    t.end();
+  });
+});
+
+testWithServer('Search for HTML', {mock: {method: 'search', response: {error: true}}}, (t, ctx) => {
+  t.plan(1);
+
+  const htmlRequest = {
+    method: 'GET',
+    url: '/search?q=charles',
+    headers: {'Accept': 'text/html'}
+  };
+
+  ctx.server.inject(htmlRequest, (res) => {
+    t.equal(res.statusCode, 400, 'Status code was as expected, 500');
+    t.end();
+  });
+});
+
+testWithServer('Request for Archive JSON with children', {mock: {method: 'search', response: {error: true}}}, (t, ctx) => {
+  t.plan(3);
+
+  const htmlRequest = {
+    method: 'GET',
+    url: '/documents/smga-documents-110000003',
+    headers: {'Accept': 'application/vnd.api+json'}
+  };
+
+  ctx.server.inject(htmlRequest, (res) => {
+    var response = JSON.parse(res.payload);
+    t.equal(res.statusCode, 200, 'Status code was as expected, 503');
+    t.deepEqual(response.data.relationships.children.data, [], 'Response has no children');
+    t.deepEqual(response.data.relationships.siblings.data, [], 'Response has no related siblings');
+    t.end();
+  });
+});

--- a/test/error.test.js
+++ b/test/error.test.js
@@ -1,4 +1,6 @@
 const testWithServer = require('./helpers/test-with-server');
+const async = require('async');
+var stub = require('sinon').stub;
 
 testWithServer('Request for Archive HTML Page but receive bad request from es', {mock: {method: 'get', response: {error: true}}}, (t, ctx) => {
   t.plan(1);
@@ -117,7 +119,7 @@ testWithServer('Search for JSON', {mock: {method: 'search', response: {error: tr
   };
 
   ctx.server.inject(htmlRequest, (res) => {
-    t.equal(res.statusCode, 400, 'Status code was as expected, 500');
+    t.equal(res.statusCode, 503, 'Status code was as expected, 503');
     t.end();
   });
 });
@@ -132,7 +134,7 @@ testWithServer('Search for HTML', {mock: {method: 'search', response: {error: tr
   };
 
   ctx.server.inject(htmlRequest, (res) => {
-    t.equal(res.statusCode, 400, 'Status code was as expected, 500');
+    t.equal(res.statusCode, 503, 'Status code was as expected, 503');
     t.end();
   });
 });
@@ -148,9 +150,29 @@ testWithServer('Request for Archive JSON with children', {mock: {method: 'search
 
   ctx.server.inject(htmlRequest, (res) => {
     var response = JSON.parse(res.payload);
-    t.equal(res.statusCode, 200, 'Status code was as expected, 503');
+    t.equal(res.statusCode, 200, 'Status code was as expected, 200');
     t.deepEqual(response.data.relationships.children.data, [], 'Response has no children');
     t.deepEqual(response.data.relationships.siblings.data, [], 'Response has no related siblings');
+    t.end();
+  });
+});
+
+testWithServer('Request for Archive JSON with children', {}, (t, ctx) => {
+  t.plan(1);
+
+  var mockAsync = stub(async, 'map');
+
+  mockAsync.callsArgWith(2, new Error(), null);
+
+  const htmlRequest = {
+    method: 'GET',
+    url: '/documents/smga-documents-110000003?expanded=smga-documents-110000009',
+    headers: {'Accept': 'application/vnd.api+json'}
+  };
+
+  ctx.server.inject(htmlRequest, (res) => {
+    t.equal(res.statusCode, 503, 'Status code was as expected, 503');
+    async.map.restore();
     t.end();
   });
 });

--- a/test/helpers/mock-database.js
+++ b/test/helpers/mock-database.js
@@ -1,55 +1,13 @@
-// Create a mock elasticsearch client with noop functions
-const Boom = require('boom');
-const database = require('../fixtures/elastic-responses/database.json');
-const getNestedProperty = require('../../lib/nested-property');
+const Client = require('elasticsearch').Client;
+const config = require('../../config');
 
-module.exports = () => ({
-  search: function () {
-    var q;
-    var search;
-    const cb = arguments[arguments.length - 1];
-    const searchName = arguments[0].searchName;
-
-    if (searchName === 'defaultSearch') {
-      q = getNestedProperty(arguments, '0.body.query.function_score.query.bool.should.0.multi_match.query') || 'all';
-    }
-
-    if (searchName === 'searchChildArchive') {
-      q = arguments[0].body.query.constant_score.filter.bool.must.term['parent.admin.uid'];
-    }
-
-    if (searchName === 'searchRelatedItems') {
-      q = arguments[0].body.query.constant_score.filter.bool.should[1].term['agents.admin.uid'];
-    }
-
-    if (searchName === 'autocomplete') {
-      q = arguments[0].body.query.bool.must[0].match_phrase_prefix.summary_title_text.query;
-
-      if (database.autocompletes[q]) {
-        return cb(database.autocompletes[q].error, database.autocompletes[q].response);
-      }
-    }
-
-    if (database.search[q]) {
-      search = database.search[q];
-      return cb(search.error, search.response);
-    } else if (database.related[q]) {
-      search = database.related[q];
-      return cb(search.error, search.response);
-    } else if (database.children[q]) {
-      search = database.children[q];
-      return cb(search.error, search.response);
-    }
-
-    console.log('search fixture not found for', q);
-    cb(Boom.notFound('Search fixture not found, did you forget to add a searchName property to your search options?'));
-  },
-
-  get: function () {
-    const cb = arguments[arguments.length - 1];
-    const type = arguments[0].type;
-    const id = arguments[0].id;
-    const data = database[type][id];
-    cb(data.error, data.response);
+module.exports = () => {
+  function getConfig () {
+    return {
+      log: 'warning',
+      host: config.elasticsearch.host
+    };
   }
-});
+
+  return new Client(getConfig());
+};

--- a/test/helpers/test-with-server.js
+++ b/test/helpers/test-with-server.js
@@ -1,11 +1,20 @@
 const tape = require('tape');
 const createServer = require('../../server');
 const config = require('../../config');
-// const createMockElastic = require('./mock-elastic');
 const createMockDatabase = require('./mock-database');
+var stub = require('sinon').stub;
 
-// Wrap tape's test function with a function that creates a new server and mocks dependencies
-module.exports = (description, cb, auth) => {
+/**
+* Wrap tape's test function with a function that creates a new server and mocks dependencies
+* @param {string} description - the description for yoyr tape test
+* @param {object} options - options object
+* @param {object} options.mock - elasticsearch database mock options
+* @param {string} options.mock.method - the elasticsearch method you want to mock, for example: 'get', 'search'
+* @param {object} options.mock.response - an object containing either an error or data to return in the es callback
+* @param {*} options.mock.response.error - optional error to return from es callback
+* @param {*} options.mock.response.data - optional data to return from es callback
+**/
+module.exports = (description, options, cb, auth) => {
   const elastic = createMockDatabase();
   if (auth) {
     config.auth = true;
@@ -14,7 +23,20 @@ module.exports = (description, cb, auth) => {
   }
   createServer(elastic, config, (err, ctx) => {
     if (err) {
+      console.log(err);
       throw err;
+    }
+
+    if (options.mock) {
+      if (!options.mock.method) {
+        throw new Error('Mock needs to include a method');
+      }
+
+      stub(elastic, options.mock.method, function (params, cb) {
+        process.nextTick(function () {
+          cb(options.mock.response.error, options.mock.response.data);
+        });
+      });
     }
 
     tape(description, (t) => {

--- a/test/images.test.js
+++ b/test/images.test.js
@@ -1,6 +1,6 @@
 const testWithServer = require('./helpers/test-with-server');
 
-testWithServer('Request for Object Page with image', (t, ctx) => {
+testWithServer('Request for Object Page with image', {}, (t, ctx) => {
   t.plan(3);
 
   const htmlRequest = {
@@ -19,7 +19,7 @@ testWithServer('Request for Object Page with image', (t, ctx) => {
   });
 });
 
-testWithServer('Search for Object Page with image', (t, ctx) => {
+testWithServer('Search for Object Page with image', {}, (t, ctx) => {
   t.plan(3);
 
   const htmlRequest = {
@@ -38,7 +38,7 @@ testWithServer('Search for Object Page with image', (t, ctx) => {
   });
 });
 
-testWithServer('Object Page with no image', (t, ctx) => {
+testWithServer('Object Page with no image', {}, (t, ctx) => {
   t.plan(2);
 
   const htmlRequest = {

--- a/test/login.test.js
+++ b/test/login.test.js
@@ -1,6 +1,6 @@
 const testWithServer = require('./helpers/test-with-server');
 
-testWithServer('Request for login Page', (t, ctx) => {
+testWithServer('Request for login Page', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -14,7 +14,7 @@ testWithServer('Request for login Page', (t, ctx) => {
   });
 }, true);
 
-testWithServer('Attempt to acces the home page without authorisation', (t, ctx) => {
+testWithServer('Attempt to acces the home page without authorisation', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -28,7 +28,7 @@ testWithServer('Attempt to acces the home page without authorisation', (t, ctx) 
   });
 }, true);
 
-testWithServer('Attempt to acces the home page without authorisation, redirect to login page if text/html origin request', (t, ctx) => {
+testWithServer('Attempt to acces the home page without authorisation, redirect to login page if text/html origin request', {}, (t, ctx) => {
   t.plan(2);
 
   const htmlRequest = {

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -1,6 +1,6 @@
 const testWithServer = require('./helpers/test-with-server');
 
-testWithServer('Request for Archive HTML Page', (t, ctx) => {
+testWithServer('Request for Archive HTML Page', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -15,7 +15,7 @@ testWithServer('Request for Archive HTML Page', (t, ctx) => {
   });
 });
 
-testWithServer('Request for Archive HTML Page for a wrong id', (t, ctx) => {
+testWithServer('Request for Archive HTML Page for a wrong id', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -30,22 +30,7 @@ testWithServer('Request for Archive HTML Page for a wrong id', (t, ctx) => {
   });
 });
 
-testWithServer('Request for Archive HTML Page but receive bad request from es', (t, ctx) => {
-  t.plan(1);
-
-  const htmlRequest = {
-    method: 'GET',
-    url: '/documents/smga-documents-badRequest',
-    headers: {'Accept': 'text/html'}
-  };
-
-  ctx.server.inject(htmlRequest, (res) => {
-    t.equal(res.statusCode, 503, 'Status code was as expected t0 503');
-    t.end();
-  });
-});
-
-testWithServer('Request for Archive HTML Page with expanded children', (t, ctx) => {
+testWithServer('Request for Archive HTML Page with expanded children', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -60,7 +45,7 @@ testWithServer('Request for Archive HTML Page with expanded children', (t, ctx) 
   });
 });
 
-testWithServer('Request for Object HTML Page', (t, ctx) => {
+testWithServer('Request for Object HTML Page', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -75,7 +60,7 @@ testWithServer('Request for Object HTML Page', (t, ctx) => {
   });
 });
 
-testWithServer('Request for Object HTML Page for a wrong id', (t, ctx) => {
+testWithServer('Request for Object HTML Page for a wrong id', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -90,22 +75,7 @@ testWithServer('Request for Object HTML Page for a wrong id', (t, ctx) => {
   });
 });
 
-testWithServer('Request for Object HTML Page but get error 503', (t, ctx) => {
-  t.plan(1);
-
-  const htmlRequest = {
-    method: 'GET',
-    url: '/objects/smgc-objects-badRequest',
-    headers: {'Accept': 'text/html'}
-  };
-
-  ctx.server.inject(htmlRequest, (res) => {
-    t.equal(res.statusCode, 503, 'Status code was as expected to 503');
-    t.end();
-  });
-});
-
-testWithServer('Request for Person HTML Page', (t, ctx) => {
+testWithServer('Request for Person HTML Page', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -119,7 +89,7 @@ testWithServer('Request for Person HTML Page', (t, ctx) => {
   });
 });
 
-testWithServer('Request for Person HTML Page who doesn\'t exists', (t, ctx) => {
+testWithServer('Request for Person HTML Page who doesn\'t exists', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -134,22 +104,7 @@ testWithServer('Request for Person HTML Page who doesn\'t exists', (t, ctx) => {
   });
 });
 
-testWithServer('Request for Person HTML Page but get error 503', (t, ctx) => {
-  t.plan(1);
-
-  const htmlRequest = {
-    method: 'GET',
-    url: '/people/smgc-people-badRequest',
-    headers: {'Accept': 'text/html'}
-  };
-
-  ctx.server.inject(htmlRequest, (res) => {
-    t.equal(res.statusCode, 503, 'Status code was as expected to 503');
-    t.end();
-  });
-});
-
-testWithServer('Request for Person HTML Page with no related items', (t, ctx) => {
+testWithServer('Request for Person HTML Page with no related items', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -164,7 +119,7 @@ testWithServer('Request for Person HTML Page with no related items', (t, ctx) =>
   });
 });
 
-testWithServer('Request for Person JSON Page with no related items', (t, ctx) => {
+testWithServer('Request for Person JSON Page with no related items', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -179,7 +134,7 @@ testWithServer('Request for Person JSON Page with no related items', (t, ctx) =>
   });
 });
 
-testWithServer('Request for Archive JSON', (t, ctx) => {
+testWithServer('Request for Archive JSON', {}, (t, ctx) => {
   t.plan(2);
 
   const htmlRequest = {
@@ -195,7 +150,7 @@ testWithServer('Request for Archive JSON', (t, ctx) => {
   });
 });
 
-testWithServer('Request for Archive JSON with error', (t, ctx) => {
+testWithServer('Request for Archive JSON with error', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -210,7 +165,7 @@ testWithServer('Request for Archive JSON with error', (t, ctx) => {
   });
 });
 
-testWithServer('Request for Object JSON Page', (t, ctx) => {
+testWithServer('Request for Object JSON Page', {}, (t, ctx) => {
   t.plan(2);
 
   const htmlRequest = {
@@ -226,8 +181,8 @@ testWithServer('Request for Object JSON Page', (t, ctx) => {
   });
 });
 
-testWithServer('Request for Object JSON Page for a wrong id', (t, ctx) => {
-  t.plan(4);
+testWithServer('Request for Object JSON Page for a wrong id', {}, (t, ctx) => {
+  t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
@@ -236,32 +191,12 @@ testWithServer('Request for Object JSON Page for a wrong id', (t, ctx) => {
   };
 
   ctx.server.inject(htmlRequest, (res) => {
-    var response = JSON.parse(res.payload);
-    t.equal(res.statusCode, 200, 'Status code was as expected');
-    t.ok(response.status, 404, 'status is 404');
-    t.ok(response.displayName, 'NotFound', 'the object is not found');
-    t.ok(response.message, 'Not Found', 'the object message is not found');
+    t.equal(res.statusCode, 404, 'Status code was as expected');
     t.end();
   });
 });
 
-testWithServer('Request for Object JSON Page, not found', (t, ctx) => {
-  t.plan(1);
-
-  const htmlRequest = {
-    method: 'GET',
-    url: '/objects/smgc-objects-noResult',
-    headers: {'Accept': 'application/vnd.api+json'}
-  };
-
-  ctx.server.inject(htmlRequest, (res) => {
-    var response = JSON.parse(res.payload);
-    t.equal(response.status, 404, 'Object not found');
-    t.end();
-  });
-});
-
-testWithServer('Request for Person JSON Page', (t, ctx) => {
+testWithServer('Request for Person JSON Page', {}, (t, ctx) => {
   t.plan(2);
 
   const htmlRequest = {
@@ -277,8 +212,8 @@ testWithServer('Request for Person JSON Page', (t, ctx) => {
   });
 });
 
-testWithServer('Request for Person JSON Page for a wrong id', (t, ctx) => {
-  t.plan(3);
+testWithServer('Request for Person JSON Page for a wrong id', {}, (t, ctx) => {
+  t.plan(1);
 
   const htmlRequest = {
     method: 'GET',
@@ -287,26 +222,7 @@ testWithServer('Request for Person JSON Page for a wrong id', (t, ctx) => {
   };
 
   ctx.server.inject(htmlRequest, (res) => {
-    var response = JSON.parse(res.payload);
-    t.ok(response.status, 404, 'status is 404');
-    t.ok(response.displayName, 'NotFound', 'the person is not found');
-    t.ok(response.message, 'Not Found', 'the person message is not found');
-    t.end();
-  });
-});
-
-testWithServer('Request for Person JSON Page, no result', (t, ctx) => {
-  t.plan(1);
-
-  const htmlRequest = {
-    method: 'GET',
-    url: '/people/smgc-people-noResult',
-    headers: {'Accept': 'application/vnd.api+json'}
-  };
-
-  ctx.server.inject(htmlRequest, (res) => {
-    var response = JSON.parse(res.payload);
-    t.equal(response.status, 404, 'Person not found');
+    t.ok(res.statusCode, 404, 'status is 404');
     t.end();
   });
 });

--- a/test/search-accession-numbers.test.js
+++ b/test/search-accession-numbers.test.js
@@ -3,7 +3,7 @@ const testWithServer = require('./helpers/test-with-server');
 const dir = __dirname.split('/')[__dirname.split('/').length - 1];
 const file = dir + __filename.replace(__dirname, '') + ' > ';
 
-testWithServer(file + 'Should accept params in filter[PARAM_NAME] format for documents type', (t, ctx) => {
+testWithServer(file + 'Should accept params in filter[PARAM_NAME] format for documents type', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {

--- a/test/search-documents-filters.test.js
+++ b/test/search-documents-filters.test.js
@@ -3,7 +3,7 @@ const testWithServer = require('./helpers/test-with-server');
 const dir = __dirname.split('/')[__dirname.split('/').length - 1];
 const file = dir + __filename.replace(__dirname, '') + ' > ';
 
-testWithServer(file + 'Should accept params in filter[PARAM_NAME] format for documents type', (t, ctx) => {
+testWithServer(file + 'Should accept params in filter[PARAM_NAME] format for documents type', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {

--- a/test/search-filters.test.js
+++ b/test/search-filters.test.js
@@ -907,39 +907,6 @@ testWithServer(file + 'Should not accept array of multiple image_licences as jso
   });
 });
 
-// testWithServer(file + 'Should return an error if the elasticsearch search function fail', {}, (t, ctx) => {
-//   t.plan(1);
-//
-//   const htmlRequest = {
-//     method: 'GET',
-//     // mock-database trigger an error if the query parameter is equal to "error"
-//     url: '/search?' + QueryString.stringify({ q: 'error' }),
-//     headers: { Accept: 'text/html' }
-//   };
-//
-//   ctx.server.inject(htmlRequest, (res) => {
-//     t.equal(res.statusCode, 400, 'Status code was as expected to 400');
-//     t.end();
-//   });
-// });
-
-// testWithServer(file + 'Should return an error if the elasticsearch search function fail on json request', {}, (t, ctx) => {
-//   t.plan(2);
-//
-//   const htmlRequest = {
-//     method: 'GET',
-//     url: '/search?' + QueryString.stringify({ q: 'error' }),
-//     headers: { Accept: 'application/vnd.api+json' }
-//   };
-//
-//   ctx.server.inject(htmlRequest, (res) => {
-//     const response = JSON.parse(res.payload);
-//     t.equal(res.statusCode, 400, 'Status code was as expected to 400');
-//     t.equal(response.errors[0].title, 'Bad Request', 'the title of the error is Bad Request');
-//     t.end();
-//   });
-// });
-
 // AND logic for the filters
 testWithServer(file + 'Number of filters for the occupation facet should be greater than 1', {}, (t, ctx) => {
   t.plan(1);
@@ -998,6 +965,23 @@ testWithServer(file + 'Should accept params and no query', {}, (t, ctx) => {
     url: '/search?' + QueryString.stringify({
       'filter[date[from]]': '2016',
       'filter[places]': ['London', 'Bath']
+    }),
+    headers: { Accept: 'text/html' }
+  };
+
+  ctx.server.inject(htmlRequest, (res) => {
+    t.equal(res.statusCode, 200, 'Status code was as expected');
+    t.end();
+  });
+});
+
+testWithServer(file + 'Should accept user params', {}, (t, ctx) => {
+  t.plan(1);
+
+  const htmlRequest = {
+    method: 'GET',
+    url: '/search?' + QueryString.stringify({
+      'user': 'Great Central Railway'
     }),
     headers: { Accept: 'text/html' }
   };

--- a/test/search-filters.test.js
+++ b/test/search-filters.test.js
@@ -3,7 +3,7 @@ const testWithServer = require('./helpers/test-with-server');
 const dir = __dirname.split('/')[__dirname.split('/').length - 1];
 const file = dir + __filename.replace(__dirname, '') + ' > ';
 
-testWithServer(file + 'Should accept params in filter[PARAM_NAME] format', (t, ctx) => {
+testWithServer(file + 'Should accept params in filter[PARAM_NAME] format', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -22,7 +22,7 @@ testWithServer(file + 'Should accept params in filter[PARAM_NAME] format', (t, c
   });
 });
 
-testWithServer(file + 'Should accept date[from] in format YYYY', (t, ctx) => {
+testWithServer(file + 'Should accept date[from] in format YYYY', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -37,7 +37,7 @@ testWithServer(file + 'Should accept date[from] in format YYYY', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept date[from] in format YYYY-MM', (t, ctx) => {
+testWithServer(file + 'Should accept date[from] in format YYYY-MM', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -52,7 +52,7 @@ testWithServer(file + 'Should accept date[from] in format YYYY-MM', (t, ctx) => 
   });
 });
 
-testWithServer(file + 'Should accept date[from] in format YYYY-MM-DD', (t, ctx) => {
+testWithServer(file + 'Should accept date[from] in format YYYY-MM-DD', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -67,7 +67,7 @@ testWithServer(file + 'Should accept date[from] in format YYYY-MM-DD', (t, ctx) 
   });
 });
 
-testWithServer(file + 'Should not accept invalid date[from]', (t, ctx) => {
+testWithServer(file + 'Should not accept invalid date[from]', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -82,7 +82,7 @@ testWithServer(file + 'Should not accept invalid date[from]', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept date[to] in format YYYY', (t, ctx) => {
+testWithServer(file + 'Should accept date[to] in format YYYY', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -97,7 +97,7 @@ testWithServer(file + 'Should accept date[to] in format YYYY', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept date[to] in format YYYY-MM', (t, ctx) => {
+testWithServer(file + 'Should accept date[to] in format YYYY-MM', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -112,7 +112,7 @@ testWithServer(file + 'Should accept date[to] in format YYYY-MM', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept date[to] in format YYYY-MM-DD', (t, ctx) => {
+testWithServer(file + 'Should accept date[to] in format YYYY-MM-DD', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -127,7 +127,7 @@ testWithServer(file + 'Should accept date[to] in format YYYY-MM-DD', (t, ctx) =>
   });
 });
 
-testWithServer(file + 'Should not accept invalid date[to]', (t, ctx) => {
+testWithServer(file + 'Should not accept invalid date[to]', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -142,7 +142,7 @@ testWithServer(file + 'Should not accept invalid date[to]', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept single places for html', (t, ctx) => {
+testWithServer(file + 'Should accept single places for html', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -157,7 +157,7 @@ testWithServer(file + 'Should accept single places for html', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept single places for json', (t, ctx) => {
+testWithServer(file + 'Should accept single places for json', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -172,7 +172,7 @@ testWithServer(file + 'Should accept single places for json', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept multiple places for html', (t, ctx) => {
+testWithServer(file + 'Should accept multiple places for html', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -187,7 +187,7 @@ testWithServer(file + 'Should accept multiple places for html', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should not accept multiple places as array for json', (t, ctx) => {
+testWithServer(file + 'Should not accept multiple places as array for json', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -202,7 +202,7 @@ testWithServer(file + 'Should not accept multiple places as array for json', (t,
   });
 });
 
-testWithServer(file + 'Should accept multiple places as csv for json', (t, ctx) => {
+testWithServer(file + 'Should accept multiple places as csv for json', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -217,7 +217,7 @@ testWithServer(file + 'Should accept multiple places as csv for json', (t, ctx) 
   });
 });
 
-testWithServer(file + 'Should accept single type', (t, ctx) => {
+testWithServer(file + 'Should accept single type', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -232,7 +232,7 @@ testWithServer(file + 'Should accept single type', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept single type as json', (t, ctx) => {
+testWithServer(file + 'Should accept single type as json', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -247,7 +247,7 @@ testWithServer(file + 'Should accept single type as json', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept multiple types', (t, ctx) => {
+testWithServer(file + 'Should accept multiple types', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -262,7 +262,7 @@ testWithServer(file + 'Should accept multiple types', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should not accept array of types as json', (t, ctx) => {
+testWithServer(file + 'Should not accept array of types as json', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -277,7 +277,7 @@ testWithServer(file + 'Should not accept array of types as json', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept single makers', (t, ctx) => {
+testWithServer(file + 'Should accept single makers', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -292,7 +292,7 @@ testWithServer(file + 'Should accept single makers', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept multiple makers', (t, ctx) => {
+testWithServer(file + 'Should accept multiple makers', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -307,7 +307,7 @@ testWithServer(file + 'Should accept multiple makers', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept single people', (t, ctx) => {
+testWithServer(file + 'Should accept single people', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -322,7 +322,7 @@ testWithServer(file + 'Should accept single people', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept multiple people', (t, ctx) => {
+testWithServer(file + 'Should accept multiple people', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -337,7 +337,7 @@ testWithServer(file + 'Should accept multiple people', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept single organisations', (t, ctx) => {
+testWithServer(file + 'Should accept single organisations', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -352,7 +352,7 @@ testWithServer(file + 'Should accept single organisations', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept multiple organisations', (t, ctx) => {
+testWithServer(file + 'Should accept multiple organisations', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -367,7 +367,7 @@ testWithServer(file + 'Should accept multiple organisations', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept single categories', (t, ctx) => {
+testWithServer(file + 'Should accept single categories', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -382,7 +382,7 @@ testWithServer(file + 'Should accept single categories', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept multiple categories', (t, ctx) => {
+testWithServer(file + 'Should accept multiple categories', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -397,7 +397,7 @@ testWithServer(file + 'Should accept multiple categories', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept valid museum NRM', (t, ctx) => {
+testWithServer(file + 'Should accept valid museum NRM', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -412,7 +412,7 @@ testWithServer(file + 'Should accept valid museum NRM', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept valid museum SMG', (t, ctx) => {
+testWithServer(file + 'Should accept valid museum SMG', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -427,7 +427,7 @@ testWithServer(file + 'Should accept valid museum SMG', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept valid museum NMeM', (t, ctx) => {
+testWithServer(file + 'Should accept valid museum NMeM', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -442,7 +442,7 @@ testWithServer(file + 'Should accept valid museum NMeM', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept valid museum MSI', (t, ctx) => {
+testWithServer(file + 'Should accept valid museum MSI', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -457,7 +457,7 @@ testWithServer(file + 'Should accept valid museum MSI', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should not accept invalid museum', (t, ctx) => {
+testWithServer(file + 'Should not accept invalid museum', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -472,7 +472,7 @@ testWithServer(file + 'Should not accept invalid museum', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept on_display true', (t, ctx) => {
+testWithServer(file + 'Should accept on_display true', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -487,7 +487,7 @@ testWithServer(file + 'Should accept on_display true', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept on_display false', (t, ctx) => {
+testWithServer(file + 'Should accept on_display false', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -502,7 +502,7 @@ testWithServer(file + 'Should accept on_display false', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should not accept invalid on_display', (t, ctx) => {
+testWithServer(file + 'Should not accept invalid on_display', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -517,7 +517,7 @@ testWithServer(file + 'Should not accept invalid on_display', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept single location', (t, ctx) => {
+testWithServer(file + 'Should accept single location', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -532,7 +532,7 @@ testWithServer(file + 'Should accept single location', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept multiple location', (t, ctx) => {
+testWithServer(file + 'Should accept multiple location', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -547,7 +547,7 @@ testWithServer(file + 'Should accept multiple location', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should not accept array of multiple locations for json', (t, ctx) => {
+testWithServer(file + 'Should not accept array of multiple locations for json', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -562,7 +562,7 @@ testWithServer(file + 'Should not accept array of multiple locations for json', 
   });
 });
 
-testWithServer(file + 'Should accept single birth[place]', (t, ctx) => {
+testWithServer(file + 'Should accept single birth[place]', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -577,7 +577,7 @@ testWithServer(file + 'Should accept single birth[place]', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept multiple birth[place]', (t, ctx) => {
+testWithServer(file + 'Should accept multiple birth[place]', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -592,7 +592,7 @@ testWithServer(file + 'Should accept multiple birth[place]', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should not accept multiple array of birth[place] as json', (t, ctx) => {
+testWithServer(file + 'Should not accept multiple array of birth[place] as json', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -607,7 +607,7 @@ testWithServer(file + 'Should not accept multiple array of birth[place] as json'
   });
 });
 
-testWithServer(file + 'Should accept birth[date] in format YYYY', (t, ctx) => {
+testWithServer(file + 'Should accept birth[date] in format YYYY', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -622,7 +622,7 @@ testWithServer(file + 'Should accept birth[date] in format YYYY', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept birth[date] in format YYYY-MM', (t, ctx) => {
+testWithServer(file + 'Should accept birth[date] in format YYYY-MM', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -637,7 +637,7 @@ testWithServer(file + 'Should accept birth[date] in format YYYY-MM', (t, ctx) =>
   });
 });
 
-testWithServer(file + 'Should accept birth[date] in format YYYY-MM-DD', (t, ctx) => {
+testWithServer(file + 'Should accept birth[date] in format YYYY-MM-DD', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -652,7 +652,7 @@ testWithServer(file + 'Should accept birth[date] in format YYYY-MM-DD', (t, ctx)
   });
 });
 
-testWithServer(file + 'Should not accept invalid birth[date]', (t, ctx) => {
+testWithServer(file + 'Should not accept invalid birth[date]', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -667,7 +667,7 @@ testWithServer(file + 'Should not accept invalid birth[date]', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept death[date] in format YYYY', (t, ctx) => {
+testWithServer(file + 'Should accept death[date] in format YYYY', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -682,7 +682,7 @@ testWithServer(file + 'Should accept death[date] in format YYYY', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept death[date] in format YYYY-MM', (t, ctx) => {
+testWithServer(file + 'Should accept death[date] in format YYYY-MM', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -697,7 +697,7 @@ testWithServer(file + 'Should accept death[date] in format YYYY-MM', (t, ctx) =>
   });
 });
 
-testWithServer(file + 'Should accept death[date] in format YYYY-MM-DD', (t, ctx) => {
+testWithServer(file + 'Should accept death[date] in format YYYY-MM-DD', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -712,7 +712,7 @@ testWithServer(file + 'Should accept death[date] in format YYYY-MM-DD', (t, ctx)
   });
 });
 
-testWithServer(file + 'Should not accept invalid death[date]', (t, ctx) => {
+testWithServer(file + 'Should not accept invalid death[date]', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -727,7 +727,7 @@ testWithServer(file + 'Should not accept invalid death[date]', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept single occupation', (t, ctx) => {
+testWithServer(file + 'Should accept single occupation', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -742,7 +742,7 @@ testWithServer(file + 'Should accept single occupation', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept multiple occupation', (t, ctx) => {
+testWithServer(file + 'Should accept multiple occupation', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -757,7 +757,7 @@ testWithServer(file + 'Should accept multiple occupation', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should not accept array of multiple occupations as json', (t, ctx) => {
+testWithServer(file + 'Should not accept array of multiple occupations as json', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -772,7 +772,7 @@ testWithServer(file + 'Should not accept array of multiple occupations as json',
   });
 });
 
-testWithServer(file + 'Should accept single archive', (t, ctx) => {
+testWithServer(file + 'Should accept single archive', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -787,7 +787,7 @@ testWithServer(file + 'Should accept single archive', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept multiple archive', (t, ctx) => {
+testWithServer(file + 'Should accept multiple archive', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -802,7 +802,7 @@ testWithServer(file + 'Should accept multiple archive', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should not accept array of multiple archives as json', (t, ctx) => {
+testWithServer(file + 'Should not accept array of multiple archives as json', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -817,7 +817,7 @@ testWithServer(file + 'Should not accept array of multiple archives as json', (t
   });
 });
 
-testWithServer(file + 'Should accept single formats', (t, ctx) => {
+testWithServer(file + 'Should accept single formats', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -832,7 +832,7 @@ testWithServer(file + 'Should accept single formats', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept multiple formats', (t, ctx) => {
+testWithServer(file + 'Should accept multiple formats', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -847,7 +847,7 @@ testWithServer(file + 'Should accept multiple formats', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept array of multiple formats as json', (t, ctx) => {
+testWithServer(file + 'Should accept array of multiple formats as json', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -862,7 +862,7 @@ testWithServer(file + 'Should accept array of multiple formats as json', (t, ctx
   });
 });
 
-testWithServer(file + 'Should accept single image_licences', (t, ctx) => {
+testWithServer(file + 'Should accept single image_licences', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -877,7 +877,7 @@ testWithServer(file + 'Should accept single image_licences', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept multiple image_licences', (t, ctx) => {
+testWithServer(file + 'Should accept multiple image_licences', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -892,7 +892,7 @@ testWithServer(file + 'Should accept multiple image_licences', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should not accept array of multiple image_licences as json', (t, ctx) => {
+testWithServer(file + 'Should not accept array of multiple image_licences as json', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -907,41 +907,41 @@ testWithServer(file + 'Should not accept array of multiple image_licences as jso
   });
 });
 
-testWithServer(file + 'Should return an error if the elasticsearch search function fail', (t, ctx) => {
-  t.plan(1);
+// testWithServer(file + 'Should return an error if the elasticsearch search function fail', {}, (t, ctx) => {
+//   t.plan(1);
+//
+//   const htmlRequest = {
+//     method: 'GET',
+//     // mock-database trigger an error if the query parameter is equal to "error"
+//     url: '/search?' + QueryString.stringify({ q: 'error' }),
+//     headers: { Accept: 'text/html' }
+//   };
+//
+//   ctx.server.inject(htmlRequest, (res) => {
+//     t.equal(res.statusCode, 400, 'Status code was as expected to 400');
+//     t.end();
+//   });
+// });
 
-  const htmlRequest = {
-    method: 'GET',
-    // mock-database trigger an error if the query parameter is equal to "error"
-    url: '/search?' + QueryString.stringify({ q: 'error' }),
-    headers: { Accept: 'text/html' }
-  };
-
-  ctx.server.inject(htmlRequest, (res) => {
-    t.equal(res.statusCode, 400, 'Status code was as expected to 400');
-    t.end();
-  });
-});
-
-testWithServer(file + 'Should return an error if the elasticsearch search function fail on json request', (t, ctx) => {
-  t.plan(2);
-
-  const htmlRequest = {
-    method: 'GET',
-    url: '/search?' + QueryString.stringify({ q: 'error' }),
-    headers: { Accept: 'application/vnd.api+json' }
-  };
-
-  ctx.server.inject(htmlRequest, (res) => {
-    const response = JSON.parse(res.payload);
-    t.equal(res.statusCode, 400, 'Status code was as expected to 400');
-    t.equal(response.errors[0].title, 'Bad Request', 'the title of the error is Bad Request');
-    t.end();
-  });
-});
+// testWithServer(file + 'Should return an error if the elasticsearch search function fail on json request', {}, (t, ctx) => {
+//   t.plan(2);
+//
+//   const htmlRequest = {
+//     method: 'GET',
+//     url: '/search?' + QueryString.stringify({ q: 'error' }),
+//     headers: { Accept: 'application/vnd.api+json' }
+//   };
+//
+//   ctx.server.inject(htmlRequest, (res) => {
+//     const response = JSON.parse(res.payload);
+//     t.equal(res.statusCode, 400, 'Status code was as expected to 400');
+//     t.equal(response.errors[0].title, 'Bad Request', 'the title of the error is Bad Request');
+//     t.end();
+//   });
+// });
 
 // AND logic for the filters
-testWithServer(file + 'Number of filters for the occupation facet should be greater than 1', (t, ctx) => {
+testWithServer(file + 'Number of filters for the occupation facet should be greater than 1', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -958,7 +958,7 @@ testWithServer(file + 'Number of filters for the occupation facet should be grea
   });
 });
 
-testWithServer(file + 'Number of filters for the occupation facet should be greater than 1', (t, ctx) => {
+testWithServer(file + 'Number of filters for the occupation facet should be greater than 1', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -975,7 +975,7 @@ testWithServer(file + 'Number of filters for the occupation facet should be grea
   });
 });
 
-testWithServer(file + 'Should accept no query', (t, ctx) => {
+testWithServer(file + 'Should accept no query', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -990,7 +990,7 @@ testWithServer(file + 'Should accept no query', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept params and no query', (t, ctx) => {
+testWithServer(file + 'Should accept params and no query', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {

--- a/test/search-objects-filters.test.js
+++ b/test/search-objects-filters.test.js
@@ -3,7 +3,7 @@ const testWithServer = require('./helpers/test-with-server');
 const dir = __dirname.split('/')[__dirname.split('/').length - 1];
 const file = dir + __filename.replace(__dirname, '') + ' > ';
 
-testWithServer(file + 'Should accept params in filter[PARAM_NAME] format for objects type', (t, ctx) => {
+testWithServer(file + 'Should accept params in filter[PARAM_NAME] format for objects type', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -27,7 +27,7 @@ testWithServer(file + 'Should accept params in filter[PARAM_NAME] format for obj
   });
 });
 
-testWithServer(file + 'Should accept params in filter[PARAM_NAME] format for objects type', (t, ctx) => {
+testWithServer(file + 'Should accept params in filter[PARAM_NAME] format for objects type', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {

--- a/test/search-params.test.js
+++ b/test/search-params.test.js
@@ -3,7 +3,7 @@ const testWithServer = require('./helpers/test-with-server');
 const dir = __dirname.split('/')[__dirname.split('/').length - 1];
 const file = dir + __filename.replace(__dirname, '') + ' > ';
 
-testWithServer(file + 'Should accept the param people', (t, ctx) => {
+testWithServer(file + 'Should accept the param people', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -20,7 +20,7 @@ testWithServer(file + 'Should accept the param people', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept the param objects', (t, ctx) => {
+testWithServer(file + 'Should accept the param objects', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {
@@ -37,7 +37,7 @@ testWithServer(file + 'Should accept the param objects', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Should accept the param documents', (t, ctx) => {
+testWithServer(file + 'Should accept the param documents', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {

--- a/test/search-params.test.js
+++ b/test/search-params.test.js
@@ -26,7 +26,7 @@ testWithServer(file + 'Should accept the param objects', {}, (t, ctx) => {
   const htmlRequest = {
     method: 'GET',
     url: '/search/objects?' + QueryString.stringify({
-      q: 'test objects'
+      q: 'test'
     }),
     headers: { Accept: 'text/html' }
   };

--- a/test/search-people-filters.test.js
+++ b/test/search-people-filters.test.js
@@ -3,7 +3,7 @@ const testWithServer = require('./helpers/test-with-server');
 const dir = __dirname.split('/')[__dirname.split('/').length - 1];
 const file = dir + __filename.replace(__dirname, '') + ' > ';
 
-testWithServer(file + 'Should accept params in filter[PARAM_NAME] format for people type', (t, ctx) => {
+testWithServer(file + 'Should accept params in filter[PARAM_NAME] format for people type', {}, (t, ctx) => {
   t.plan(1);
 
   const htmlRequest = {

--- a/test/session-auth.test.js
+++ b/test/session-auth.test.js
@@ -1,7 +1,7 @@
 const testWithServer = require('./helpers/test-with-server');
 const config = require('../config');
 
-testWithServer('Authentication is ok', (t, ctx) => {
+testWithServer('Authentication is ok', {}, (t, ctx) => {
   t.plan(2);
   // mock config user
   const user = config.user;
@@ -24,7 +24,7 @@ testWithServer('Authentication is ok', (t, ctx) => {
   });
 }, true);
 
-testWithServer('Authentication is not ok', (t, ctx) => {
+testWithServer('Authentication is not ok', {}, (t, ctx) => {
   t.plan(1);
   // mock config user
   const user = config.user;

--- a/test/static-file.test.js
+++ b/test/static-file.test.js
@@ -5,7 +5,7 @@ const cssFile = fs.readFileSync('public/bundle.css');
 const dir = __dirname.split('/')[__dirname.split('/').length - 1];
 const file = dir + __filename.replace(__dirname, '') + ' > ';
 
-testWithServer(file + 'Javascript Files served correctly', (t, ctx) => {
+testWithServer(file + 'Javascript Files served correctly', {}, (t, ctx) => {
   t.plan(1);
 
   const jsRequest = {
@@ -19,7 +19,7 @@ testWithServer(file + 'Javascript Files served correctly', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'CSS Files served correctly', (t, ctx) => {
+testWithServer(file + 'CSS Files served correctly', {}, (t, ctx) => {
   t.plan(1);
 
   const cssRequest = {
@@ -33,7 +33,7 @@ testWithServer(file + 'CSS Files served correctly', (t, ctx) => {
   });
 });
 
-testWithServer(file + 'Non Existent Files', (t, ctx) => {
+testWithServer(file + 'Non Existent Files', {}, (t, ctx) => {
   t.plan(1);
 
   const badRequest = {


### PR DESCRIPTION
ref #338 

Simplifies tests by cutting out poorly managed fixtures, and using real database for now.

Using Sinon to stub elasticsearch/some other functions to allow for easy testing of errors. We could also use this in the future to return simpler fixtures, which would allow for testing offline, but as we have to be online for the nightwatch tests, that's not a huge priority.

Now with 100% coverage.