### PR TITLE
feat: filtering out falsy values from filterbadges

### DIFF
--- a/lib/transforms/search-results-to-template-data.js
+++ b/lib/transforms/search-results-to-template-data.js
@@ -18,9 +18,22 @@ module.exports = (queryParams, results, config) => {
   config = config || {};
   const rootUrl = config.rootUrl || '';
   const selectedFilters = createSelectedFilters(queryParams);
+  // catch and filter out any falsy values and stop from being pulled into filterbadges
+  // -createSelectedFilters transforms values into keys from values and can do so with falsy values
+  const selectedCategoryFilters = Object.keys(selectedFilters.categories || {});
 
-  const categoryFilters = Object.keys(selectedFilters.categories || {});
-  const collectionFilters = Object.keys(selectedFilters.collection || {});
+  const categoryFilters = selectedCategoryFilters.filter(
+    (cat) => cat !== 'false' && cat !== 'undefined'
+  );
+
+  const selectedCollectionFilters = Object.keys(
+    selectedFilters.collection || {}
+  );
+
+  const collectionFilters = selectedCollectionFilters.filter(
+    (cat) => cat !== 'false' && cat !== 'undefined'
+  );
+
   // transforms uid to more human readable title in filter badge + description box - from separate query as data not available in search results
   const mphcParent = results.mphcParent;
   const mphcFilters = pillboxMph(selectedFilters, mphcParent);
@@ -75,6 +88,7 @@ module.exports = (queryParams, results, config) => {
     filters: results.meta.filters,
     selectedFilters,
     categoryFilters,
+    // filteredCats,
     collectionFilters,
     mphcFilters,
     museumFilters,

--- a/lib/transforms/search-results-to-template-data.js
+++ b/lib/transforms/search-results-to-template-data.js
@@ -88,7 +88,6 @@ module.exports = (queryParams, results, config) => {
     filters: results.meta.filters,
     selectedFilters,
     categoryFilters,
-    // filteredCats,
     collectionFilters,
     mphcFilters,
     museumFilters,


### PR DESCRIPTION
[Issue #1709](https://github.com/TheScienceMuseum/collectionsonline/issues/1709) - This change is to handle an edge case where values such as undefined and false are pulled into filterbadges. This happens because the createSelectedFilters creates and returns an object using values from the query params as a key. There are a few instances where those values can be falsy values, such as if the user entered wrong values into the url.