### PR TITLE
lowercases filters in the url

### DIFF
--- a/client/lib/archive-listeners.js
+++ b/client/lib/archive-listeners.js
@@ -10,7 +10,7 @@ module.exports = () => {
       var q = document.getElementById('archive-q').value;
       var qs = { q };
       var archive = document.getElementById('archive-title').value;
-      qs['filter[archive]'] = archive;
+      qs['filter[archive]'] = archive.toLowerCase();
       var url = '/search/documents?' + QueryString.stringify(qs);
       page.show(url);
     });

--- a/client/lib/get-qs.js
+++ b/client/lib/get-qs.js
@@ -17,5 +17,5 @@ module.exports = function (pageType) {
   // select result per page
   var rpp = document.querySelector('.control--rpp select') ? document.querySelector('.control--rpp select').value : 50;
   params['page[size]'] = rpp;
-  return paramify(params) + querify(params);
+  return paramify(params).toLowerCase() + querify(params);
 };

--- a/client/lib/search-listener.js
+++ b/client/lib/search-listener.js
@@ -41,7 +41,7 @@ module.exports = function () {
     }
     var params = paramify(qs);
     var query = querify(qs);
-    var url = '/search' + params + query;
+    var url = '/search' + params.toLowerCase() + query;
     page.show(url);
   });
 };

--- a/test/client/routes/document.clienttest.js
+++ b/test/client/routes/document.clienttest.js
@@ -14,7 +14,7 @@ module.exports = {
       .setValue('input[type=search]#archive-q', 'scheutz\'s')
       .click('.searchbox--archive button.searchbox__submit')
       .pause(1000)
-      .assert.urlEquals('http://localhost:8000/search/documents?q=scheutz%27s&filter%5Barchive%5D=The%20Babbage%20Papers')
+      .assert.urlEquals('http://localhost:8000/search/documents?q=scheutz%27s&filter%5Barchive%5D=the%20babbage%20papers')
       .assert.containsText('.resultcard', 'Papers relating to the Scheutz\'s Differenc...')
       .end();
   }


### PR DESCRIPTION
ref #867
When adding filters using the sidebar, they are now added to the url in lower case.
Queries were already case insensitive on the back end, so they now work both ways.