### PR TITLE
Multiple filters

### DIFF
--- a/lib/facets/aggs-all.js
+++ b/lib/facets/aggs-all.js
@@ -1,3 +1,5 @@
+const filter = require('./create-filters');
+
 module.exports = function (queryParams) {
   const aggregationObjects = {
     filter: {
@@ -11,11 +13,7 @@ module.exports = function (queryParams) {
     },
     aggs: {
       category: {
-        filter: {
-          bool: {
-            must: filter(queryParams)
-          }
-        },
+        filter: filter(queryParams),
         aggs: {
           category_filters: {
             terms: { field: 'categories.name' }
@@ -23,11 +21,7 @@ module.exports = function (queryParams) {
         }
       },
       maker: {
-        filter: {
-          bool: {
-            must: filter(queryParams)
-          }
-        },
+        filter: filter(queryParams),
         aggs: {
           maker_filters: {
             terms: { field: 'lifecycle.creation.maker.name.value' }
@@ -35,11 +29,7 @@ module.exports = function (queryParams) {
         }
       },
       type: {
-        filter: {
-          bool: {
-            must: [{ term: {'type.base': 'object'} }].concat(filter(queryParams))
-          }
-        },
+        filter: filter(queryParams),
         aggs: {
           type_filters: {
             terms: { field: 'name.value' }
@@ -47,11 +37,7 @@ module.exports = function (queryParams) {
         }
       },
       place: {
-        filter: {
-          bool: {
-            must: filter(queryParams)
-          }
-        },
+        filter: filter(queryParams),
         aggs: {
           place_filters: {
             terms: { field: 'lifecycle.creation.places.name.value' }
@@ -59,11 +45,7 @@ module.exports = function (queryParams) {
         }
       },
       user: {
-        filter: {
-          bool: {
-            must: filter(queryParams)
-          }
-        },
+        filter: filter(queryParams),
         aggs: {
           user_filters: {
             terms: { field: 'agents.summary_title' }
@@ -71,11 +53,7 @@ module.exports = function (queryParams) {
         }
       },
       archive: {
-        filter: {
-          bool: {
-            must: filter(queryParams)
-          }
-        },
+        filter: filter(queryParams),
         aggs: {
           archive_filters: {
             terms: { field: 'fonds.summary_title' }
@@ -83,11 +61,7 @@ module.exports = function (queryParams) {
         }
       },
       occupation: {
-        filter: {
-          bool: {
-            must: filter(queryParams)
-          }
-        },
+        filter: filter(queryParams),
         aggs: {
           occupation_filters: {
             terms: {field: 'occupation'}
@@ -95,11 +69,7 @@ module.exports = function (queryParams) {
         }
       },
       place_born: {
-        filter: {
-          bool: {
-            must: filter(queryParams)
-          }
-        },
+        filter: filter(queryParams),
         aggs: {
           place_born_filters: {
             terms: {field: 'lifecycle.birth.location.name.value'}
@@ -107,11 +77,7 @@ module.exports = function (queryParams) {
         }
       },
       organisation: {
-        filter: {
-          bool: {
-            must: filter(queryParams)
-          }
-        },
+        filter: filter(queryParams),
         aggs: {
           organisations_filters: {
             terms: {field: 'type.sub_type'}
@@ -119,11 +85,7 @@ module.exports = function (queryParams) {
         }
       },
       count: {
-        filter: {
-          bool: {
-            must: filter(queryParams)
-          }
-        },
+        filter: filter(queryParams),
         aggs: {
           count_filters: {
             value_count: {field: 'admin.id'}
@@ -131,11 +93,7 @@ module.exports = function (queryParams) {
         }
       },
       material: {
-        filter: {
-          bool: {
-            must: filter(queryParams)
-          }
-        },
+        filter: filter(queryParams),
         aggs: {
           material_filters: {
             terms: { field: 'materials' }
@@ -147,101 +105,3 @@ module.exports = function (queryParams) {
 
   return aggregationObjects;
 };
-
-function filter (queryParams) {
-  var filters = [];
-  // category
-  const categories = queryParams.filter.objects.categories;
-  if (categories) {
-    filters.push({ terms: { 'categories.name': categories } });
-  }
-
-  // archive
-  const archive = queryParams.filter.documents.archive;
-  if (archive) {
-    filters.push({ terms: {'fonds.summary_title': archive} });
-  }
-
-  // maker
-  const makers = queryParams.filter.objects.makers;
-  if (makers) {
-    filters.push({ terms: { 'lifecycle.creation.maker.name.value': makers } });
-  }
-
-  // type
-  const type = queryParams.filter.objects.type;
-  if (type) {
-    filters.push({ terms: { 'name.value': type } });
-  }
-
-  // places
-  const places = queryParams.filter.all.places;
-  if (places) {
-    filters.push({ terms: { 'lifecycle.creation.places.name.value': places } });
-  }
-
-  // user
-  const user = queryParams.filter.objects.user;
-  if (user) {
-    filters.push({ terms: { 'agents.summary_title': user } });
-  }
-
-  // occupation
-  const occupation = queryParams.filter.people.occupation;
-  if (occupation) {
-    filters.push({ terms: { 'occupation': occupation } });
-  }
-
-  // birth place
-  const birthPlace = queryParams.filter.people.birthPlace;
-  if (birthPlace) {
-    filters.push({ terms: { 'lifecycle.birth.location.name.value': birthPlace } });
-  }
-
-  // organisation
-  const organisations = queryParams.filter.people.organisations;
-  if (organisations) {
-    filters.push({ terms: {'type.sub_type': organisations} });
-  }
-
-  // Date
-  const filterDate = {bool: {should: []}};
-
-  const dateFrom = queryParams.filter.objects.dateFrom;
-  const birthDate = queryParams.filter.people.birthDate;
-  if (Object.prototype.toString.call(dateFrom) === '[object Date]') {
-    if (!isNaN(dateFrom.getTime())) {
-      filterDate.bool.should.push({ range: { 'lifecycle.creation.date.latest': { 'gte': dateFrom.getFullYear() } } });
-    }
-  } else if (Object.prototype.toString.call(birthDate) === '[object Date]') {
-    if (!isNaN(birthDate.getTime())) {
-      filterDate.bool.should.push({ range: { 'lifecycle.birth.date.earliest': { 'gte': birthDate.getFullYear() } } });
-    }
-  }
-
-  const dateTo = queryParams.filter.objects.dateTo;
-  const deathDate = queryParams.filter.people.deathDate;
-  if (Object.prototype.toString.call(dateTo) === '[object Date]') {
-    if (!isNaN(dateTo.getTime())) {
-      filterDate.bool.should.push({ range: { 'lifecycle.creation.date.latest': { 'lte': dateTo.getFullYear() } } });
-    }
-  } else if (Object.prototype.toString.call(deathDate) === '[object Date]') {
-    if (!isNaN(deathDate.getTime())) {
-      filterDate.bool.should.push({ range: { 'lifecycle.death.date.latest': { 'lte': deathDate.getFullYear() } } });
-    }
-  }
-
-  if (filterDate.bool.should.length > 0) {
-    filters.push(filterDate);
-  }
-
-  // materials
-  const material = queryParams.filter.objects.material;
-  if (material) {
-    material.forEach(e => {
-      filters.push({ terms: { 'materials': [e] } });
-    });
-  }
-
-  return filters;
-}

--- a/lib/facets/create-filters.js
+++ b/lib/facets/create-filters.js
@@ -1,88 +1,110 @@
 module.exports = function (queryParams, filterType) {
   var filters = [];
   // type
-  filters.push({ term: {'type.base': filterType} });
+  if (filterType) {
+    filters.push({ term: {'type.base': filterType} });
+  }
 
   // category
   const categories = queryParams.filter.objects.categories;
   if (categories) {
-    filters.push({ terms: { 'categories.name': categories } });
-  }
-  // Date
-  const filterDate = {bool: {should: []}};
-
-  const dateFrom = queryParams.filter.objects.dateFrom;
-  const birthDate = queryParams.filter.people.birthDate;
-  if (filterType !== 'agent' && Object.prototype.toString.call(dateFrom) === '[object Date]') {
-    if (!isNaN(dateFrom.getTime())) {
-      filterDate.bool.should.push({ range: { 'lifecycle.creation.date.latest': { 'gte': dateFrom.getFullYear() } } });
-    }
-  } else if (filterType === 'agent' && Object.prototype.toString.call(birthDate) === '[object Date]') {
-    if (!isNaN(birthDate.getTime())) {
-      filterDate.bool.should.push({ range: { 'lifecycle.birth.date.earliest': { 'gte': birthDate.getFullYear() } } });
-    }
-  }
-
-  const dateTo = queryParams.filter.objects.dateTo;
-  const deathDate = queryParams.filter.people.deathDate;
-  if (filterType !== 'agent' && Object.prototype.toString.call(dateTo) === '[object Date]') {
-    if (!isNaN(dateTo.getTime())) {
-      filterDate.bool.should.push({ range: { 'lifecycle.creation.date.latest': { 'lte': dateTo.getFullYear() } } });
-    }
-  } else if (filterType === 'agent' && Object.prototype.toString.call(deathDate) === '[object Date]') {
-    if (!isNaN(deathDate.getTime())) {
-      filterDate.bool.should.push({ range: { 'lifecycle.death.date.latest': { 'lte': deathDate.getFullYear() } } });
-    }
-  }
-
-  if (filterDate.bool.should.length > 0) {
-    filters.push(filterDate);
-  }
-
-  // maker
-  const makers = queryParams.filter.objects.makers;
-  if (makers) {
-    filters.push({ terms: { 'lifecycle.creation.maker.name.value': makers } });
-  }
-
-  // type
-  const type = queryParams.filter.objects.type;
-  if (type) {
-    filters.push({ terms: { 'name.value': type } });
-  }
-
-  // places
-  const places = queryParams.filter.all.places;
-  if (places) {
-    filters.push({ terms: { 'lifecycle.creation.places.name.value': places } });
-  }
-
-  // user
-  const user = queryParams.filter.objects.user;
-  if (user) {
-    filters.push({ terms: { 'agents.summary_title': user } });
-  }
-
-  // occupation
-  const occupation = queryParams.filter.people.occupation;
-  if (occupation) {
-    filters.push({ terms: { 'occupation': occupation } });
-  }
-  // birth place
-  const birthPlace = queryParams.filter.people.birthPlace;
-  if (birthPlace) {
-    filters.push({ terms: { 'lifecycle.birth.location.name.value': birthPlace } });
-  }
-  // organisation
-  const organisations = queryParams.filter.people.organisations;
-  if (organisations) {
-    filters.push({ terms: {'type.sub_type': organisations} });
+    categories.forEach(e => {
+      filters.push({ terms: { 'categories.name': [e] } });
+    });
   }
 
   // archive
   const archive = queryParams.filter.documents.archive;
   if (archive) {
-    filters.push({ terms: {'fonds.summary_title': archive} });
+    archive.forEach(e => {
+      filters.push({ terms: {'fonds.summary_title': [e]} });
+    });
+  }
+
+  // maker
+  const makers = queryParams.filter.objects.makers;
+  if (makers) {
+    makers.forEach(e => {
+      filters.push({ terms: { 'lifecycle.creation.maker.name.value': [e] } });
+    });
+  }
+
+  // type
+  const type = queryParams.filter.objects.type;
+  if (type) {
+    filters.push({ term: {'type.base': 'object'} });
+    type.forEach(e => {
+      filters.push({ terms: { 'name.value': [e] } });
+    });
+  }
+
+  // places
+  const places = queryParams.filter.all.places;
+  if (places) {
+    places.forEach(e => {
+      filters.push({ terms: { 'lifecycle.creation.places.name.value': [e] } });
+    });
+  }
+
+  // user
+  const user = queryParams.filter.objects.user;
+  if (user) {
+    user.forEach(e => {
+      filters.push({ terms: { 'agents.summary_title': [e] } });
+    });
+  }
+
+  // occupation
+  const occupation = queryParams.filter.people.occupation;
+  if (occupation) {
+    occupation.forEach(e => {
+      filters.push({ terms: { 'occupation': [e] } });
+    });
+  }
+
+  // birth place
+  const birthPlace = queryParams.filter.people.birthPlace;
+  if (birthPlace) {
+    birthPlace.forEach(e => {
+      filters.push({ terms: { 'lifecycle.birth.location.name.value': [e] } });
+    });
+  }
+
+  // organisation
+  const organisations = queryParams.filter.people.organisations;
+  if (organisations) {
+    organisations.forEach(e => {
+      filters.push({ terms: {'type.sub_type': [e]} });
+    });
+  }
+
+  // Date
+  const filterDate = {bool: {should: []}};
+
+  const dateFrom = queryParams.filter.objects.dateFrom;
+  const birthDate = queryParams.filter.people.birthDate;
+
+  if (dateFrom && filterType !== 'agent' && !(isNaN(dateFrom))) {
+    filterDate.bool.should.push({ range: { 'lifecycle.creation.date.latest': { 'gte': dateFrom.getFullYear() } } });
+  } else if (dateFrom && filterType === 'agent' && !(isNaN(dateFrom))) {
+    filterDate.bool.should.push({ range: { 'lifecycle.birth.date.earliest': { 'gte': dateFrom.getFullYear() } } });
+  } else if (birthDate && !isNaN(birthDate)) {
+    filterDate.bool.should.push({ range: { 'lifecycle.birth.date.earliest': { 'gte': birthDate.getFullYear() } } });
+  }
+
+  const dateTo = queryParams.filter.objects.dateTo;
+  const deathDate = queryParams.filter.people.deathDate;
+
+  if (dateTo && filterType !== 'agent' && !(isNaN(dateTo))) {
+    filterDate.bool.should.push({ range: { 'lifecycle.creation.date.latest': { 'lte': dateTo.getFullYear() } } });
+  } else if (dateTo && filterType === 'agent' && !(isNaN(dateTo))) {
+    filterDate.bool.should.push({ range: { 'lifecycle.death.date.latest': { 'lte': dateTo.getFullYear() } } });
+  } else if (deathDate && !isNaN(deathDate)) {
+    filterDate.bool.should.push({ range: { 'lifecycle.death.date.latest': { 'lte': deathDate.getFullYear() } } });
+  }
+
+  if (filterDate.bool.should.length > 0) {
+    filters.push(filterDate);
   }
 
   // materials

--- a/test/client/multiple-filters.clienttest.js
+++ b/test/client/multiple-filters.clienttest.js
@@ -1,0 +1,33 @@
+module.exports = {
+  'Selecting multiple filters on search page': function (browser) {
+    browser
+      .url('http://localhost:8000/search?q=engine')
+      .waitForElementVisible('body', 1000)
+      .pause(1000)
+      .click('#fb')
+      .pause(1000)
+      .waitForElementVisible('.filter__box[value="Petrol engines"]', 3000)
+      .click('.filter__box[value="Petrol engines"]')
+      .pause(1000)
+      .assert.urlEquals('http://localhost:8000/search?q=engine&filter%5Btype%5D=Petrol%20engines&page%5Bsize%5D=50&page%5Btype%5D=search')
+      .assert.containsText('.searchtab:nth-of-type(1)', '58')
+      .assert.containsText('.searchtab:nth-of-type(2)', '0')
+      .assert.containsText('.searchtab:nth-of-type(3)', '58')
+      .assert.containsText('.searchtab:nth-of-type(4)', '0')
+      .click('.filter__box[value=Clutches]')
+      .pause(1000)
+      .assert.urlEquals('http://localhost:8000/search?q=engine&filter%5Btype%5D=Petrol%20engines&filter%5Btype%5D=Clutches&page%5Bsize%5D=50&page%5Btype%5D=search')
+      .assert.containsText('.searchtab:nth-of-type(1)', '7')
+      .assert.containsText('.searchtab:nth-of-type(2)', '0')
+      .assert.containsText('.searchtab:nth-of-type(3)', '7')
+      .assert.containsText('.searchtab:nth-of-type(4)', '0')
+      .click('.searchtab:nth-of-type(3)')
+      .pause(1000)
+      .assert.urlEquals('http://localhost:8000/search/objects?q=engine&filter%5Btype%5D=Petrol%20engines&filter%5Btype%5D=Clutches&page%5Bsize%5D=50&page%5Btype%5D=search')
+      .assert.containsText('.searchtab:nth-of-type(1)', '7')
+      .assert.containsText('.searchtab:nth-of-type(2)', '0')
+      .assert.containsText('.searchtab:nth-of-type(3)', '7')
+      .assert.containsText('.searchtab:nth-of-type(4)', '0')
+      .end();
+  }
+};


### PR DESCRIPTION
### To be merged after #412

ref #420 
Allows multiple filters of the same facet to be selected when objects have more than one, by using an array for the filter instead of a single value.

I've also factored out the filter creation function from `aggs-all`, as it was almost identical to the filter creation function in `create-filters`