### PR TITLE
test: added try catch for articles test

### DIFF
--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -833,13 +833,20 @@ testWithServer(
       headers: { Accept: 'application/json' }
     };
 
-    const res = await ctx.server.inject(htmlRequest);
-    t.ok(JSON.parse(res.payload), 'Result is JSON');
-    t.equal(res.statusCode, 200, 'Status code was as expected');
+    try {
+      const res = await ctx.server.inject(htmlRequest);
+      t.ok(JSON.parse(res.payload), 'Result is JSON');
+      t.equal(res.statusCode, 200, 'Status code was as expected');
+    } catch (error) {
+      t.fail(error.message);
+    } finally {
+      await ctx.server.stop();
+      cacheStart.restore();
+      cacheGet.restore();
+    }
     await ctx.server.stop();
     cacheStart.restore();
     cacheGet.restore();
-    t.end();
   }
 );
 


### PR DESCRIPTION
Fixed the [hanging test](https://github.com/TheScienceMuseum/collectionsonline/issues/1807) by wrapping it in a try/catch block. It still takes a moment to finish, but does so in a fraction of the time it did before