### PR TITLE
Fix cache lifecycle leak causing Node.js CPU saturation and 4xx failures

### DIFF
--- a/bin/server.mjs
+++ b/bin/server.mjs
@@ -4,6 +4,7 @@ const require = createRequire(import.meta.url);
 
 const config = require('../config');
 const createServer = require('../server');
+const cache = require('./cache');
 
 const elastic = new Client(config.elasticsearch);
 
@@ -21,5 +22,16 @@ createServer(elastic, config, async (err, ctx) => {
   } catch (err) {
     console.log(err);
     throw err;
+  }
+
+  // Start the shared cache client once at startup.
+  // All cache lib modules (cached-article, cached-feed, cached-wikidata,
+  // cached-document) rely on this single connection — they must NOT call
+  // cache.start() / cache.stop() themselves.
+  try {
+    await cache.start();
+    console.log('Cache started, connected:', cache.isReady());
+  } catch (err) {
+    console.warn('Cache unavailable at startup, running without cache:', err.message);
   }
 });

--- a/lib/cached-article.js
+++ b/lib/cached-article.js
@@ -1,18 +1,8 @@
 const cache = require('../bin/cache.js');
+
 module.exports = async (endpoint) => {
   try {
-    // to handle different envs where might not be a redis server, i.e. Travis
-
-    if (!cache) {
-      console.debug('There is no cache.');
-      return null;
-    }
-
-    await cache.start();
-
-    // to handle different envs where might not be a redis server, i.e. Travis
-    if (!cache.isReady()) {
-      console.debug('Cache is not connected.');
+    if (!cache || !cache.isReady()) {
       return null;
     }
 
@@ -21,17 +11,14 @@ module.exports = async (endpoint) => {
       segment: 'feed',
       id: url
     });
+
     if (cached) {
-      await cache.stop();
       return cached.item;
     }
 
-    await cache.stop();
     return null;
   } catch (err) {
-    await cache.stop();
-    // ToDo: Explicitly catch errors related to cache.start (and no redis Server) with Boom to reducxe noise in logs
-    // console.debug('An error occurred while accessing the cache');
-    throw err;
+    // Swallow cache errors — caller falls back to live fetch
+    return null;
   }
 };

--- a/lib/cached-document.js
+++ b/lib/cached-document.js
@@ -6,86 +6,24 @@ const getPrimaryValue = require('./get-primary-value');
 // Constants for cache configuration
 const CACHE_SEGMENT = 'documents';
 const CACHE_TTL = 100000000; // Cache time-to-live in milliseconds
-const REDIS_CONNECTION_ERRORS = [
-  'ECONNREFUSED',
-  'ETIMEDOUT',
-  'ENOTFOUND',
-  'ECONNRESET',
-  'Connection is closed'
-];
 
 module.exports = async (elastic, id, fondsId) => {
-  let cacheActive = true;
-
-  try {
-    // Attempt to start cache with timeout
-    await startCacheWithTimeout();
-
-    // Try to get from cache
-    const cached = await getFromCache(fondsId);
-    if (cached) {
-      return cached.item;
-    }
-
-    // Fall back to direct Elastic search if cache fails
-    return await getDataDirectly(elastic, id, fondsId);
-  } catch (err) {
-    if (isRedisConnectionError(err)) {
-      console.warn('Redis connection failed, falling back to direct Elastic search', {
-        error: err.message,
-        fondsId,
-        stack: err.stack // Add stack for debugging
-      });
-      cacheActive = false;
-      // Ensure cache is properly stopped
-      try {
-        await cache.stop();
-      } catch (stopErr) {
-        console.error('Failed to stop cache after error', stopErr);
-      }
-      return await getDataDirectly(elastic, id, fondsId);
-    }
-  } finally {
-    if (cacheActive) {
-      try {
-        await cache.stop();
-      } catch (stopErr) {
-        console.error('Failed to stop cache connection', {
-          error: stopErr.message
-        });
-      }
-    }
+  // Try to get from cache
+  const cached = await getFromCache(fondsId);
+  if (cached) {
+    return cached.item;
   }
 
-  async function startCacheWithTimeout () {
-    try {
-      await Promise.race([
-        cache.start(),
-        new Promise((_resolve, reject) =>
-          setTimeout(() => reject(new Error('Redis connection timeout')), 5000)
-        )
-      ]);
-    } catch (err) {
-      console.warn('Cache initialization failed', {
-        error: err.message,
-        fondsId
-      });
-      cacheActive = false;
-      throw err;
-    }
-  }
+  // Fall back to direct Elasticsearch query
+  return await getDataDirectly(elastic, id, fondsId);
 
   async function getFromCache (fondsId) {
-    if (!cacheActive) return null;
+    if (!cache || !cache.isReady()) return null;
 
     try {
       return await cache.get({ segment: CACHE_SEGMENT, id: fondsId });
     } catch (err) {
-      console.warn('Cache get operation failed', {
-        error: err.message,
-        fondsId
-      });
-      cacheActive = false;
+      console.warn('Cache get operation failed', { error: err.message, fondsId });
       return null;
     }
   }
@@ -94,15 +32,10 @@ module.exports = async (elastic, id, fondsId) => {
     const data = await getFullArchive(elastic, id);
     const tree = archiveTree.sortChildren(data);
 
-    if (cacheActive) {
-      try {
-        await cacheDocument(fondsId, tree);
-      } catch (err) {
-        console.warn('Failed to cache document', {
-          error: err.message,
-          fondsId
-        });
-      }
+    try {
+      await cacheDocument(fondsId, tree);
+    } catch (err) {
+      console.warn('Failed to cache document', { error: err.message, fondsId });
     }
 
     return tree;
@@ -149,28 +82,12 @@ async function getFullArchive (elastic, id) {
 }
 
 async function cacheDocument (id, data) {
+  if (!cache || !cache.isReady()) return;
+
   try {
     await cache.set({ segment: CACHE_SEGMENT, id }, data, CACHE_TTL);
-    console.debug('Successfully cached document', { documentId: id });
   } catch (err) {
-    console.error('Failed to cache document', {
-      error: err.message,
-      documentId: id
-    });
+    console.error('Failed to cache document', { error: err.message, documentId: id });
     throw err;
-  } finally {
-    try {
-      await cache.stop();
-    } catch (err) {
-      console.error('Failed to stop cache after caching document', {
-        error: err.message
-      });
-    }
   }
-}
-
-function isRedisConnectionError (err) {
-  return REDIS_CONNECTION_ERRORS.includes(err.code) ||
-         err.message.includes('Redis') ||
-         err.message.includes('connection');
 }

--- a/lib/cached-feed.js
+++ b/lib/cached-feed.js
@@ -1,48 +1,52 @@
 const cache = require('../bin/cache.js');
 const fetch = require('fetch-ponyfill')().fetch;
+
+// Deduplicates concurrent fetches for the same URL.
+// If a fetch is already in flight, callers await the same promise
+// rather than each firing their own outbound HTTP request.
+const inFlight = new Map();
+
 // Function to fetch and cache data from an endpoint
 exports.fetchAndCacheEndpoint = async function (endpoint) {
-  try {
-    const response = await fetch(endpoint.url, {
-      timeout: 200000,
-      headers: { 'User-Agent': 'SMG Collection Site 1.0' }
-    });
-    const data = await response.json();
-    await cacheEndpoints(cache, endpoint, data);
-    console.log(`Successfully cached ${endpoint.label}`);
-    return data;
-  } catch (err) {
-    console.error(`Failed to cache ${endpoint.label}:`, err);
-  }
+  const existing = inFlight.get(endpoint.url);
+  if (existing) return existing;
+
+  const promise = (async () => {
+    try {
+      const response = await fetch(endpoint.url, {
+        timeout: 8000,
+        headers: { 'User-Agent': 'SMG Collection Site 1.0' }
+      });
+      const data = await response.json();
+      await cacheEndpoints(cache, endpoint, data);
+      return data;
+    } catch (err) {
+      console.error(`Failed to fetch ${endpoint.label}:`, err.message);
+      return null;
+    } finally {
+      inFlight.delete(endpoint.url);
+    }
+  })();
+
+  inFlight.set(endpoint.url, promise);
+  return promise;
 };
 
 // Function to cache data in the cache
-
 async function cacheEndpoints (cache, endpoint, data) {
   try {
-    if (!cache) {
-      console.debug('There is no cache.');
-      return;
-    }
-
-    await cache.start();
-
-    if (!cache.isReady()) {
-      console.debug('Cache is not connected.');
+    if (!cache || !cache.isReady()) {
       return;
     }
     const url = endpoint.url;
     const cached = await cache.get({ segment: 'feed', id: url });
 
     if (cached) {
-      console.log('cleared cache');
       await cache.drop({ segment: 'feed', id: url });
     }
     await cache.set({ segment: 'feed', id: url }, data, 86400000);
-    console.log('Feed successfully cached');
+    console.log(`Successfully cached ${endpoint.label}`);
   } catch (err) {
-    console.debug("Couldn't cache item:", err);
-  } finally {
-    await cache.stop();
+    console.error(`Couldn't cache ${endpoint.label}:`, err.message);
   }
 }

--- a/lib/cached-wikidata.js
+++ b/lib/cached-wikidata.js
@@ -1,51 +1,31 @@
 exports.fetchCache = async function (cache, qCode, clearCache = undefined) {
   try {
-    if (!cache) {
-      console.debug('There is no cache.');
-      return;
-    }
-
-    await cache.start();
-
-    if (!cache.isReady()) {
-      console.debug('Cache is not connected.');
-      return;
+    if (!cache || !cache.isReady()) {
+      return null;
     }
     const cached = await cache.get({ segment: 'wikidata', id: qCode });
     if (cached && clearCache !== undefined) {
       await cache.drop({ segment: 'wikidata', id: qCode });
-      console.log('cache has been cleared');
       return null;
     }
-
     return cached;
   } catch (err) {
-    console.debug("Couldn't cache item:", err);
-  } finally {
-    await cache.stop();
+    console.debug("Couldn't fetch from wikidata cache:", err.message);
+    return null;
   }
 };
 
 exports.setCache = async function (cache, qCode, data, clear = undefined) {
   try {
-    if (!cache) {
-      console.debug('There is no cache.');
-      return;
-    }
-    await cache.start();
-
-    if (!cache.isReady()) {
-      console.debug('Cache is not connected.');
-      return;
+    if (!cache || !cache.isReady()) {
+      return null;
     }
     if (!clear) {
       await cache.set({ segment: 'wikidata', id: qCode }, data, 2629746000);
-      console.log('wikidata successfully cached');
     }
     return null;
   } catch (err) {
-    console.debug("Couldn't cache item:", err);
-  } finally {
-    await cache.stop();
+    console.debug("Couldn't write to wikidata cache:", err.message);
+    return null;
   }
 };

--- a/lib/feeds.js
+++ b/lib/feeds.js
@@ -52,39 +52,28 @@ const endpoints = [
 async function fetchAndCacheEndpoint (endpoint) {
   try {
     const response = await fetch(endpoint.url, {
-      timeout: 10000,
+      timeout: 8000,
       headers: { 'User-Agent': 'SMG Collection Site 1.0' }
     });
 
     const data = await response.json();
     await cacheEndpoints(cache, endpoint, data);
-    console.log(`Successfully cached ${endpoint.label}`);
   } catch (err) {
-    console.error(`Failed to cache ${endpoint.label}:`, err);
+    console.error(`Failed to fetch ${endpoint.label}:`, err.message);
   }
 }
 
 // Function to cache data in the cache
 async function cacheEndpoints (cache, endpoint, data) {
   try {
-    if (!cache) {
-      console.error('Cache is not connected.');
-      return;
-    }
-
-    await cache.start();
-
-    if (!cache.isReady()) {
-      console.error('Cache is not connected.');
+    if (!cache || !cache.isReady()) {
       return;
     }
     const url = endpoint.url;
     await cache.set({ segment: 'feed', id: url }, data, 100000000);
-    console.log('Feed successfully cached');
+    console.log(`Feed successfully cached: ${endpoint.label}`);
   } catch (err) {
-    console.error("Couldn't cache item:", err);
-  } finally {
-    await cache.stop();
+    console.error("Couldn't cache item:", err.message);
   }
 }
 

--- a/routes/iiif.js
+++ b/routes/iiif.js
@@ -8,6 +8,11 @@ const cacheHeaders = require('./route-helpers/cache-control');
 const { promisify } = require('util');
 const setTimeoutPromise = promisify(setTimeout);
 
+// Pre-load the IIIF manifest template once at startup rather than on every request
+const iiifTemplate = Handlebars.compile(
+  fs.readFileSync(path.join(__dirname, '/../templates/iiif/iiifmanifest.json'), 'utf8')
+);
+
 module.exports = (elastic, config) => ({
   method: 'GET',
   path: '/iiif/{type}/{id}/{slug?}',
@@ -51,11 +56,7 @@ module.exports = (elastic, config) => ({
           });
         }
 
-        return h.response(
-          Handlebars.compile(
-            fs.readFileSync(path.join(__dirname, '/../templates/iiif/iiifmanifest.json'), 'utf8')
-          )(iiifData)
-        ).header('content-type', 'application/json');
+        return h.response(iiifTemplate(iiifData)).header('content-type', 'application/json');
       } catch (err) {
         request.log({
           tags: ['iiif', 'error'],


### PR DESCRIPTION
## Summary

Fixes a production issue on ElasticBeanstalk where Node.js CPU gradually reached 97–100% over several hours, eventually causing 100% HTTP 4xx response rates and instance lock-up.

**Root cause:** `cache.start()` / `cache.stop()` were called on every incoming request across all four cache modules. The shared `ioredis` client is a singleton, so concurrent start/stop cycles created a race condition that leaked ioredis reconnection retry timers on every failed connection attempt. Over hours these accumulated in Node's timer queue, saturating the event loop — confirmed by `TIME+` in `top` growing proportionally with uptime (16m CPU at 1h21m uptime → 53m CPU at 4h04m uptime).

A secondary effect: because `cache.isReady()` was always false during the race, `"Successfully cached X"` logs were misleading — data was never actually written to Redis. This meant every `/articles/{id}` request (triggered client-side on every object page load) made 10 concurrent outbound HTTP requests to external museum APIs with a 200-second timeout, piling up hundreds of open connections under production load.

## Changes

- **`bin/server.mjs`** — call `cache.start()` once at server startup with graceful fallback if Redis is unavailable
- **`lib/cached-article.js`** — remove `start()`/`stop()`; guard with `isReady()` only
- **`lib/cached-wikidata.js`** — same, for both `fetchCache` and `setCache`
- **`lib/cached-document.js`** — same; also removes the per-request 5s Redis connection timeout race, `cacheActive` flag, and `isRedisConnectionError` helper (all now unnecessary)
- **`lib/cached-feed.js`** — remove `start()`/`stop()`; add **in-flight request deduplication** so N concurrent requests for the same external URL share one outbound HTTP call; reduce fetch timeout 200s → 8s; fix misleading success log (now only fires after actual `cache.set()`)
- **`lib/feeds.js`** — same timeout and log fixes
- **`routes/iiif.js`** — compile the IIIF Handlebars template once at module load rather than calling `fs.readFileSync` on every IIIF request

## Test plan

- [x] All 576 unit tests pass (`npm run test:unit:tape`)
- [x] Dev server starts cleanly; `Cache started, connected: false` logged (expected without local Redis)
- [x] `/iiif/objects/co8862675` → 200 `application/json`
- [x] `/articles/co8862675` → 200 `{"data":[...]}`
- [x] No server errors in logs
- [ ] Deploy to staging and confirm `cache.isReady()` returns `true` once `ELASTICACHE_EP` env var is set
- [ ] Monitor `process._getActiveHandles().length` over time — should remain stable rather than growing