### PR TITLE
fixes bug where orgs were showing as object type in filters

### DIFF
--- a/lib/facets/aggs-all.js
+++ b/lib/facets/aggs-all.js
@@ -37,7 +37,7 @@ module.exports = function (queryParams) {
       type: {
         filter: {
           bool: {
-            must: filter(queryParams)
+            must: [{ term: {'type.base': 'object'} }].concat(filter(queryParams))
           }
         },
         aggs: {


### PR DESCRIPTION
ref #403

For the aggregations on the 'all' tab, we were just using the 'name' field, which on objects is the category, but on people/organisations is their name. We're now only using the name field if the item is actually an object.