### PR TITLE
removes old archive schema

### DIFF
--- a/schemas/archive.js
+++ b/schemas/archive.js
@@ -1,5 +1,0 @@
-const Joi = require('joi');
-
-module.exports = {
-  'expanded': Joi.array().items(Joi.string().regex(/\bsmg[ac]-documents-\d+\b/)).single()
-};


### PR DESCRIPTION
because of #513, archives were not loading from the search page. They were using a schema with the format of the old ids. This schema was for a query that we're no longer using, so I've just deleted it.