### PR TITLE
single image display

### DIFF
--- a/client/styles/components/_carousel.scss
+++ b/client/styles/components/_carousel.scss
@@ -31,6 +31,15 @@
   }
 }
 
+.single_image_container {
+  text-align: center;
+
+  .single_image {
+    height: 36rem;
+  }
+}
+
+
 
 .flickity-prev-next-button {
   width: 6rem;

--- a/lib/transforms/json-to-html-data.js
+++ b/lib/transforms/json-to-html-data.js
@@ -403,8 +403,8 @@ function getImages (data) {
     images = data.attributes.multimedia.map(e => {
       if (e.processed) {
         return {
-          large: getNestedProperty(e, 'processed.large.location'),
-          thumb: getNestedProperty(e, 'processed.large_thumbnail.location'),
+          large: getNestedProperty(e, 'processed.medium.location'),
+          thumb: getNestedProperty(e, 'processed.medium_thumbnail.location'),
           zoom: getNestedProperty(e, 'processed.zoom.location'),
           author: e.author,
           credit: e.credit,

--- a/lib/transforms/search-results-to-jsonapi.js
+++ b/lib/transforms/search-results-to-jsonapi.js
@@ -81,8 +81,8 @@ const createResource = {
           delete attrs[key].credit_line;
         }
         // Adds image host to path
-        if (key === 'multimedia' && getNestedProperty(hit, '_source.multimedia.0.processed.medium.location')) {
-          attrs[key][0].processed.medium.location = mediaPath + hit._source[key][0].processed.medium.location;
+        if (key === 'multimedia' && getNestedProperty(hit, '_source.multimedia.0.processed.large_thumbnail.location')) {
+          attrs[key][0].processed.large_thumbnail.location = mediaPath + hit._source[key][0].processed.large_thumbnail.location;
         }
       }
       return attrs;
@@ -172,8 +172,8 @@ const createResource = {
         attrs[key] = hit._source[key];
 
         // Adds image host to path
-        if (key === 'multimedia' && getNestedProperty(hit, '_source.multimedia.0.processed.medium.location')) {
-          attrs[key][0].processed.medium.location = mediaPath + hit._source[key][0].processed.medium.location;
+        if (key === 'multimedia' && getNestedProperty(hit, '_source.multimedia.0.processed.large_thumbnail.location')) {
+          attrs[key][0].processed.large_thumbnail.location = mediaPath + hit._source[key][0].processed.large_thumbnail.location;
         }
       }
       return attrs;

--- a/lib/transforms/search-results-to-template-data.js
+++ b/lib/transforms/search-results-to-template-data.js
@@ -97,7 +97,8 @@ function getOccupation (item) {
 }
 
 function getFigure (item, config) {
-  var location = getNestedProperty(item, 'attributes.multimedia.0.processed.medium.location');
+  var location = getNestedProperty(item, 'attributes.multimedia.0.processed.large_thumbnail.location');
+  console.log(location);
   return location || null;
 }
 

--- a/routes/object.js
+++ b/routes/object.js
@@ -1,6 +1,4 @@
-const fs = require('fs');
 const Boom = require('boom');
-const exampleData = JSON.parse(fs.readFileSync('./src/data/object.json'));
 const buildJSONResponse = require('../lib/jsonapi-response');
 const TypeMapping = require('../lib/type-mapping');
 const JSONToHTML = require('../lib/transforms/json-to-html-data.js');
@@ -48,8 +46,7 @@ module.exports = (elastic, config) => ({
 
 function HTMLResponse (request, reply, elastic, config) {
   const data = {
-    page: 'object',
-    slides: exampleData.slides
+    page: 'object'
   };
 
   elastic.get({index: 'smg', type: 'object', id: TypeMapping.toInternal(request.params.id)}, (err, result) => {

--- a/templates/pages/object.html
+++ b/templates/pages/object.html
@@ -12,10 +12,6 @@
     {{else}}
       {{>records/single-image}}
     {{/ifmultiple}}
-  {{else}}
-    {{#ifmultiple slides}}
-      {{> records/carousel}}
-    {{/ifmultiple}}
   {{/if}}
 
   <section class="white">

--- a/templates/partials/records/single-image.html
+++ b/templates/partials/records/single-image.html
@@ -1,7 +1,7 @@
 <div class="record-imgpanel">
-  <div class="carousel">
+  <div class="single_image_container">
     {{#each images}}
-      <img src="{{this.large}}" class="carousel__image"/>
+      <img src="{{this.large}}" class="single_image"/>
     {{/each}}
   </div>
 


### PR DESCRIPTION
Fix so that if an object only has one image it displays correctly. Also removes example images and uses correct image sizes. ref: #602 