### PR TITLE
deletes no longer used archive listener function

### DIFF
--- a/client/lib/archive-listeners.js
+++ b/client/lib/archive-listeners.js
@@ -1,67 +1,15 @@
-var QueryString = require('querystring');
-var getData = require('./get-data.js');
-var Templates = require('../templates');
-var JSONToHTML = require('../../lib/transforms/json-to-html-data');
 var page = require('page');
-var Snackbar = require('snackbarlightjs');
 
-module.exports = (ctx, listeners) => {
-  // Archive Browser Listener
-  var formsArvhive = document.querySelectorAll('.expand');
-  for (var i = 0; i < formsArvhive.length; i++) {
-    formsArvhive[i].addEventListener('submit', function (e) {
-      e.preventDefault();
-      var archiveTree = document.getElementById('archive-tree');
-      var documentID = this.id.slice(7);
-      var query = QueryString.parse(ctx.querystring.substr(1));
-      var url = ctx.pathname;
-
-      if (query.expanded) {
-        if (!Array.isArray(query.expanded)) {
-          query.expanded = [query.expanded];
-        }
-        var queryPos = query.expanded.indexOf(documentID);
-        if (queryPos > -1) {
-          query.expanded.splice(queryPos, 1);
-        } else {
-          query.expanded.push(documentID);
-        }
-      } else {
-        query.expanded = [];
-        query.expanded.push(documentID);
-      }
-
-      ctx.querystring = '?' + QueryString.stringify(query);
-
-      url += ctx.querystring;
-
-      ctx.path = url;
-
-      var opts = {
-        headers: { Accept: 'application/vnd.api+json' }
-      };
-
-      getData(url, opts, function (err, json) {
-        if (err) {
-          console.error(err);
-          Snackbar.create('Error getting data from the server');
-          return;
-        }
-        var data = JSONToHTML(json);
-        archiveTree.innerHTML = Templates['archiveTree'](data);
-        document.getElementsByTagName('title')[0].textContent = data.titlePage;
-        listeners(ctx);
-      });
-    });
-  }
-
+module.exports = () => {
   // 'Search this Archive' Listener
   var archiveSearch = document.querySelector('#archive-search');
-  archiveSearch.addEventListener('submit', function (e) {
-    e.preventDefault();
-    var q = encodeURIComponent(document.getElementById('archive-q').value);
-    var archive = encodeURIComponent(document.getElementById('archive-title').value);
-    var url = '/search/documents?q=' + q + '&archive=' + archive;
-    page.show(url);
-  });
+  if (archiveSearch) {
+    archiveSearch.addEventListener('submit', function (e) {
+      e.preventDefault();
+      var q = encodeURIComponent(document.getElementById('archive-q').value);
+      var archive = encodeURIComponent(document.getElementById('archive-title').value);
+      var url = '/search/documents?q=' + q + '&archive=' + archive;
+      page.show(url);
+    });
+  }
 };

--- a/client/routes/document.js
+++ b/client/routes/document.js
@@ -45,5 +45,5 @@ function render (ctx, next) {
 function listeners (ctx, next) {
   initComp(ctx);
   searchListener();
-  archiveListeners(ctx, listeners);
+  archiveListeners();
 }


### PR DESCRIPTION
resolves #427.

Error was appearing because it was trying to attach an event listener to a non existent element. This PR removes one of the listeners that we're not using any more, and checks if the element exists before trying to add the other.