### PR TITLE
remove /categories from robots.txt

### DIFF
--- a/routes/robot.js
+++ b/routes/robot.js
@@ -15,7 +15,6 @@ module.exports = () => ({
         'Disallow: /iiif/\n' +
         'Disallow: /iris/\n' +
         'Disallow: /barcode/\n' +
-        'Disallow: /categories/\n' +
         'Disallow: /*?*\n' +
         'User-agent: AhrefsBot\n' +
         'Disallow: /'


### PR DESCRIPTION
Stop limiting indexing of categories

(not sure why we did this originally)