### PR TITLE
lazy load images

### DIFF
--- a/client/lib/carousel.js
+++ b/client/lib/carousel.js
@@ -12,6 +12,7 @@ module.exports = (ctx) => {
       setGallerySize: false,
       pageDots: false,
       imagesLoaded: true,
+      lazyLoad: 1,
       arrowShape: {
         x0: 30,
         x1: 63.5, y1: 50,

--- a/client/styles/components/_carousel.scss
+++ b/client/styles/components/_carousel.scss
@@ -13,13 +13,21 @@
 .carousel__image {
   @include imgpanel-h;
 
-  &:not(.is-selected) {
-    filter: blur(2px);
-    opacity: 0.5;
-  }
+  height: 36rem;
+  opacity: 0;
 
   &.is-selected {
     outline: 1px white solid;
+  }
+
+  &.flickity-lazyloaded {
+    opacity: 1;
+    transition: opacity 1s;
+
+    &:not(.is-selected) {
+      filter: blur(2px);
+      opacity: 0.5;
+    }
   }
 }
 

--- a/templates/partials/records/carousel.html
+++ b/templates/partials/records/carousel.html
@@ -17,7 +17,7 @@
       {{/each}}
     {{else}}
       {{#each slides}}
-        <img src="/assets/img/example/babbage/{{ this }}" class="carousel__image" />
+        <img data-flickity-lazyload="/assets/img/example/babbage/{{ this }}" class="carousel__image" />
       {{/each}}
     {{/if}}
   </div>


### PR DESCRIPTION
Lazy loads images and transitions them from transparent to opaque, to avoid images later in the carousel from appearing before the first image, and briefly causing flashing/overlapping images