### PR TITLE
feat: fix fuzzy images for 2 or less child records

### DIFF
--- a/client/templates.js
+++ b/client/templates.js
@@ -492,6 +492,11 @@ Handlebars.registerHelper(
   require('../templates/helpers/isWikiList.js')
 );
 
+Handlebars.registerHelper(
+  'twoChildRecords',
+  require('../templates/helpers/twoChildRecords.js')
+);
+
 Handlebars.registerPartial(
   'records/record-sph-images',
   Fs.readFileSync('./templates/partials/records/record-sph-images.html', 'utf8')

--- a/templates/helpers/twoChildRecords.js
+++ b/templates/helpers/twoChildRecords.js
@@ -1,0 +1,8 @@
+module.exports = (childRecords) => {
+  if (!childRecords) {
+    return;
+  }
+  const twoRecords = childRecords.length <= 2;
+
+  return twoRecords;
+};

--- a/templates/partials/records/record-mph-records.html
+++ b/templates/partials/records/record-mph-records.html
@@ -7,8 +7,14 @@
 
         <figure class="resultcard__figure">
           {{#if images}}
+          {{#if (twoChildRecords ../childRecords)}}
+          <img src="{{firstImage images 0 'large' }}" class="" alt="{{title}}" />
+
+          {{else}}
           <img src="{{firstImage images 0 'card' }}" class="" alt="{{title}}" />
           {{/if }}
+          {{/if }}
+
         </figure>
 
         <div class="resultcard__info">


### PR DESCRIPTION
Fixed fuzzy images for records with two or less child records, using larger images. Ticket #1864 