### PR TITLE
lighten purple used on document icons

### DIFF
--- a/client/styles/base/_colour.scss
+++ b/client/styles/base/_colour.scss
@@ -34,7 +34,8 @@ $c-yellow: #ffee00;
 $c-green: #95c11f;
 $c-teal: #4bbecf;
 $c-blue: #004899;
-$c-purple: #af1280;
+$c-purple: #fa1ab7;
+//$c-purple: #af1280; # too dark
 
 $c-lightgrey: #DADADA;
 $c-turquoise: #40E0D0;


### PR DESCRIPTION
Brighten up document icon so it's clear when used on related documents (wide a dark background) etc.