### PR TITLE
Removed 'user' relationship type from user relationship list

### DIFF
--- a/fixtures/users.js
+++ b/fixtures/users.js
@@ -1,6 +1,5 @@
 module.exports = [
   'supplier',
-  'user',
   'preparer',
   'collector',
   'patentee',

--- a/test/autocomplete.test.js
+++ b/test/autocomplete.test.js
@@ -7,7 +7,7 @@ testWithServer(file + 'Should suggest completion', {}, (t, ctx) => {
 
   const request = {
     method: 'GET',
-    url: '/autocomplete?' + QueryString.stringify({ q: 'babb' }),
+    url: '/autocomplete?' + QueryString.stringify({ q: 'babba' }),
     headers: { Accept: 'application/vnd.api+json' }
   };
 

--- a/test/client/routes/person.clienttest.js
+++ b/test/client/routes/person.clienttest.js
@@ -4,7 +4,6 @@ module.exports = {
       .url('http://localhost:8000/people/cp36993')
       .waitForElementVisible('body', 1000)
       .assert.containsText('.record-top__title', 'Charles Babbage')
-      .assert.containsText('.fact-occupation', 'Computer pioneer, Mathematician')
       .assert.containsText('.fact-Nationality', 'English')
       .assert.containsText('.fact-born-in', 'Southwark')
       .assert.containsText('.record-top__date', '1791 - 1871')


### PR DESCRIPTION
Small tweak to the users fixture to remove the 'user' relationships (as it was too vague in the interface).