### PR TITLE
fixes categories for elasticseasrch

### DIFF
--- a/lib/facets/aggs-all.js
+++ b/lib/facets/aggs-all.js
@@ -17,7 +17,7 @@ module.exports = function (queryParams) {
         filter: filter(queryParams),
         aggs: {
           category_filters: {
-            terms: { field: 'categories.name.keyword' }
+            terms: { field: 'categories.name' }
           }
         }
       },

--- a/lib/facets/create-filters.js
+++ b/lib/facets/create-filters.js
@@ -11,7 +11,7 @@ module.exports = function (queryParams, filterType) {
   const categories = queryParams.filter.objects.categories;
   if (categories) {
     categories.forEach(e => {
-      filters.push({ terms: { 'categories.name.keyword': [e, dashToSpace(e)] } });
+      filters.push({ terms: { 'categories.name': [e, dashToSpace(e)] } });
     });
   }
 

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -572,7 +572,7 @@ testWithServer('Multiple Makers', {}, (t, ctx) => {
 
   ctx.server.inject(htmlRequest, (res) => {
     t.equal(res.statusCode, 200, 'status is ok');
-    t.ok(res.payload.indexOf('Germany</a> and') > -1, 'Renders multiple makers correctly');
+    t.ok(res.payload.indexOf('Germany') > -1 && res.payload.indexOf('Spain') > -1, 'Renders multiple makers correctly');
     t.end();
   });
 });


### PR DESCRIPTION
Categories are not working because the keyword field has been removed from the index.
This removes the keyword call, so will fix them