### PR TITLE
delete location_is_relative from api result

### DIFF
--- a/lib/jsonapi-response.js
+++ b/lib/jsonapi-response.js
@@ -34,11 +34,14 @@ function getImagePaths (attributes, config) {
         } else {
           processed[k].location = config.mediaPath + processed[k].location;
         }
+
+        delete processed[k].location_is_relative;
       });
       e.processed = processed;
     }
     return e;
   });
+
   return multimedia;
 }
 


### PR DESCRIPTION
see  #778
delete location_is_relative property which is not useful in the api response