### PR TITLE
replaces osd to make zoom work

### DIFF
--- a/client/lib/openseadragon.js
+++ b/client/lib/openseadragon.js
@@ -27,8 +27,9 @@ module.exports = {
           e.eventSource.gestureSettingsMouse.scrollToZoom = true;
         } else {
           e.eventSource.gestureSettingsMouse.scrollToZoom = false;
+          this.quit(ctx);
         }
-      });
+      }.bind(this));
 
       ctx.save();
     }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "joi": "^9.0.0",
     "jsonwebtoken": "^7.1.7",
     "lodash.debounce": "^4.0.8",
-    "openseadragon": "^2.2.0",
+    "openseadragon": "https://github.com/TheScienceMuseum/openseadragon/tarball/smg",
     "page": "^1.7.1",
     "rc": "^1.1.6",
     "snackbarlightjs": "^1.1.2",


### PR DESCRIPTION
ref #372 
Replaces openseadragon with a fork that solves the deepzoom issue.