### PR TITLE
add title for serp

### DIFF
--- a/lib/helpers/search-results-to-template-data/title-page.js
+++ b/lib/helpers/search-results-to-template-data/title-page.js
@@ -1,0 +1,44 @@
+'use strict';
+
+/**
+* see #699
+* category : {name of the category} | Science Museum Group Collection
+* museum (+ gallery): On display at {name muserum} : {name gallery} | Science Museum Group Collection
+* category + museum + gallery:
+*  {name of the category} on display at {name muserum} : {name gallery} | Science Museum Group Collection
+*/
+
+var nameFromFilter = function (selectedFilters) {
+  var name = '';
+  var category = selectedFilters.categories && Object.keys(selectedFilters.categories)[0];
+  var museum = selectedFilters.museum && Object.keys(selectedFilters.museum)[0];
+  var gallery = selectedFilters.gallery && Object.keys(selectedFilters.gallery)[0];
+
+  // check that only the filter categories, museum or gallery are selected
+  var otherFilters = Object.keys(selectedFilters).filter(function (f) {
+    return f !== 'categories' && f !== 'museum' && f !== 'gallery';
+  });
+
+  // no other filters
+  if (otherFilters.length === 0) {
+    name += category ? category + ' ' : '';
+    name += museum ? 'on display at the ' + museum + ' ' : '';
+    name += gallery ? ': ' + gallery + ' ' : '';
+    // capitalise:
+    // if category not define "on display..." is converted to "On display..."
+    name = name.charAt(0).toUpperCase() + name.slice(1);
+  }
+
+  return name;
+};
+
+module.exports = function (q, selectedFilters) {
+  var name = nameFromFilter(selectedFilters);
+
+  // if no search specified and a name is defined
+  if (!q && name) {
+    return name + '| Science Museum Group Collection';
+  }
+
+  return 'Search our collection | Science Museum Group Collection';
+};

--- a/lib/transforms/search-results-to-template-data.js
+++ b/lib/transforms/search-results-to-template-data.js
@@ -7,6 +7,7 @@ const createSelectedFilters = require('./create-selected-filters');
 const getNestedProperty = require('../nested-property');
 const createClearFacetLinks = require('./create-clear-facet-links');
 const pillboxOndisplay = require('../helpers/search-results-to-template-data/pillbox-ondisplay.js');
+const getTitlePage = require('../helpers/search-results-to-template-data/title-page.js');
 
 module.exports = (queryParams, results, config) => {
   config = config || {};
@@ -21,7 +22,7 @@ module.exports = (queryParams, results, config) => {
   const inProduction = Boolean(results.inProduction);
   const data = {
     title: 'Search our collection | Science Museum Group Collection',
-    titlePage: 'Search our collection | Science Museum Group Collection',
+    titlePage: getTitlePage(queryParams.q, selectedFilters),
     page: results.data.length ? queryParams.pageType : 'noresults',
     q: queryParams.q,
     results: results.data.map(createResult),
@@ -72,6 +73,7 @@ module.exports = (queryParams, results, config) => {
   if (results.meta.count.type.all === 0) {
     data.filterAllDisabled = true;
   }
+
   return data;
 };
 

--- a/lib/transforms/search-results-to-template-data.js
+++ b/lib/transforms/search-results-to-template-data.js
@@ -73,7 +73,6 @@ module.exports = (queryParams, results, config) => {
   if (results.meta.count.type.all === 0) {
     data.filterAllDisabled = true;
   }
-
   return data;
 };
 

--- a/test/title-serp.test.js
+++ b/test/title-serp.test.js
@@ -1,0 +1,69 @@
+const test = require('tape');
+const getTitlePage = require('../lib/helpers/search-results-to-template-data/title-page.js');
+const dir = __dirname.split('/')[__dirname.split('/').length - 1];
+const file = dir + __filename.replace(__dirname, '') + ' > ';
+
+// no filters selected
+test(file + 'serp title - no filters selected', (t) => {
+  var selectedFilters = {};
+  var title = getTitlePage('', selectedFilters);
+  t.equal(title, 'Search our collection | Science Museum Group Collection', 'no filters - title ok');
+  t.end();
+});
+
+// filter other than category museum and gallery
+test(file + 'serp title - no filters selected', (t) => {
+  var selectedFilters = {hasImage: { true: true }};
+  var title = getTitlePage('', selectedFilters);
+  t.equal(title, 'Search our collection | Science Museum Group Collection', 'filter image selected - title ok');
+  t.end();
+});
+
+// filter containing the category museum or gallery but with other filter
+test(file + 'serp title - no filters selected', (t) => {
+  var selectedFilters = {
+    hasImage: { true: true },
+    gallery: { 'Science & Art of Medicine Gallery': true },
+    museum: { 'Science Museum': true }
+  };
+  var title = getTitlePage('', selectedFilters);
+  t.equal(title, 'Search our collection | Science Museum Group Collection', 'filter museum but with image selected - title ok');
+  t.end();
+});
+// filter with category only
+test(file + 'serp title - no filters selected', (t) => {
+  var selectedFilters = { categories: { Photographs: true } };
+  var title = getTitlePage('', selectedFilters);
+  t.equal(title, 'Photographs | Science Museum Group Collection', 'filter category - title ok');
+  t.end();
+});
+// filter with category only bit with a query parameter q
+test(file + 'serp title - no filters selected', (t) => {
+  var selectedFilters = { categories: { Photographs: true } };
+  var title = getTitlePage('babbage', selectedFilters);
+  t.equal(title, 'Search our collection | Science Museum Group Collection', 'filter category - title ok');
+  t.end();
+});
+// filter with museum and gallery
+test(file + 'serp title - no filters selected', (t) => {
+  var selectedFilters = {
+    gallery: { Warehouse: true },
+    museum: { 'National Railway Museum': true }
+  };
+  var title = getTitlePage('', selectedFilters);
+  t.equal(title, 'On display at the National Railway Museum : Warehouse | Science Museum Group Collection', 'filter museum & gallery - title ok');
+  t.end();
+});
+
+// filter with category and museum and gallery (a gallery can't be defined without a museum)
+test(file + 'serp title - no filters selected', (t) => {
+  var selectedFilters = {
+    categories: { 'Railway Models': true },
+    gallery: { Warehouse: true },
+    museum: { 'National Railway Museum': true }
+  };
+  var title = getTitlePage('', selectedFilters);
+  t.equal(title, 'Railway Models on display at the National Railway Museum : Warehouse | Science Museum Group Collection', 'filter museum & gallery - title ok');
+  t.end();
+});
+


### PR DESCRIPTION
if only on of the filter for categories, museum or gallery is selected and the search is empty (no query parameters defined for q, or empty string) we are add the name of the filter in the title of the page

see #699