### PR TITLE
fixes org-name as type bug again

### DIFF
--- a/lib/facets/aggs-all.js
+++ b/lib/facets/aggs-all.js
@@ -29,7 +29,11 @@ module.exports = function (queryParams) {
         }
       },
       type: {
-        filter: filter(queryParams),
+        filter: {
+          bool: {
+            must: filter(queryParams).bool.must.concat({ term: {'type.base': 'object'} })
+          }
+        },
         aggs: {
           type_filters: {
             terms: { field: 'name.value' }

--- a/lib/facets/create-filters.js
+++ b/lib/facets/create-filters.js
@@ -32,7 +32,6 @@ module.exports = function (queryParams, filterType) {
   // type
   const type = queryParams.filter.objects.type;
   if (type) {
-    filters.push({ term: {'type.base': 'object'} });
     type.forEach(e => {
       filters.push({ terms: { 'name.value': [e] } });
     });

--- a/test/search-filters.test.js
+++ b/test/search-filters.test.js
@@ -991,3 +991,20 @@ testWithServer(file + 'Should accept user params', {}, (t, ctx) => {
     t.end();
   });
 });
+
+testWithServer(file + 'Should not return people or organisations as object type', {}, (t, ctx) => {
+  t.plan(1);
+
+  const htmlRequest = {
+    method: 'GET',
+    url: '/search?' + QueryString.stringify({
+      'q': 'Asbestos'
+    }),
+    headers: { Accept: 'application/vnd.api+json' }
+  };
+
+  ctx.server.inject(htmlRequest, (res) => {
+    t.notOk(JSON.parse(res.payload).meta.filters.type.find(el => el.value === 'Turner Bros Asbestos Co'), 'Org does not appear in object type filter');
+    t.end();
+  });
+});


### PR DESCRIPTION
#403 was reintroduced in the refactoring of the filters.

This pr fixes it and adds a regression test to make sure it doesn't happen again