### PR TITLE
Ios image bugs

### DIFF
--- a/client/lib/listeners/carousel.js
+++ b/client/lib/listeners/carousel.js
@@ -35,9 +35,7 @@ module.exports = (ctx) => {
       Array.prototype.slice.call(thumbnails).forEach((el) => {
         el.classList.remove('record-imgpanel__thumb--selected');
       });
-      if (thumbnails[flkty.selectedIndex]) {
-        thumbnails[flkty.selectedIndex].classList.add('record-imgpanel__thumb--selected');
-      }
+      thumbnails[flkty.selectedIndex].classList.add('record-imgpanel__thumb--selected');
       captions.forEach((el) => showHide('record-imgpanel__caption', flkty, el));
       zooms.forEach((el) => showHide('openseadragon-toolbar', flkty, el));
       rights.forEach((el) => showHide('cite__method', flkty, el));

--- a/client/lib/listeners/carousel.js
+++ b/client/lib/listeners/carousel.js
@@ -5,7 +5,7 @@ var openseadragon = require('../openseadragon');
 module.exports = (ctx) => {
   var carousel = document.querySelector('.carousel');
   if (carousel) {
-    var thumbnails = Array.prototype.slice.call(document.getElementsByClassName('record-imgpanel__thumb'));
+    var thumbnails = document.getElementsByClassName('record-imgpanel__thumb');
     var captions = Array.prototype.slice.call(document.getElementsByClassName('record-imgpanel__caption'));
     var rights = Array.prototype.slice.call(document.getElementsByClassName('cite__menu__methods'));
     var zooms = Array.prototype.slice.call(document.getElementsByClassName('osd__toolbar-container'));
@@ -32,7 +32,7 @@ module.exports = (ctx) => {
       if (navigator.platform && /iPad|iPhone|iPod/.test(navigator.platform)) {
         document.querySelector('#openseadragon').style.width = '100%';
       }
-      thumbnails.forEach((el) => {
+      Array.prototype.slice.call(thumbnails).forEach((el) => {
         el.classList.remove('record-imgpanel__thumb--selected');
       });
       if (thumbnails[flkty.selectedIndex]) {
@@ -44,7 +44,7 @@ module.exports = (ctx) => {
       useImage.forEach((el) => showHide('cite__button', flkty, el));
     });
 
-    thumbnails.forEach((el, i) => el.addEventListener('click', function (e) {
+    Array.prototype.slice.call(thumbnails).forEach((el, i) => el.addEventListener('click', function (e) {
       ctx.carousel.select(i);
       if (ctx.viewer) {
         ctx.viewer.destroy();

--- a/client/lib/listeners/carousel.js
+++ b/client/lib/listeners/carousel.js
@@ -29,7 +29,9 @@ module.exports = (ctx) => {
 
     var flkty = Flickity.data(carousel);
     ctx.carousel.on('select', function () {
-      document.querySelector('#openseadragon').style.width = '100%';
+      if (navigator.platform && /iPad|iPhone|iPod/.test(navigator.platform)) {
+        document.querySelector('#openseadragon').style.width = '100%';
+      }
       thumbnails.forEach((el) => {
         el.classList.remove('record-imgpanel__thumb--selected');
       });


### PR DESCRIPTION
Only apply safari ios fix when on ios device

Ref #807 

For some reason, safari desktop could crash when making an image full screen. The change should no longer effect desktop and will only apply to mobile