### PR TITLE
Get non-creator related objects for people

### DIFF
--- a/client/templates.js
+++ b/client/templates.js
@@ -249,6 +249,8 @@ Handlebars.registerHelper('toggleDetail', require('../templates/helpers/toggleDe
 Handlebars.registerHelper('isResourcePage', require('../templates/helpers/isResourcePage.js'));
 Handlebars.registerHelper('concat', require('../templates/helpers/concat.js'));
 
+Handlebars.registerHelper('ifcreator', require('../templates/helpers/ifcreator.js'));
+
 // Routes
 module.exports = {
   '404': Handlebars.compile(

--- a/lib/get-related-items.js
+++ b/lib/get-related-items.js
@@ -8,14 +8,22 @@ module.exports = async (elastic, id, count) => {
       function_score: {
         query: {
           bool: {
-            must: {
-              term: {
-                'lifecycle.creation.maker.admin.uid': TypeMapping.toInternal(id)
+            should: [
+              {
+                match: {
+                  'lifecycle.creation.maker.admin.uid': TypeMapping.toInternal(id)
+                }
+              },
+              {
+                match: {
+                  'agents.admin.uid': TypeMapping.toInternal(id)
+                }
               }
-            },
+            ],
             must_not: {
               term: { 'type.base': 'agent' }
-            }
+            },
+            minimum_should_match: 1
           }
         },
         functions: searchWeights

--- a/lib/sort-related-items.js
+++ b/lib/sort-related-items.js
@@ -30,7 +30,7 @@ module.exports = (related, id) => {
         link: config.rootUrl + '/' + TypeMapping.toExternal(el._type) + '/' + TypeMapping.toExternal(el._id) + slugValue
       };
 
-      if (id) { item.role = getRole(el, id); }
+      if (id) { item.role = getCreationRole(el, id); }
 
       sortedRelated[group].push(item);
     }
@@ -44,12 +44,34 @@ module.exports = (related, id) => {
   };
 };
 
-function getRole (item, id) {
+function getCreationRole (item, id) {
   const creation = (getNestedProperty(item, '_source.lifecycle.creation') || []).find(el => {
-    return el.maker.some(e => e.admin.uid === id);
+    if (Array.isArray(el.maker)) {
+      return el.maker.some(e => e.admin.uid === id);
+    }
   });
 
-  const maker = creation.maker.find(el => el.admin.uid === id) || { '@link': {} };
+  if (creation && Array.isArray(creation.maker)) {
+    const maker = creation.maker.find(el => el.admin.uid === id);
 
-  return getPrimaryValue(maker['@link'].role);
+    if (maker['@link']) {
+      return getPrimaryValue(maker['@link'].role);
+    }
+  } else {
+    return getAssociatedRole(item, id);
+  }
+
+  return null;
+}
+
+function getAssociatedRole (item, id) {
+  const association = (getNestedProperty(item, '_source.agents') || []).find(el => {
+    return el.admin.uid === id;
+  });
+
+  if (association && association['@link']) {
+    return getPrimaryValue(association['@link'].role);
+  }
+
+  return null;
 }

--- a/lib/sort-related-items.js
+++ b/lib/sort-related-items.js
@@ -57,11 +57,9 @@ function getCreationRole (item, id) {
     if (maker['@link']) {
       return getPrimaryValue(maker['@link'].role);
     }
-  } else {
-    return getAssociatedRole(item, id);
   }
 
-  return null;
+  return getAssociatedRole(item, id);
 }
 
 function getAssociatedRole (item, id) {
@@ -72,6 +70,4 @@ function getAssociatedRole (item, id) {
   if (association && association['@link']) {
     return getPrimaryValue(association['@link'].role);
   }
-
-  return null;
 }

--- a/templates/helpers/ifcreator.js
+++ b/templates/helpers/ifcreator.js
@@ -1,0 +1,12 @@
+module.exports = (related, options) => {
+  // If any of these roles match, see more button will link to
+  // search page with 'maker' filter selected as the person
+  // If not, it will link to object search page with the person as the query
+  var makerRoles = ['creator', 'designer', 'engineer', 'inventor'];
+
+  if (related.length > 0 && related.some(el => makerRoles.indexOf(el.role.toLowerCase()) > -1)) {
+    return options.fn(options.data.root);
+  } else {
+    return options.inverse(options.data.root);
+  }
+};

--- a/templates/partials/records/record-related-objects.html
+++ b/templates/partials/records/record-related-objects.html
@@ -1,28 +1,32 @@
-  <section class="record-related">
-    <div class="nested row">
-      <h2 class="columns">Related Objects</h2>
+<section class="record-related">
+  <div class="nested row">
+    <h2 class="columns">Related Objects</h2>
 
-      {{#each related.objects}}
-        {{#formatrelated ../related.objects @index this}}
-          <div class="large-2 medium-3 small-4 columns">
-            <a href="{{link}}">
-              <div class="resultcard resultcard--related {{#if type}}resultcard--{{ this.type }}{{/if}}">
-                <figure class="resultcard__figure">
-                  {{#if this.attributes.figure}}<img src="{{ this.attributes.figure }}" /> {{/if}}
-                </figure>
-                <div class="resultcard__info">
-                  <h4 class="resultcard__title">{{this.attributes.summary_title}}</h4>
-                </div>
+    {{#each related.objects}}
+      {{#formatrelated ../related.objects @index this}}
+        <div class="large-2 medium-3 small-4 columns">
+          <a href="{{link}}">
+            <div class="resultcard resultcard--related {{#if type}}resultcard--{{ this.type }}{{/if}}">
+              <figure class="resultcard__figure">
+                {{#if this.attributes.figure}}<img src="{{ this.attributes.figure }}" /> {{/if}}
+              </figure>
+              <div class="resultcard__info">
+                <h4 class="resultcard__title">{{this.attributes.summary_title}}</h4>
               </div>
-            </a>
-          </div>
-        {{/formatrelated}}
-      {{/each}}
+            </div>
+          </a>
+        </div>
+      {{/formatrelated}}
+    {{/each}}
 
-      {{#isequal this.type 'people' this}}
-        {{#seemore related.objects}}
-          <div class="large-2 medium-3 small-4 columns">
+    {{#isequal this.type 'people' this}}
+      {{#seemore related.objects}}
+        <div class="large-2 medium-3 small-4 columns">
+          {{#ifcreator related.objects}}
             <a href="/search/objects/makers/{{normalise this.title this}}">
+          {{else}}
+            <a href="/search/objects?q={{normalise this.title this}}">
+          {{/ifcreator}}
               <div class="resultcard resultcard--seemore see-more-objects">
                 <figure class="resultcard__figure">{{> global/icon i="search" size="48" }}</figure>
                 <div class="resultcard__info">
@@ -30,9 +34,9 @@
                 </div>
               </div>
             </a>
-          </div>
-        {{/seemore}}
-      {{/isequal}}
+        </div>
+      {{/seemore}}
+    {{/isequal}}
 
-    </div>
-  </section>
+  </div>
+</section>

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -899,3 +899,34 @@ testWithServer(file + 'Request for Person with non-creator related items', {}, a
   await ctx.server.stop();
   t.end();
 });
+
+testWithServer(file + 'Request for Person with creator related items', {}, async (t, ctx) => {
+  t.plan(2);
+
+  const htmlRequest = {
+    method: 'GET',
+    url: '/people/cp2735',
+    headers: { 'Accept': 'text/html' }
+  };
+
+  const res = await ctx.server.inject(htmlRequest);
+  t.equal(res.statusCode, 200, 'Status code was as expected');
+  t.ok(res.payload.indexOf('/search/objects/makers') > -1);
+  await ctx.server.stop();
+  t.end();
+});
+
+testWithServer(file + 'Request for Person with no related items', {}, async (t, ctx) => {
+  t.plan(1);
+
+  const htmlRequest = {
+    method: 'GET',
+    url: '/people/cp88238',
+    headers: { 'Accept': 'application/vnd.api+json' }
+  };
+
+  const res = await ctx.server.inject(htmlRequest);
+  t.equal(res.statusCode, 200, 'Status code was as expected');
+  await ctx.server.stop();
+  t.end();
+});

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -883,3 +883,19 @@ testWithServer(file + 'Request for image tags JSON Page', {}, async (t, ctx) => 
   t.equal(res.headers['content-type'], 'application/vnd.api+json', 'JSONAPI response header ok');
   t.end();
 });
+
+testWithServer(file + 'Request for Person with non-creator related items', {}, async (t, ctx) => {
+  t.plan(2);
+
+  const htmlRequest = {
+    method: 'GET',
+    url: '/people/cp85708',
+    headers: { 'Accept': 'application/vnd.api+json' }
+  };
+
+  const res = await ctx.server.inject(htmlRequest);
+  t.equal(res.statusCode, 200, 'Status code was as expected');
+  t.ok(res.result.included.length > 0);
+  await ctx.server.stop();
+  t.end();
+});


### PR DESCRIPTION
ref #662

Gets related items that aren't just those created by the person (items they owned, portraits of them etc.), along with the relationship/role data (as per #1260).