### PR TITLE
shows caption for single images

### DIFF
--- a/client/styles/components/_carousel.scss
+++ b/client/styles/components/_carousel.scss
@@ -33,9 +33,13 @@
 
 .single_image_container {
   text-align: center;
+  border: 1px white solid;
+  border-width: 1px 0;
 
   .single_image {
     height: 36rem;
+    border: 1px white solid;
+    border-width: 0 1px;
   }
 }
 

--- a/templates/partials/records/record-imgpanel__controlbar.html
+++ b/templates/partials/records/record-imgpanel__controlbar.html
@@ -38,7 +38,7 @@
       </div>
 
       {{#each images}}
-      <p id="record-imgpanel__caption-{{@index}}" class="hidden record-imgpanel__caption">{{title}}<br />
+      <p id="record-imgpanel__caption-{{@index}}" class="record-imgpanel__caption">{{title}}<br />
       {{credit}}<br />
       {{rights.details}}
       </p>


### PR DESCRIPTION
ref #641, caption wasn't displaying for single images because 'hidden' class was applied, which was only being removed by the carousel (which doesn't exist for single images)