### PR TITLE
Fix image order

### DIFF
--- a/lib/helpers/jsonapi-response/sort-images.js
+++ b/lib/helpers/jsonapi-response/sort-images.js
@@ -9,12 +9,15 @@ function compare (img1, img2) {
   var img1Date = Date.parse(img1.sort);
   var img2Date = Date.parse(img2.sort);
 
+  var img1Pos = parseInt(img1.position);
+  var img2Pos = parseInt(img2.position);
+
   // sort by page numebr / position if present
   // (P1,2,3 value in image object identifier field in Trinity)
-  if (parseInt(img1.position) < parseInt(img2.position)) {
+  if (img1Pos < img2Pos) {
     return -1;
   }
-  if (parseInt(img1.position) > parseInt(img2.position)) {
+  if (img1Pos > img2Pos) {
     return 1;
   }
 
@@ -28,10 +31,10 @@ function compare (img1, img2) {
 
   // if the priorities are equal sort by the property sort
   if (img1Date < img2Date) {
-    return 1;
+    return -1;
   }
   if (img1Date > img2Date) {
-    return -1;
+    return 1;
   }
 
   return 0;

--- a/lib/helpers/jsonapi-response/sort-images.js
+++ b/lib/helpers/jsonapi-response/sort-images.js
@@ -1,45 +1,12 @@
+var _ = require('lodash');
+
 /*
 * Sort the list of images by priority and by date upload, see #499
 * @param {Array} images - array of images object
 * The image object has the properties priority (0 to 9) and sort (upload date)
 */
 
-// compare function use in sort
-function compare (img1, img2) {
-  var img1Date = Date.parse(img1.sort);
-  var img2Date = Date.parse(img2.sort);
-
-  var img1Pos = parseInt(img1.position);
-  var img2Pos = parseInt(img2.position);
-
-  // sort by page numebr / position if present
-  // (P1,2,3 value in image object identifier field in Trinity)
-  if (img1Pos < img2Pos) {
-    return -1;
-  }
-  if (img1Pos > img2Pos) {
-    return 1;
-  }
-
-  // sort by priority if avaliable (default = 0.5)
-  if (img1.priority < img2.priority) {
-    return 1;
-  }
-  if (img1.priority > img2.priority) {
-    return -1;
-  }
-
-  // if the priorities are equal sort by the property sort
-  if (img1Date < img2Date) {
-    return -1;
-  }
-  if (img1Date > img2Date) {
-    return 1;
-  }
-
-  return 0;
-}
-
 module.exports = function (images) {
-  return images.sort(compare);
+  var sorted = _.orderBy(images, [i => i.position || 99999, i => i.priority || 0.5, 'sort'], ['asc', 'desc', 'asc']);
+  return sorted;
 };

--- a/lib/jsonapi-response.js
+++ b/lib/jsonapi-response.js
@@ -17,7 +17,7 @@ module.exports = (data, config, relatedItems) => {
 
   if (attributes.multimedia) {
     attributes.multimedia = getImagePaths(attributes, config);
-    sortImages(attributes.multimedia);
+    attributes.multimedia = sortImages(attributes.multimedia);
   }
 
   return {data: {type, id, attributes, links, relationships}, included, inProduction};

--- a/lib/transforms/search-results-to-jsonapi.js
+++ b/lib/transforms/search-results-to-jsonapi.js
@@ -5,10 +5,10 @@
 const TypeMapping = require('../type-mapping');
 const createFacets = require('../facets/create-facets');
 const checkPurchased = require('../check-purchased');
-const getNestedProperty = require('../nested-property');
 const paramify = require('../helpers/paramify.js');
 const querify = require('../helpers/querify.js');
 const slug = require('slugg');
+const sortImages = require('../helpers/jsonapi-response/sort-images.js');
 
 module.exports = (queryParams, results, config) => {
   results = results || {};
@@ -83,8 +83,9 @@ const createResource = {
           delete attrs[key].credit_line;
         }
         // Adds image host to path
-        if (key === 'multimedia' && getNestedProperty(hit, '_source.multimedia.0.processed.large_thumbnail.location')) {
-          attrs[key][0].processed.large_thumbnail.location = mediaPath + hit._source[key][0].processed.large_thumbnail.location;
+        if (key === 'multimedia' && hit._source.multimedia) {
+          var sortedImages = sortImages(hit._source.multimedia);
+          attrs[key][0].processed.large_thumbnail.location = mediaPath + sortedImages[0].processed.large_thumbnail.location;
         }
       }
       return attrs;
@@ -174,8 +175,9 @@ const createResource = {
         attrs[key] = hit._source[key];
 
         // Adds image host to path
-        if (key === 'multimedia' && getNestedProperty(hit, '_source.multimedia.0.processed.large_thumbnail.location')) {
-          attrs[key][0].processed.large_thumbnail.location = mediaPath + hit._source[key][0].processed.large_thumbnail.location;
+        if (key === 'multimedia' && hit._source.multimedia) {
+          var sortedImages = sortImages(hit._source.multimedia);
+          attrs[key][0].processed.large_thumbnail.location = mediaPath + sortedImages[0].processed.large_thumbnail.location;
         }
       }
       return attrs;

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "joi": "^10.0.5",
     "json-beautify": "^1.0.1",
     "jsonwebtoken": "^7.1.7",
+    "lodash": "^4.17.4",
     "lodash.debounce": "^4.0.8",
     "openseadragon": "https://github.com/TheScienceMuseum/openseadragon/tarball/smg",
     "page": "^1.7.1",

--- a/test/client/images.clienttest.js
+++ b/test/client/images.clienttest.js
@@ -9,7 +9,7 @@ module.exports = {
       .click('.searchtab:nth-of-type(4)')
       .pause(2000)
       .waitForElementVisible('.resultcard__figure', 1000)
-      .assert.attributeEquals('.resultcard__figure img', 'src', 'http://smgco-images.s3.amazonaws.com/media/I/A/A/large_thumbnail_BAB_K_62v_Calculating_Machine.jpg')
+      .assert.attributeEquals('.resultcard__figure img', 'src', 'http://smgco-images.s3.amazonaws.com/media/I/A/A/large_thumbnail_BAB_K_62_Calculating_Machine.jpg')
       .end();
   }
 };

--- a/test/sort-images.test.js
+++ b/test/sort-images.test.js
@@ -3,35 +3,41 @@ const sortImages = require('../lib/helpers/jsonapi-response/sort-images');
 const dir = __dirname.split('/')[__dirname.split('/').length - 1];
 const file = dir + __filename.replace(__dirname, '') + ' > ';
 
-test(file + 'Sort a list of images by priority and date upload(sort pririty)', (t) => {
+test(file + 'Sort a list of images by position, priority and date upload(sort pririty)', (t) => {
   t.plan(1);
   const images = [
     {priority: 1, sort: '2015-06-07 13:10:41.0'},
     {priority: 2, sort: '2015-06-07 13:10:41.0'},
     {priority: 1, sort: '2016-06-07 13:10:41.0'},
-    {priority: 2, sort: '2015-06-07 16:10:41.0'},
+    {priority: 2, sort: '2015-05-07 16:10:41.0'},
     {priority: 1, sort: '2015-06-07 10:10:40.0'},
     {priority: 1, sort: '2016-07-07'},
     {priority: 1, sort: '2016-07-07'},
     {position: 1, sort: '2016-07-07'},
+    {position: 1, sort: '2015-07-07'},
     {position: 2, sort: '2016-07-07'},
-    {position: 1, sort: '2016-07-07'}
+    {position: 3, sort: '2016-07-07'},
+    {sort: '2015-06-06'},
+    {sort: '2015-05-05'}
   ];
 
   const expected = [
-   {priority: 2, sort: '2015-06-07 16:10:41.0'},
-   {priority: 2, sort: '2015-06-07 13:10:41.0'},
-   {priority: 1, sort: '2016-07-07'},
-   {priority: 1, sort: '2016-07-07'},
-   {position: 1, sort: '2016-07-07'},
-   {position: 1, sort: '2016-07-07'},
-   {position: 2, sort: '2016-07-07'},
-   {priority: 1, sort: '2016-06-07 13:10:41.0'},
-   {priority: 1, sort: '2015-06-07 13:10:41.0'},
-   {priority: 1, sort: '2015-06-07 10:10:40.0'}
+    { sort: '2015-05-05' },
+    { priority: 2, sort: '2015-05-07 16:10:41.0' },
+    { sort: '2015-06-06' },
+    { priority: 2, sort: '2015-06-07 13:10:41.0' },
+    { priority: 1, sort: '2015-06-07 10:10:40.0' },
+    { priority: 1, sort: '2015-06-07 13:10:41.0' },
+    { position: 1, sort: '2015-07-07' },
+    { priority: 1, sort: '2016-06-07 13:10:41.0' },
+    { priority: 1, sort: '2016-07-07' },
+    { position: 1, sort: '2016-07-07' },
+    { position: 2, sort: '2016-07-07' },
+    { position: 3, sort: '2016-07-07' },
+    { priority: 1, sort: '2016-07-07' }
   ];
 
-  t.deepEqual(sortImages(images), expected, 'The images are sorted by priority, date and position');
+  t.deepEqual(sortImages(images), expected, 'The images are sorted by position, date and priority');
   t.end();
 });
 

--- a/test/sort-images.test.js
+++ b/test/sort-images.test.js
@@ -22,19 +22,19 @@ test(file + 'Sort a list of images by position, priority and date upload(sort pr
   ];
 
   const expected = [
-    { sort: '2015-05-05' },
-    { priority: 2, sort: '2015-05-07 16:10:41.0' },
-    { sort: '2015-06-06' },
-    { priority: 2, sort: '2015-06-07 13:10:41.0' },
-    { priority: 1, sort: '2015-06-07 10:10:40.0' },
-    { priority: 1, sort: '2015-06-07 13:10:41.0' },
     { position: 1, sort: '2015-07-07' },
-    { priority: 1, sort: '2016-06-07 13:10:41.0' },
-    { priority: 1, sort: '2016-07-07' },
     { position: 1, sort: '2016-07-07' },
     { position: 2, sort: '2016-07-07' },
     { position: 3, sort: '2016-07-07' },
-    { priority: 1, sort: '2016-07-07' }
+    { priority: 2, sort: '2015-05-07 16:10:41.0' },
+    { priority: 2, sort: '2015-06-07 13:10:41.0' },
+    { priority: 1, sort: '2015-06-07 10:10:40.0' },
+    { priority: 1, sort: '2015-06-07 13:10:41.0' },
+    { priority: 1, sort: '2016-06-07 13:10:41.0' },
+    { priority: 1, sort: '2016-07-07' },
+    { priority: 1, sort: '2016-07-07' },
+    { sort: '2015-05-05' },
+    { sort: '2015-06-06' }
   ];
 
   t.deepEqual(sortImages(images), expected, 'The images are sorted by position, date and priority');


### PR DESCRIPTION
Resolves the ordering of images (by position, priority and date [sort]) on object and document pages. Also ensure the correctly sorted (first image) is used in the search results pages.

Resolves https://github.com/TheScienceMuseum/collectionsonline/issues/983

_It seems image order has been broken of a while now and we just never noticed till we started using page ordering on the archive images._

I used [Lodash](https://lodash.com/docs/) `orderBy` to do the sorting, not sure if we want to avoid using it, but seemed nice and concise solution over writing a custom sort to handle multiple fields/types and asc/desc. But happy to revert back to standard JS if we feel that's cleaner.

Also not 100% sure if sorting the images in 'lib/transforms/search-results-to-jsonapi.js` prior to assigning a full path to the first image, was the best place for it (ie. non-DRY). Let me know if you think that was a bad idea.
