### PR TITLE
feat: added check for filterbadges

### DIFF
--- a/lib/helpers/search-results-to-template-data/pillbox-mph.js
+++ b/lib/helpers/search-results-to-template-data/pillbox-mph.js
@@ -1,16 +1,27 @@
 const getPrimaryValue = require('../../get-primary-value');
 const truncate = require('./truncate.js');
 
-// transforms filter UID into title for use in pillbox - more human readable than UID
 module.exports = function (selectedFilters, mphcParent) {
-  return Object.keys(selectedFilters.mphc || {}).map((filterId) => {
-    if (filterId === mphcParent._source?.['@admin']?.uid) {
-      const title = mphcParent
-        ? getPrimaryValue(mphcParent._source.title)
-        : null;
+  // exclude anything not mph type
+  if (
+    !mphcParent?._source?.['@datatype'] ||
+    mphcParent?._source?.['@datatype'].grouping !== 'MPH'
+  ) {
+    return [];
+  }
+  // configure filter
+  const mphcFilters = Object.keys(selectedFilters.mphc || {})
+    .map((filterId) => {
+      if (filterId === mphcParent?._source?.['@admin']?.uid) {
+        const title = mphcParent
+          ? getPrimaryValue(mphcParent?._source.title)
+          : null;
 
-      return truncate(title, 40);
-    }
-    return null;
-  });
+        return truncate(title, 40);
+      }
+      return null;
+    })
+    .filter(Boolean); // filter out null values
+
+  return mphcFilters;
 };


### PR DESCRIPTION
One further check to ensure filterbadges aren't pulled through for non mphc items in search - where a non mph record uid is accidentally entered