### PR TITLE
fix result card css, image not full width of Edge

### DIFF
--- a/client/styles/components/_result.scss
+++ b/client/styles/components/_result.scss
@@ -17,7 +17,9 @@
 
     img {
       position: absolute;
-      width: auto;
+      /* remove: width: auto; add below */
+      width: 100%;
+      max-width: none;
       height: auto;
       min-height: 100%;
       top: 0;

--- a/routes/stats.js
+++ b/routes/stats.js
@@ -14,6 +14,10 @@ module.exports = (elastic, config) => ({
           objects: results.body.responses[0].hits.total.value,
           objectsWithImages: results.body.responses[1].hits.total.value,
 
+          // Mimsy records (same as above)
+          records: results.body.responses[0].hits.total.value,
+          recordsWithImages: results.body.responses[1].hits.total.value,
+
           // Records flagged as an SPH layout (parent image)
           recordsSPH: results.body.responses[2].hits.total.value,
           recordsSPHWithImages: results.body.responses[3].hits.total.value,


### PR DESCRIPTION
Hopefully resolves 
https://github.com/TheScienceMuseum/collectionsonline/issues/1620