### PR TITLE
fix https -> http link to science museum site

### DIFF
--- a/fixtures/museums.js
+++ b/fixtures/museums.js
@@ -8,7 +8,7 @@ module.exports = {
   links: [
     {
       name: 'Science Museum',
-      url: 'https://www.sciencemuseum.org.uk',
+      url: 'http://www.sciencemuseum.org.uk',
       image: '/assets/img/global/sml-logo.svg'
     },
     {


### PR DESCRIPTION
Site link should be to `http` not `https`