### PR TITLE
gives higher boost to name matches

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -58,7 +58,8 @@ module.exports = (elastic, queryParams, next) => {
               match_phrase: {
                 'title.value_text': {
                   query: queryParams.q,
-                  slop: 5
+                  slop: 5,
+                  boost: 5
                 }
               }
             }, {


### PR DESCRIPTION
ref #980, searching for exact name of an object should place it higher than less accurate results that are on display.