### PR TITLE
Updates SSPL link and ensures cite block shows correct identifier/acc…

### DIFF
--- a/client/templates.js
+++ b/client/templates.js
@@ -181,6 +181,8 @@ Handlebars.registerHelper('isselected', require('../templates/helpers/isselected
 
 Handlebars.registerHelper('getinventorynumber', require('../templates/helpers/getinventorynumber.js'));
 
+Handlebars.registerHelper('geturlsafeinventorynumber', require('../templates/helpers/geturlsafeinventorynumber.js'));
+
 Handlebars.registerHelper('gettodaysdate', require('../templates/helpers/gettodaysdate.js'));
 
 Handlebars.registerHelper('ifmultiple', require('../templates/helpers/ifmultiple.js'));

--- a/templates/helpers/geturlsafeinventorynumber.js
+++ b/templates/helpers/geturlsafeinventorynumber.js
@@ -7,5 +7,5 @@ module.exports = function (details) {
       }
     });
   }
-  return accession ? accession + '. ' : '';
+  return accession ? encodeURIComponent(accession) : '';
 };

--- a/templates/partials/records/record-imgpanel__controlbar.html
+++ b/templates/partials/records/record-imgpanel__controlbar.html
@@ -23,7 +23,7 @@
               </div>
               <div class="cite__method">
                 <p>License this image for commercial use at Science and Society Picture Library</p>
-                <a href="http://www.scienceandsociety.co.uk/results.asp?search=1&searchtxtkeys={{title}}">
+                <a href="http://www.scienceandsociety.co.uk/results.asp?source={{geturlsafeinventorynumber details}}">
                   <button class="">{{> global/icon i="external" size="16" }} License</button>
                 </a>
               </div>


### PR DESCRIPTION
- Updates SSPL link (to use accession no.) 
- Ensures cite block shows correct identifier/accession no. (previously it only showed the accession no. for object pages and not the identifier no. used by document pages).

Resolves https://github.com/TheScienceMuseum/collectionsonline/issues/977