### PR TITLE
allow empty search which return all the results

### DIFF
--- a/schemas/search.js
+++ b/schemas/search.js
@@ -1,7 +1,7 @@
 const Joi = require('joi');
 
 module.exports = {
-  q: Joi.string(),
+  q: Joi.string().allow(''),
   'page[number]': Joi.number().integer().min(0),
   'page[size]': Joi.number().integer().min(1),
   'page[type]': Joi.string().valid('search', 'results-list'),


### PR DESCRIPTION
see #399

[This code](https://github.com/TheScienceMuseum/collectionsonline/blob/f2fb6e8a3c05033e509d95424631da03894c306d/lib/search.js#L157-L159) will catch the empty query and return all the results.