### PR TITLE
fix error in registering handlbars template

### DIFF
--- a/client/templates.js
+++ b/client/templates.js
@@ -479,7 +479,7 @@ Handlebars.registerPartial(
 );
 
 Handlebars.registerPartial(
-  'records/record-sph-properties',
+  'records/record-sph-priority-item',
   Fs.readFileSync('./templates/partials/records/record-sph-priority-item.html', 'utf8')
 );
 


### PR DESCRIPTION
Fix typo in Handlebars.registerPartial (record-sph-properties should be record-sph-priority-item)

Handlebars.registerPartial(
   'records/record-sph-properties',
   Fs.readFileSync('./templates/partials/records/record-sph-priority-item.html', 'utf8')