### PR TITLE
add details to sph records with long descriptions

### DIFF
--- a/client/styles/components/_record.scss
+++ b/client/styles/components/_record.scss
@@ -494,15 +494,11 @@
 
   &__title {
     font-size: 1.5rem;
+    margin-block: 1rem;
   }
 
   &__description {
-    // p {
-    //   font-size: 1rem;
-    // }
-
-    max-height: 15rem;
-    overflow-y: scroll;
+    margin-block: 1rem;
   }
 
 }

--- a/client/templates.js
+++ b/client/templates.js
@@ -447,7 +447,7 @@ Handlebars.registerHelper('dedupe', require('../templates/helpers/dedupe'));
 Handlebars.registerHelper(
   'sphDescription',
   require('../templates/helpers/sphDescription')
-); 
+);
 Handlebars.registerHelper(
   'groupState',
   require('../templates/helpers/groupState.js')

--- a/client/templates.js
+++ b/client/templates.js
@@ -445,9 +445,9 @@ Handlebars.registerHelper(
 Handlebars.registerHelper('dedupe', require('../templates/helpers/dedupe'));
 
 Handlebars.registerHelper(
-  'ifWebAndPrimary',
-  require('../templates/helpers/ifWebAndPrimary')
-);
+  'sphDescription',
+  require('../templates/helpers/sphDescription')
+); 
 Handlebars.registerHelper(
   'groupState',
   require('../templates/helpers/groupState.js')

--- a/templates/helpers/ifWebAndPrimary.js
+++ b/templates/helpers/ifWebAndPrimary.js
@@ -1,7 +1,0 @@
-module.exports = (description, options) => {
-  if (description.web && description.primary) {
-    return options.fn(this);
-  } else {
-    return options.inverse(this);
-  }
-};

--- a/templates/helpers/sphDescription.js
+++ b/templates/helpers/sphDescription.js
@@ -1,0 +1,9 @@
+module.exports = (description, part) => {
+  // for sph records that have no primary.initialDescription, make a summary from the web.initialDescription, and use the rest as moreDescription
+
+  if (part === 'initialDescription') {
+    return description.primary?.initialDescription || description.web?.initialDescription.slice(0, 1);
+  } else if (part === 'moreDescription') {
+    return description.primary?.initialDescription ? description.web?.initialDescription : description.web?.initialDescription.slice(1);
+  }
+}

--- a/templates/helpers/sphDescription.js
+++ b/templates/helpers/sphDescription.js
@@ -6,4 +6,4 @@ module.exports = (description, part) => {
   } else if (part === 'moreDescription') {
     return description.primary?.initialDescription ? description.web?.initialDescription : description.web?.initialDescription.slice(1);
   }
-}
+};

--- a/templates/partials/records/record-sph-item.html
+++ b/templates/partials/records/record-sph-item.html
@@ -17,26 +17,23 @@
   </h3>
 
   <div class="sph-records__description">
-    {{#if description.primary}}
-    {{#each description.primary.initialDescription }}
-    <p>
-      {{ this}}
-    </p>
-    {{/each}}
-    {{/if}}
-    {{#ifWebAndPrimary description}}
-    <hr>
-    {{/ifWebAndPrimary}}
-    {{#if description.web}}
-
-    {{#each description.web.initialDescription}}
+    {{#if (sphDescription description "initialDescription")}}
+    {{#each (sphDescription description "initialDescription") }}
     <p>
       {{this}}
     </p>
     {{/each}}
     {{/if}}
-
-
+    {{#if (sphDescription description "moreDescription")}}
+    <details class="c-truncated">
+      <summary>More</summary>
+      {{#each (sphDescription description "moreDescription")}}
+      <p>
+        {{this}}
+      </p>
+      {{/each}}
+    </details>
+    {{/if}}
   </div>
 
   <div class="c-property-list --ruled:above">


### PR DESCRIPTION
This formats as per other expandable descriptions.

Note I found a few records [without an initial description](https://collection.sciencemuseumgroup.org.uk/objects/co416960/album-of-cyanotypes-of-british-and-foreign-ferns-album-cyanotype), in these cases, I nick the first para from the longer part, similarly to `lib/helpers/json-to-html-data/format-description.js`.

Feels like there could be some refactoring of the different description types now, but i'm not sure how they're used elsewhere, or coming from disparate sources.

![image](https://github.com/TheScienceMuseum/collectionsonline/assets/109024/bb34e19a-3c41-4336-ab04-1ec76dd32041)
