### PR TITLE
updates OpenSeadragon, stops safari crashing when closing full screen

### DIFF
--- a/client/lib/listeners/carousel.js
+++ b/client/lib/listeners/carousel.js
@@ -47,9 +47,6 @@ module.exports = (ctx) => {
     Array.prototype.slice.call(thumbnails).forEach((el, i) => el.addEventListener('click', function (e) {
       ctx.carousel.select(i);
       if (ctx.viewer) {
-        ctx.viewer.destroy();
-        ctx.viewer = false;
-        ctx.save();
         openseadragon.init(ctx, e.target.src);
       }
     }));

--- a/client/lib/listeners/osd-listener.js
+++ b/client/lib/listeners/osd-listener.js
@@ -16,14 +16,8 @@ module.exports = (ctx) => {
         el.classList.remove('hidden');
       });
 
-      if (!ctx.viewer) {
-        openseadragon.init(ctx);
-        ctx.viewer.setFullScreen(true);
-      }
-
-      if (e.target.id !== 'osd-fullpage') {
-        ctx.viewer.setFullScreen(true);
-      }
+      openseadragon.init(ctx);
+      ctx.viewer.setFullScreen(true);
     });
   });
 };

--- a/client/lib/openseadragon.js
+++ b/client/lib/openseadragon.js
@@ -1,4 +1,4 @@
-require('openseadragon');
+var OpenSeadragon = require('openseadragon');
 
 module.exports = {
   init: function (ctx, imgUrl, cb) {
@@ -17,7 +17,9 @@ module.exports = {
       }
     }
 
-    if (!ctx.viewer) {
+    if (ctx.viewer) {
+      ctx.viewer.open(imgUrl + '.dzi');
+    } else {
       ctx.viewer = OpenSeadragon({
         id: 'openseadragon',
         prefixUrl: '/assets/img/openseadragon/',
@@ -59,8 +61,5 @@ module.exports = {
     allButtons.forEach(function (el) {
       el.classList.add('hidden');
     });
-    ctx.viewer.destroy();
-    ctx.viewer = false;
-    ctx.save();
   }
 };

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "jsonwebtoken": "^7.1.7",
     "lodash": "^4.17.4",
     "lodash.debounce": "^4.0.8",
-    "openseadragon": "https://github.com/TheScienceMuseum/openseadragon/tarball/smg",
+    "openseadragon": "2.3.1",
     "page": "^1.7.1",
     "rc": "^1.1.6",
     "request": "^2.81.0",


### PR DESCRIPTION
Openseadragon fixed the issue that caused us to need to fork it (https://github.com/openseadragon/openseadragon/issues/1017) so we can now go back to using the master branch.

This PR also stops safari crashing when we close fullscreen. Previously we were destroying the osd viewer every time the full screen was closed, then creating a new viewer every time another image was opened. We're now using the same viewer, just changing the tilesource.