### PR TITLE
add sph image copyright

### DIFF
--- a/client/lib/listeners/carousel.js
+++ b/client/lib/listeners/carousel.js
@@ -147,6 +147,11 @@ module.exports = ctx => {
               }
             })
           );
+        },
+        change: function () {
+          const copyright = this.selectedElement.dataset.copyright;
+          const dd = this.element.closest('article').querySelector('.details-image-copyright');
+          if (copyright && dd) dd.innerHTML = copyright;
         }
       }
     });

--- a/client/templates.js
+++ b/client/templates.js
@@ -452,6 +452,10 @@ Handlebars.registerHelper(
   'groupState',
   require('../templates/helpers/groupState.js')
 );
+Handlebars.registerHelper(
+  'formatCopyright',
+  require('../templates/helpers/formatCopyright.js')
+);
 
 // Routes
 module.exports = {

--- a/templates/helpers/formatCopyright.js
+++ b/templates/helpers/formatCopyright.js
@@ -1,0 +1,7 @@
+module.exports = function (string) {
+  // removes the opening © from the string, because we're showing that to the left anyway
+  if (string.startsWith('©')) {
+    return string.slice(1);
+  }
+  return string;
+};

--- a/templates/partials/records/record-sph-item.html
+++ b/templates/partials/records/record-sph-item.html
@@ -3,7 +3,8 @@
   {{#if hasMultipleImages}}
   <div class="card-carousel">
     {{#each images}}
-    <a class="card-carousel__cell" data-lightbox href="{{this.large}}">
+    <a class="card-carousel__cell" data-lightbox href="{{this.large}}"
+      data-copyright="{{formatCopyright this.rights.details}}">
       <img src="{{this.medium}}" alt="{{this.title}}" />
     </a>
     {{/each}}
@@ -68,6 +69,13 @@
       </dd>
     </dl>
     {{/each}}
+    {{#if images.0.rights.details}}
+    <dl>
+      <dt>Image ©</dt>
+      <dd><small class="details-image-copyright">{{formatCopyright images.0.rights.details}}</small></dd>
+    </dl>
+    {{/if}}
+
     {{# if parentTitle}}
     <dl>
       <dt>Part of:</dt>


### PR DESCRIPTION
if multiple images (therefore possible multiple copyrights) the image carousel updates the displayed text.

Note sometimes that text is '... Mus**ue**m' [sic]! e.g. /objects/co8412068/hoover-%20constellation-vacuum-cleaner-with-attachments-vacuum-cleaner