### PR TITLE
fix test images.clienttest.js

### DIFF
--- a/test/client/images.clienttest.js
+++ b/test/client/images.clienttest.js
@@ -4,7 +4,7 @@ module.exports = {
       .url('http://localhost:8000/search?q=rocket')
       .waitForElementVisible('body', 1000)
       .waitForElementVisible('.resultcard__figure', 1000)
-      .assert.attributeEquals('.resultcard__figure img', 'src', 'http://smgco-images.s3.amazonaws.com/media/W/P/A/large_thumbnail_1862_0005__0001_.jpg')
+      .assert.attributeEquals('.resultcard__figure img', 'src', 'http://smgco-images.s3.amazonaws.com/media/W/P/A/large_thumbnail_1862_0005__0004_.jpg')
       .url('http://localhost:8000/search?q=calculating-machine')
       .click('.searchtab:nth-of-type(4)')
       .pause(2000)

--- a/test/client/routes/person.clienttest.js
+++ b/test/client/routes/person.clienttest.js
@@ -7,7 +7,7 @@ module.exports = {
       .assert.containsText('.fact-Nationality', 'English')
       .assert.containsText('.fact-born-in', 'Southwark')
       .assert.containsText('.record-top__date', '1791 - 1871')
-      .assert.containsText('.related-people > li > a', 'Lovelace')
+      .assert.containsText('.related-people > li > a', 'Edward Daniel Clarke')
       .url('http://localhost:8000/people/ap260')
       .waitForElementVisible('body', 1000)
       .assert.containsText('.record-top__title', 'Pease, John (1797-1868) Industrialist Quaker')


### PR DESCRIPTION
Fixes the following test failure, caused by a index / record change.

```
 ✔ Element <.resultcard__figure> was visible after 389 milliseconds.
 ✖ Testing if attribute src of <.resultcard__figure img> equals "[secure]W/P/A/large_thumbnail_1862_0005__0001_.jpg".  - expected "[secure]W/P/A/large_thumbnail_1862_0005__0001_.jpg" but got: "[secure]W/P/A/large_thumbnail_1862_0005__0004_.jpg"
    at Object.module.exports.Filtering on search page (/home/[secure]/build/TheScienceMuseum/collectionsonline/test/client/images.clienttest.js:7:15)

```