### PR TITLE
relevance tweaks

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -26,7 +26,7 @@ module.exports = (elastic, queryParams, next) => {
             should: [{
               multi_match: {
                 query: queryParams.q,
-                type: 'cross_fields',
+                type: 'best_fields',
                 fields: [
                   'name.value_text',
                   'name.value_lower',
@@ -80,7 +80,7 @@ module.exports = (elastic, queryParams, next) => {
           filter: {
             exists: {field: 'locations'}
           },
-          weight: 1.2
+          weight: 10
         }, {
           filter: {
             exists: {field: 'options.option1'}
@@ -110,7 +110,7 @@ module.exports = (elastic, queryParams, next) => {
           filter: {
             exists: {field: 'multimedia.processed'}
           },
-          weight: 1.4
+          weight: 5
         }, {
           filter: {
             term: {'categories.value': 'SCM - Art'}

--- a/test/check-purchased.test.js
+++ b/test/check-purchased.test.js
@@ -22,7 +22,7 @@ testWithServer('Search request for Object with "Purchased" in credit line', {}, 
 
   const htmlRequest = {
     method: 'GET',
-    url: '/search/objects?q=hawking%20painting',
+    url: '/search/objects?q=stephen%20hawking%20painting',
     headers: {'Accept': 'application/vnd.api+json'}
   };
 


### PR DESCRIPTION
Prioritises location, then image for results: #578
Uses best fields rather than cross fields, provides better results for terms with apostrophes: #583 