### PR TITLE
Get random search results 

### DIFF
--- a/lib/query-params/query-params.js
+++ b/lib/query-params/query-params.js
@@ -18,6 +18,7 @@ module.exports = (typeFormat, queryParams) => {
   result.pageSize = parseInt(queryParams.query['page[size]']) || 50;
   result.pageType = queryParams.query['page[type]'] || 'search';
   result.type = queryParams.params.type || queryParams.query['fields[type]'] || 'all';
+  result.random = queryParams.query.random;
 
   result.filter = {all: {}, objects: {}, people: {}, documents: {}};
   // All

--- a/lib/search.js
+++ b/lib/search.js
@@ -14,7 +14,8 @@ const searchWeights = require('./search-weights');
 module.exports = (elastic, queryParams, next) => {
   const pageNumber = queryParams.pageNumber;
   const pageSize = queryParams.pageSize;
-  const body = {
+  var body = {
+    size: pageSize,
     query: {
       function_score: {
         query: {
@@ -86,12 +87,32 @@ module.exports = (elastic, queryParams, next) => {
   const searchOpts = {
     index: 'smg',
     from: pageNumber * pageSize,
-    size: pageSize,
     body: body
   };
 
   if (!queryParams.q) {
     searchOpts.body.query.function_score.query = {match_all: {}};
+  }
+
+  if (queryParams.random) {
+    /* See https://github.com/TheScienceMuseum/collectionsonline/issues/780
+      Allows users to request a number (n) of random items using query '?random=n'
+      Where 'n' is a number between 1 and 50
+    */
+    searchOpts.body = {
+      size: queryParams.random,
+      query: {
+        function_score: {
+          query: {match_all: {}},
+          functions: [{
+            random_score: {
+              seed: Date.now()
+            }
+          }]
+        }
+      },
+      min_score: 0.01
+    };
   }
 
   const filtersType = [{terms: {'type.base': ['agent', 'archive', 'object']}}];

--- a/schemas/search.js
+++ b/schemas/search.js
@@ -6,6 +6,7 @@ module.exports = {
     'page[number]': Joi.number().integer().min(0),
     'page[size]': Joi.number().integer().min(1),
     'page[type]': Joi.string().valid('search', 'results-list'),
-    'ajax': Joi.boolean().truthy('true').falsy('false')
+    'ajax': Joi.boolean().truthy('true').falsy('false'),
+    'random': Joi.number().integer().min(1).max(50)
   }
 };

--- a/test/random.test.js
+++ b/test/random.test.js
@@ -1,0 +1,65 @@
+const QueryString = require('querystring');
+const testWithServer = require('./helpers/test-with-server');
+const dir = __dirname.split('/')[__dirname.split('/').length - 1];
+const file = dir + __filename.replace(__dirname, '') + ' > ';
+
+testWithServer(file + 'Request for 4 random items', {}, (t, ctx) => {
+  const htmlRequest = {
+    method: 'GET',
+    url: '/search?' + QueryString.stringify({
+      'random': 4
+    }),
+    headers: { Accept: 'application/json' }
+  };
+
+  ctx.server.inject(htmlRequest, (res) => {
+    var result = JSON.parse(res.payload).data;
+    t.equal(res.statusCode, 200, 'Status code was as expected');
+    t.equal(result.length, 4, 'Returns 4 items');
+    ctx.server.inject(htmlRequest, (res) => {
+      var result2 = JSON.parse(res.payload).data;
+      t.notDeepEqual(result, result2, 'Random results are not equal');
+      t.end();
+    });
+  });
+});
+
+testWithServer(file + 'Query has no effect on randomness', {}, (t, ctx) => {
+  const htmlRequest = {
+    method: 'GET',
+    url: '/search?' + QueryString.stringify({
+      'random': 2,
+      'q': 'rocket'
+    }),
+    headers: { Accept: 'application/json' }
+  };
+
+  ctx.server.inject(htmlRequest, (res) => {
+    var result = JSON.parse(res.payload).data;
+    t.equal(res.statusCode, 200, 'Status code was as expected');
+    t.equal(result.length, 2, 'Returns 4 items');
+    ctx.server.inject(htmlRequest, (res2) => {
+      var result2 = JSON.parse(res2.payload).data;
+      t.notDeepEqual(result, result2, 'Random results are not equal');
+      t.end();
+    });
+  });
+});
+
+testWithServer(file + 'Query has no effect on randomness', {}, (t, ctx) => {
+  const htmlRequest = {
+    method: 'GET',
+    url: '/search?' + QueryString.stringify({
+      'random': 2,
+      'categories': 'Art'
+    }),
+    headers: { Accept: 'application/json' }
+  };
+
+  ctx.server.inject(htmlRequest, (res) => {
+    var result = JSON.parse(res.payload).data;
+    t.equal(res.statusCode, 200, 'Status code was as expected');
+    t.ok(result[0].attributes.categories.find(el => el.name === 'Art'), 'Item in correct category');
+    t.end();
+  });
+});


### PR DESCRIPTION
ref #780

Allows addition of `random=n` as a query string, where `n` is a number between 1 and 50, and returns `n` random results 