### PR TITLE
add a back link to MPH child pages

### DIFF
--- a/lib/jsonapi-response.js
+++ b/lib/jsonapi-response.js
@@ -32,7 +32,7 @@ module.exports = (data, config, relatedItems, childRecordsList) => {
     type,
     id,
     relationships,
-    attributes.summary?.title,
+    attributes.summary?.title
   );
   const inProduction = config && config.NODE_ENV === 'production';
 
@@ -365,9 +365,9 @@ function getChildRecords (data, childRecordsArr, config) {
           identifier
         } = match._source;
 
-        const id = match._source['@admin'].uid
+        const id = match._source['@admin'].uid;
         const links = {
-          self: `${config.rootUrl}/objects/${id}/${slug(title).toLowerCase()}`,
+          self: `${config.rootUrl}/objects/${id}/${slug(title).toLowerCase()}`
         };
 
         const creationDate = match._source.creation?.date;
@@ -383,8 +383,6 @@ function getChildRecords (data, childRecordsArr, config) {
         const inProduction = config && config.NODE_ENV === 'production';
 
         const type = 'objects';
-
-        const titleForSlug = title[0].value;
 
         // adds nested child records to response recursively
         if (record.child) {

--- a/lib/jsonapi-response.js
+++ b/lib/jsonapi-response.js
@@ -10,9 +10,6 @@ const sortImages = require('./helpers/jsonapi-response/sort-images.js');
 
 module.exports = (data, config, relatedItems, childRecordsList) => {
   const type = TypeMapping.toExternal(data._source['@datatype']?.base);
-  const parentLink = TypeMapping.toExternal(
-    data._source.grouping && data._source.grouping[0].summary?.title
-  );
   const record = getRecordType(data);
   const id = TypeMapping.toExternal(data._id);
   const attributes = getAttributes(data._source);
@@ -36,7 +33,6 @@ module.exports = (data, config, relatedItems, childRecordsList) => {
     id,
     relationships,
     attributes.summary?.title,
-    parentLink
   );
   const inProduction = config && config.NODE_ENV === 'production';
 
@@ -112,7 +108,7 @@ function getAttributes (data) {
   return attributes;
 }
 
-function getLinks (config, type, id, relationships, title, parentTitle) {
+function getLinks (config, type, id, relationships, title) {
   const links = {
     self: `${config.rootUrl}/${type}/${id}/${slug(title).toLowerCase()}`,
     root: config.rootUrl,
@@ -120,10 +116,8 @@ function getLinks (config, type, id, relationships, title, parentTitle) {
     iiif: `${config.rootUrl}/iiif/${type}/${id}`
   };
   if (relationships && relationships.parent) {
+    // add slug, value held in attributes.level.fonds for AdLib documents
     links.parent = `${config.rootUrl}/${relationships.parent.data[0].type}/${relationships.parent.data[0].id}`;
-    links.parentSlug = `${config.rootUrl}/${
-      relationships.parent.data[0].type
-    }/${relationships.parent.data[0].id}/${slug(parentTitle).toLowerCase()}`;
   }
   return links;
 }
@@ -371,10 +365,10 @@ function getChildRecords (data, childRecordsArr, config) {
           identifier
         } = match._source;
 
-        const id = match._source['@admin'].uid;
-        const link = `${config.rootUrl}/objects/${id}/${slug(
-          title[0].value
-        ).toLowerCase()}`;
+        const id = match._source['@admin'].uid
+        const links = {
+          self: `${config.rootUrl}/objects/${id}/${slug(title).toLowerCase()}`,
+        };
 
         const creationDate = match._source.creation?.date;
 
@@ -391,15 +385,6 @@ function getChildRecords (data, childRecordsArr, config) {
         const type = 'objects';
 
         const titleForSlug = title[0].value;
-
-        const links = getLinks(
-          config,
-          type,
-          id,
-          match._source.relationships,
-          titleForSlug,
-          null
-        );
 
         // adds nested child records to response recursively
         if (record.child) {
@@ -430,7 +415,6 @@ function getChildRecords (data, childRecordsArr, config) {
               category,
               creationDate,
               identifier,
-              link,
               links,
               children: match._source.child || []
             },

--- a/templates/partials/records/record-top.html
+++ b/templates/partials/records/record-top.html
@@ -4,11 +4,11 @@
       <h1 class="record-top__title">{{#if level}}{{> global/icon i=level}}{{else}}{{> global/icon i=type}}{{/if}}
         {{normalise title this}} {{#ifpage 'person'}}<span class="record-top__date">{{date}}</span>{{/ifpage}}</h1>
 
-      {{#if links.parentSlug }}
+      {{#if parent }}
       <dl class="record-top__dl fact-Made">
         <dt>PART OF:</dt>
         <dd>
-          <a href="{{links.parentLink}}">{{links.parentTitle}}</a>
+          <a href="{{parent.links.self}}">{{parent.attributes.summary.title}}</a>
         </dd>
       </dl>
       {{/if}}

--- a/templates/partials/records/record-top.html
+++ b/templates/partials/records/record-top.html
@@ -3,8 +3,14 @@
     <div class="large-12 columns">
       <h1 class="record-top__title">{{#if level}}{{> global/icon i=level}}{{else}}{{> global/icon i=type}}{{/if}}
         {{normalise title this}} {{#ifpage 'person'}}<span class="record-top__date">{{date}}</span>{{/ifpage}}</h1>
+
       {{#if links.parentSlug }}
-      <a href="{{links.parentSlug}}" class="record-top__back-mph">Back to parent collection</a>
+      <dl class="record-top__dl fact-Made">
+        <dt>PART OF:</dt>
+        <dd>
+          <a href="{{links.parentLink}}">{{links.parentTitle}}</a>
+        </dd>
+      </dl>
       {{/if}}
       {{#each fact}}
       <dl class="record-top__dl fact-{{classname this.key}}">


### PR DESCRIPTION
Also removes usage of getLinks() in lib/jsonapi-response.js and instead uses a simplified links array in getChildren
