### PR TITLE
retreive all occupations

### DIFF
--- a/lib/jsonapi-response.js
+++ b/lib/jsonapi-response.js
@@ -53,18 +53,6 @@ function getAttributes (data) {
       if (key === 'legal' && checkPurchased(attributes, key)) {
         delete attributes[key].credit_line;
       }
-      // temporary until new index - clean occupation values
-      // https://github.com/TheScienceMuseum/collectionsonline/issues/518
-      if (key === 'occupation') {
-        if (data[key].length > 1) {
-          // delete the last value which represent the concatenation of all the occupation separated by ;
-          attributes[key].pop();
-        }
-        // delete spaces in occupation values
-        attributes[key] = attributes[key].map(function (occupation) {
-          return occupation.trim();
-        });
-      }
     }
   });
 


### PR DESCRIPTION
## To be merged after #776 
The database has the now the right values for the occupations (#518) so this PR delete a fix code we used to extract the right values from the Elasticsearch index

see #773