### PR TITLE
Enhance titles 1175

### DIFF
--- a/lib/helpers/search-results-to-template-data/title-page.js
+++ b/lib/helpers/search-results-to-template-data/title-page.js
@@ -25,7 +25,8 @@ const nameFromFilter = function (selectedFilters) {
     'makers',
     'page[size]',
     'page[type]',
-    'page[number]'
+    'page[number]',
+    'subgroup'
   ];
 
   // check that only the filter categories, museum or gallery are selected
@@ -50,7 +51,6 @@ const nameFromFilter = function (selectedFilters) {
       const filterType = filterKeys.filter(
         (k) => k !== '' && k !== 'search' && k !== 'type'
       );
-
       if (filterType.length > 0) {
         const firstFilterType = filterType[0];
         const museum =
@@ -134,11 +134,29 @@ function handleFilter (filterType, filterValue) {
   return '';
 }
 
-module.exports = function (q, selectedFilters) {
+// titles by search tab (without filters)
+function defaultText (type) {
+  switch (type) {
+    case 'people':
+      return 'People and Companies';
+    case 'documents':
+      return 'Documents and Archives';
+
+    case 'objects':
+      return 'Objects';
+
+    case 'group':
+      return 'Explore objects by topic';
+
+    default:
+      return 'Search our collection';
+  }
+}
+module.exports = function (q, selectedFilters, type) {
   const name = nameFromFilter(selectedFilters);
   if (!q && name) {
     return name + '| Science Museum Group Collection'; // if no search specified and a name is defined
   }
 
-  return 'Search our collection | Science Museum Group Collection'; // default
+  return `${defaultText(type)} | Science Museum Group Collection`; // default (by search tab)
 };

--- a/lib/transforms/search-results-to-template-data.js
+++ b/lib/transforms/search-results-to-template-data.js
@@ -77,7 +77,7 @@ module.exports = (queryParams, results, config) => {
   const inProduction = Boolean(results.inProduction);
   const data = {
     title: 'Search our collection | Science Museum Group Collection',
-    titlePage: getTitlePage(queryParams.q, selectedFilters),
+    titlePage: getTitlePage(queryParams.q, selectedFilters, queryParams.type),
     page: results.data.length ? queryParams.pageType : 'noresults',
     q: queryParams.q,
     results: results.data.map(createResult),

--- a/templates/pages/person.html
+++ b/templates/pages/person.html
@@ -19,10 +19,12 @@
 
           {{#if related.people}}{{> records/record-related-people }}{{/if}}
           {{#if related.organisations}}{{> records/record-related-organisations }}{{/if}}
+
+          {{#unless inProduction}}
           {{#if wikidata}}
           <div id="wikiInfo" data-name="{{wikidata}}" style="margin-top: 1em"></div>
           {{/if}}
-
+          {{/unless}}
         </aside>
       </div>
     </section>


### PR DESCRIPTION
From [this ticket](https://github.com/TheScienceMuseum/collectionsonline/issues/1175) 

There were a few suggestions in the ticket that I couldn't do - i.e text for Documents - archive + makers, as Documents don't have those filters in the filterlist. Also, archives aren't included in the title pages, as this was discussed previously and decided to not include (I assume due to long field names). Similar with dates, we decided not to include in titles.