### PR TITLE
add carousel for multiple sph images

### DIFF
--- a/client/lib/listeners/carousel.js
+++ b/client/lib/listeners/carousel.js
@@ -2,6 +2,7 @@ const Flickity = require('flickity');
 require('flickity-imagesloaded');
 
 module.exports = ctx => {
+  const arrowShape = 'M 0,50 L 45.67,4.33 L 52.5,11.16 L 18.49,45.17 L 100,45.17 L 100,54.83 L 18.49,54.83 L 52.5,88.84 45.67,95.67 Z';
   const carousel = document.querySelector('.carousel');
   if (carousel) {
     const thumbnails = document.getElementsByClassName('record-imgpanel__thumb');
@@ -24,8 +25,7 @@ module.exports = ctx => {
       pageDots: false,
       imagesLoaded: true,
       lazyLoad: 1,
-      arrowShape:
-        'M 0,50 L 45.67,4.33 L 52.5,11.16 L 18.49,45.17 L 100,45.17 L 100,54.83 L 18.49,54.83 L 52.5,88.84 45.67,95.67 Z'
+      arrowShape
     });
 
     const flkty = Flickity.data(carousel);
@@ -85,8 +85,7 @@ module.exports = ctx => {
       cellAlign: 'left',
       percentPosition: false,
       accessibility: true,
-      arrowShape:
-        'M 0,50 L 45.67,4.33 L 52.5,11.16 L 18.49,45.17 L 100,45.17 L 100,54.83 L 18.49,54.83 L 52.5,88.84 45.67,95.67 Z',
+      arrowShape,
       on: {
         ready: function () {
           offsetContainer();
@@ -116,6 +115,42 @@ module.exports = ctx => {
     ).style.marginLeft =
     containerOffset + 'px';
   }
+
+  const cardCarousels = document.querySelectorAll('.card-carousel');
+
+  cardCarousels.forEach(function (cardCarousel, index) {
+    ctx['cardCarousels' + index] = new Flickity(cardCarousel, {
+      wrapAround: true,
+      pageDots: true,
+      imagesLoaded: true,
+      accessibility: true,
+      setGallerySize: false,
+      arrowShape,
+      on: {
+        ready: function () {
+          // href wrappers don't play nicely with draggable elements
+          const links = cardCarousel.querySelectorAll('a');
+          links.forEach((link) => {
+            link.dataset.lightboxSrc = link.href;
+            link.removeAttribute('href');
+          });
+        },
+        staticClick: function (event, pointer, cellElement, cellIndex) {
+          if (!cellElement) {
+            return;
+          }
+          document.dispatchEvent(
+            new CustomEvent('open-lightbox', {
+              detail: {
+                src: cellElement.dataset.lightboxSrc,
+                alt: cellElement.getAttribute('alt')
+              }
+            })
+          );
+        }
+      }
+    });
+  });
 };
 
 function showHide (idBase, flkty, element) {

--- a/client/lib/listeners/carousel.js
+++ b/client/lib/listeners/carousel.js
@@ -147,6 +147,11 @@ module.exports = ctx => {
               }
             })
           );
+        },
+        change: function () {
+          const copyright = this.selectedElement.dataset.copyright;
+          const dd = this.element.closest('article').querySelector('.details-image-copyright');
+          if (copyright && dd) dd.innerHTML = copyright;
         }
       }
     });

--- a/client/lib/listeners/lightbox.js
+++ b/client/lib/listeners/lightbox.js
@@ -17,13 +17,29 @@ module.exports = () => {
     };
     const $lightbox = createBox();
 
-    $lightbox.addEventListener('click', e => {
+    function openLightbox (e) {
+      const $img = $lightbox.querySelector('img');
+      $img.src = e.detail.src;
+      $img.alt = e.detail.alt;
+      $lightbox.classList.add('is-open');
+    }
+
+    function closeLightbox () {
       $lightbox.classList.remove('is-open');
+    }
+
+    $lightbox.addEventListener('click', e => {
+      closeLightbox();
     });
     document.addEventListener('keydown', e => {
       if (e.code === 'KeyX' || e.code === 'Escape') {
-        $lightbox.classList.remove('is-open');
+        closeLightbox();
       }
+    });
+
+    // define a custom eventlistener on the document so external scripts can trigger the lightbox
+    document.addEventListener('open-lightbox', e => {
+      openLightbox(e);
     });
 
     $lightboxes.forEach(el => {
@@ -31,10 +47,12 @@ module.exports = () => {
         e.preventDefault();
 
         if (el.hasAttribute('href')) {
-          const $img = $lightbox.querySelector('img');
-          $img.src = el.href;
-          $img.alt = el.getAttribute('title');
-          $lightbox.classList.add('is-open');
+          openLightbox({
+            detail: {
+              src: el.href,
+              alt: el.getAttribute('title') || el.querySelector('img').getAttribute('alt')
+            }
+          });
         }
       });
     });

--- a/client/styles/components/_carousel.scss
+++ b/client/styles/components/_carousel.scss
@@ -130,3 +130,103 @@
     width: 18rem;
   }
 }
+
+/*
+  Used in sph records where there are multiple images.
+*/
+.card-carousel {
+  position: relative;
+  margin-bottom: 2.5rem; // page-dots space
+
+  &.flickity-enabled {
+
+    &:focus {
+      outline: none;
+    }
+  }
+
+  .flickity-viewport {
+    overflow: hidden;
+    aspect-ratio: 4/3;
+  }
+
+  &__cell {
+    width: 100%;
+  }
+
+  img {
+    display: block;
+    aspect-ratio: 4/3;
+    width: 100%;
+    object-fit: cover;
+  }
+
+  .flickity-prev-next-button {
+    width: 3rem;
+    color: white;
+    appearance: none;
+    background-color: transparent;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    display: flex;
+    align-items: center;
+    opacity: 0.6;
+    padding: 0.5rem;
+    transition: all $transition-default;
+  }
+
+  &:hover {
+    .flickity-prev-next-button {
+      opacity: 1;
+    }
+  }
+
+  .previous {
+    left: 0;
+    cursor: w-resize;
+
+    &:hover {
+      background-image: linear-gradient(90deg,
+          rgba(0, 0, 0, 0.4),
+          rgba(0, 0, 0, 0),
+        );
+    }
+  }
+
+  .next {
+    right: 0;
+    cursor: e-resize;
+
+    &:hover {
+      background-image: linear-gradient(90deg,
+          rgba(0, 0, 0, 0),
+          rgba(0, 0, 0, 0.4));
+    }
+  }
+
+  .flickity-page-dots {
+    position: absolute;
+    top: 100%;
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0.5rem 0;
+    padding: 0;
+
+    li {
+      display: block;
+      width: 1rem;
+      height: 1rem;
+      background-color: grey(20);
+      border-radius: 50%;
+      border: 0.25rem solid white;
+      cursor: pointer
+    }
+
+    .is-selected {
+      background-color: black;
+    }
+  }
+}

--- a/client/styles/components/_mediaplayer.scss
+++ b/client/styles/components/_mediaplayer.scss
@@ -9,7 +9,7 @@
     align-items: flex-start;
 
     &__show {
-      width: calc(66.6666% - 0.3333333rem);
+      width: calc(66.6666% + clamp-between(0.5rem, 1rem));
     }
   }
 

--- a/client/templates.js
+++ b/client/templates.js
@@ -452,6 +452,10 @@ Handlebars.registerHelper(
   'groupState',
   require('../templates/helpers/groupState.js')
 );
+Handlebars.registerHelper(
+  'formatCopyright',
+  require('../templates/helpers/formatCopyright.js')
+);
 
 // Routes
 module.exports = {

--- a/lib/transforms/json-to-html-data.js
+++ b/lib/transforms/json-to-html-data.js
@@ -854,6 +854,7 @@ function getChildRecords (
 
     // used to show no image placeholders at all if none of the images have an image
     const hasImage = !!images.length;
+    const hasMultipleImages = images.length > 1;
     const priority = isPriorityCard(childRecords, record, description);
     if (
       record.data.attributes &&
@@ -887,6 +888,7 @@ function getChildRecords (
       creation,
       category,
       hasImage,
+      hasMultipleImages,
       parentId,
       parentTitle,
       priority,

--- a/templates/helpers/formatCopyright.js
+++ b/templates/helpers/formatCopyright.js
@@ -1,0 +1,7 @@
+module.exports = function (string) {
+  // removes the opening © from the string, because we're showing that to the left anyway
+  if (string.startsWith('©')) {
+    return string.slice(1);
+  }
+  return string;
+};

--- a/templates/pages/object.html
+++ b/templates/pages/object.html
@@ -15,7 +15,7 @@
     {{/if}}
 
     <section class="record-description section">
-      <div class="o-container o-grid -grid--3cols@m">
+      <div class="o-container o-grid o-grid--3cols@m">
         <div class="section__content o-grid__span2@m">
 
           {{> records/record-description}}

--- a/templates/partials/records/record-sph-item.html
+++ b/templates/partials/records/record-sph-item.html
@@ -1,11 +1,22 @@
 <article class="sph-records__item resultcard--priority-card" id="part{{uid}}">
-
   {{#if images}}
+  {{#if hasMultipleImages}}
+  <div class="card-carousel">
+    {{#each images}}
+    <a class="card-carousel__cell" data-lightbox href="{{this.large}}">
+      <img src="{{this.medium}}" alt="{{this.title}}" />
+    </a>
+    {{/each}}
+  </div>
+  {{#each images}}
+  {{/each }}
+  {{ else }}
   <a href="{{firstImage images 0 'large' }}" data-lightbox>
     <figure class="sph-records__figure">
       <img src="{{firstImage images 0 }}" class="sph-records__img" alt="{{this.title}}" />
     </figure>
   </a>
+  {{/if}}
   {{ else }}
   <figure class="sph-records__figure">
     <figcaption>{{title}}</figcaption>

--- a/templates/partials/records/record-sph-item.html
+++ b/templates/partials/records/record-sph-item.html
@@ -3,7 +3,8 @@
   {{#if hasMultipleImages}}
   <div class="card-carousel">
     {{#each images}}
-    <a class="card-carousel__cell" data-lightbox href="{{this.large}}">
+    <a class="card-carousel__cell" data-lightbox href="{{this.large}}"
+      data-copyright="{{formatCopyright this.rights.details}}">
       <img src="{{this.medium}}" alt="{{this.title}}" />
     </a>
     {{/each}}
@@ -68,6 +69,13 @@
       </dd>
     </dl>
     {{/each}}
+    {{#if images.0.rights.details}}
+    <dl>
+      <dt>Image ©</dt>
+      <dd><small class="details-image-copyright">{{formatCopyright images.0.rights.details}}</small></dd>
+    </dl>
+    {{/if}}
+
     {{# if parentTitle}}
     <dl>
       <dt>Part of:</dt>


### PR DESCRIPTION
Seems there are some duplicate images across parts, at least on `/objects/co26704/rocket-locomotive-steam-locomotive`
which is the only multiple-images example I can find. Not the end of the world.

![image](https://github.com/TheScienceMuseum/collectionsonline/assets/109024/9e036da6-f3af-4ddf-96da-beb66d57a56c)
