### PR TITLE
feat: configured full path to image server

### DIFF
--- a/lib/transforms/search-results-to-jsonapi.js
+++ b/lib/transforms/search-results-to-jsonapi.js
@@ -262,6 +262,18 @@ const createResource = {
           attrs[key][0]['@processed'].large_thumbnail.location =
             mediaPath + sortedImages[0]['@processed'].large_thumbnail.location;
         }
+        // Adds image host to child records
+        if (key === 'child' && hit._source.child) {
+          Array.isArray(
+            hit._source.child.forEach((child) => {
+              if (child.multimedia) {
+                child.multimedia['@processed'].medium_thumbnail.location =
+                  mediaPath +
+                  child.multimedia?.['@processed'].medium_thumbnail.location;
+              }
+            })
+          );
+        }
       }
       return attrs;
     }, {});


### PR DESCRIPTION
@tobystokes The full path to the images should now be built correctly, at the api level, in line with how it is done on record pages