### PR TITLE
updates get image functions for new index structure

### DIFF
--- a/lib/transforms/json-to-html-data.js
+++ b/lib/transforms/json-to-html-data.js
@@ -403,9 +403,9 @@ function getImages (data) {
     images = data.attributes.multimedia.map(e => {
       if (e.processed) {
         return {
-          large: e.processed.large.location,
-          thumb: e.processed.thumbnail.location,
-          zoom: e.processed.zoom.location,
+          large: getNestedProperty(e, 'processed.large.location'),
+          thumb: getNestedProperty(e, 'processed.large_thumbnail.location'),
+          zoom: getNestedProperty(e, 'processed.zoom.location'),
           author: e.author,
           credit: e.credit,
           rights: formatLicense(e.source.legal.rights[0]),

--- a/lib/transforms/search-results-to-jsonapi.js
+++ b/lib/transforms/search-results-to-jsonapi.js
@@ -81,8 +81,8 @@ const createResource = {
           delete attrs[key].credit_line;
         }
         // Adds image host to path
-        if (key === 'multimedia' && getNestedProperty(hit, '_source.multimedia.0.processed.mid.location')) {
-          attrs[key][0].processed.mid.location = mediaPath + hit._source[key][0].processed.mid.location;
+        if (key === 'multimedia' && getNestedProperty(hit, '_source.multimedia.0.processed.medium.location')) {
+          attrs[key][0].processed.medium.location = mediaPath + hit._source[key][0].processed.medium.location;
         }
       }
       return attrs;
@@ -172,8 +172,8 @@ const createResource = {
         attrs[key] = hit._source[key];
 
         // Adds image host to path
-        if (key === 'multimedia' && getNestedProperty(hit, '_source.multimedia.0.processed.mid.location')) {
-          attrs[key][0].processed.mid.location = mediaPath + hit._source[key][0].processed.mid.location;
+        if (key === 'multimedia' && getNestedProperty(hit, '_source.multimedia.0.processed.medium.location')) {
+          attrs[key][0].processed.medium.location = mediaPath + hit._source[key][0].processed.medium.location;
         }
       }
       return attrs;

--- a/lib/transforms/search-results-to-template-data.js
+++ b/lib/transforms/search-results-to-template-data.js
@@ -97,7 +97,7 @@ function getOccupation (item) {
 }
 
 function getFigure (item, config) {
-  var location = getNestedProperty(item, 'attributes.multimedia.0.processed.mid.location');
+  var location = getNestedProperty(item, 'attributes.multimedia.0.processed.medium.location');
   return location || null;
 }
 

--- a/test/images.test.js
+++ b/test/images.test.js
@@ -1,42 +1,42 @@
 const testWithServer = require('./helpers/test-with-server');
 
-// testWithServer('Request for Object Page with image', {}, (t, ctx) => {
-//   t.plan(3);
-//
-//   const htmlRequest = {
-//     method: 'GET',
-//     url: '/objects/smgc-objects-26704',
-//     headers: {'Accept': 'application/vnd.api+json'}
-//   };
-//
-//   ctx.server.inject(htmlRequest, (res) => {
-//     var response = JSON.parse(res.payload);
-//
-//     t.equal(res.statusCode, 200, 'Found Object');
-//     t.ok(response.data.attributes.multimedia, 'Object has images');
-//     t.ok(response.data.attributes.multimedia[0].processed.large.location, 'Has path');
-//     t.end();
-//   });
-// });
+testWithServer('Request for Object Page with image', {}, (t, ctx) => {
+  t.plan(3);
 
-// testWithServer('Search for Object Page with image', {}, (t, ctx) => {
-//   t.plan(3);
-//
-//   const htmlRequest = {
-//     method: 'GET',
-//     url: '/search/objects?q=rocket',
-//     headers: {'Accept': 'application/vnd.api+json'}
-//   };
-//
-//   ctx.server.inject(htmlRequest, (res) => {
-//     var response = JSON.parse(res.payload);
-//
-//     t.equal(res.statusCode, 200, 'Succesful request');
-//     t.ok(response.data[0], 'Got results');
-//     t.ok(response.data[0].attributes.multimedia, 'First result has image');
-//     t.end();
-//   });
-// });
+  const htmlRequest = {
+    method: 'GET',
+    url: '/objects/co26704',
+    headers: {'Accept': 'application/vnd.api+json'}
+  };
+
+  ctx.server.inject(htmlRequest, (res) => {
+    var response = JSON.parse(res.payload);
+
+    t.equal(res.statusCode, 200, 'Found Object');
+    t.ok(response.data.attributes.multimedia, 'Object has images');
+    t.ok(response.data.attributes.multimedia[0].processed.large.location, 'Has path');
+    t.end();
+  });
+});
+
+testWithServer('Search for Object Page with image', {}, (t, ctx) => {
+  t.plan(3);
+
+  const htmlRequest = {
+    method: 'GET',
+    url: '/search/objects?q=rocket%20locomotive',
+    headers: {'Accept': 'application/vnd.api+json'}
+  };
+
+  ctx.server.inject(htmlRequest, (res) => {
+    var response = JSON.parse(res.payload);
+
+    t.equal(res.statusCode, 200, 'Succesful request');
+    t.ok(response.data[0], 'Got results');
+    t.ok(response.data[0].attributes.multimedia, 'First result has image');
+    t.end();
+  });
+});
 
 testWithServer('Object Page with no image', {}, (t, ctx) => {
   t.plan(2);


### PR DESCRIPTION
Small updates to bring the code into line with the new index fields for the images and make the one image we currently have display correctly.

We've uncommented one test now, which brings the coverage up. Still won't quite be up to 100 until we have a few more images with the different values we can test (#491)

(diff coverage is only at 80% because I updated the code for the document images too, which still don't exist)