### PR TITLE
feat: overflow added to web descriptions

### DIFF
--- a/client/styles/components/_record.scss
+++ b/client/styles/components/_record.scss
@@ -486,6 +486,8 @@
     p {
       font-size: 1rem;
     }
+    max-height: 15rem;
+    overflow-y: scroll;
   }
 
   &__details {


### PR DESCRIPTION
Added in a fixed height and overflow property to web descriptions, as the descriptions added to this ticket a while ago caused the heights of the records to differ wildly. This is a stopgap to fix this until a decision is made on how to style the web descriptions. I think having the descriptions appear in a modal, similar to how the images appear could be a good idea, but needs some thought on how to make accessible, whether the extra clicking on each record to see the entire description is a good user experience, etc.