### PR TITLE
Show on-display location from child records on parent object pages

### DIFF
--- a/lib/transforms/get-values.js
+++ b/lib/transforms/get-values.js
@@ -101,6 +101,35 @@ module.exports = {
     return display.museum ? display : null;
   },
 
+  // Collects on-display locations from the parent record and all direct child records.
+  // Returns a deduplicated array of {museum, gallery, link} objects, or null if none found.
+  getDisplayLocations (data) {
+    const locations = [];
+    const seen = new Set();
+
+    const addIfNew = (loc) => {
+      if (!loc) return;
+      const key = loc.museum + '|' + (loc.gallery || '');
+      if (!seen.has(key)) {
+        seen.add(key);
+        locations.push(loc);
+      }
+    };
+
+    // Parent record location
+    addIfNew(this.getDisplayLocation(data));
+
+    // Direct children (WHOLE/PART / SPH records)
+    const children = data.children || [];
+    children.forEach((child) => {
+      if (child && child.data) {
+        addIfNew(this.getDisplayLocation(child.data));
+      }
+    });
+
+    return locations.length > 0 ? locations : null;
+  },
+
   getDocumentLevel (item) {
     if (item.type === 'documents') {
       return getNestedProperty(item, 'attributes.level.value') === 'fonds'

--- a/lib/transforms/json-ld.js
+++ b/lib/transforms/json-ld.js
@@ -50,14 +50,13 @@ module.exports = {
       '@type': getObjectType(resource.data)
     };
     let locationJSONLD = {};
-    if (getValues.getDisplayLocation(resource.data)) {
+    const displayLocations = getValues.getDisplayLocations(resource.data);
+    if (displayLocations) {
       locationJSONLD = {
-        contentLocation: [
-          {
-            '@type': 'Place',
-            name: getValues.getDisplayLocation(resource.data).museum
-          }
-        ]
+        contentLocation: displayLocations.map((loc) => ({
+          '@type': 'Place',
+          name: loc.museum
+        }))
       };
     }
     return JSON.stringify(

--- a/lib/transforms/json-to-html-data.js
+++ b/lib/transforms/json-to-html-data.js
@@ -21,7 +21,7 @@ module.exports = (resource) => {
   const aiRelated = getAIRelated(resource, type);
   const system = getValues.getSystem(resource.data);
   const description = getDescription(resource.data);
-  const displayLocation = getValues.getDisplayLocation(resource.data);
+  const displayLocation = getValues.getDisplayLocations(resource.data);
   const level = getValues.getDocumentLevel(resource.data);
   const date = getValues.getDate(resource.data);
   const parent = getParent(resource);
@@ -180,10 +180,12 @@ function getAudio (data) {
 }
 
 function formatDisplayLocation (location) {
-  if (location) {
-    const value = location.museum + ' : ' + location.gallery;
-    return { key: 'Display Location', value, link: location.link };
-  }
+  if (!location) return null;
+  // location is now an array; use first entry for the data layer
+  const first = Array.isArray(location) ? location[0] : location;
+  if (!first) return null;
+  const value = first.museum + (first.gallery ? ' : ' + first.gallery : '');
+  return { key: 'Display Location', value, link: first.link };
 }
 
 // use formatDisplayLocation instead

--- a/templates/partials/records/ondisplay.html
+++ b/templates/partials/records/ondisplay.html
@@ -2,7 +2,9 @@
   <!--<img class="bleed" src="/assets/img/example/locations/scimus.png">-->
   <div class="panel__text">
     <h2 class="panel__withicon">{{> global/icon i="room" }} On display</h2>
-    <p><a href="{{displayLocation.link}}">{{displayLocation.museum}}: {{displayLocation.gallery}} </a></p>
+    {{#each displayLocation}}
+    <p><a href="{{link}}">{{museum}}: {{gallery}}</a></p>
+    {{/each}}
     <p>
       If you are visiting to see this object, <a
         href="https://www.sciencemuseumgroup.org.uk/our-work/our-collection/ask-about-our-collection">please contact


### PR DESCRIPTION
## Summary

- For WHOLE/PART (SPH) parent records where the physical location is held on a child record (not the parent), the 'On display' panel was not shown at all — e.g. Rocket locomotive (`co26704`) and NeXT Computer (`co8094437`)
- Adds `getDisplayLocations()` to `get-values.js` which collects on-display locations from the parent record **and** all direct child records, deduplicating by museum+gallery
- The `ondisplay.html` partial now iterates over the array so multiple distinct locations are shown if present
- `json-ld.js` updated to also surface child locations in `contentLocation`
- Existing `getDisplayLocation()` (single-record, used by search results) is unchanged

## Examples

| Record | Before | After |
|--------|--------|-------|
| Babbage's Analytical Engine `co62245` | Science Museum: Mathematics: The Winton Gallery | Same (no change) |
| Rocket locomotive `co26704` | *(blank — parent has no facility)* | National Railway Museum: Great Hall |
| NeXT Computer `co8094437` | *(blank — parent has empty facility)* | Science Museum: Information Age Gallery |

## Test plan

- [x] Visit `/objects/co26704/rocket-locomotive` — 'On display' panel shows **National Railway Museum: Great Hall**
- [x] Visit `/objects/co8094437/next-computer` — 'On display' panel shows **Science Museum: Information Age Gallery**
- [x] Visit `/objects/co62245/babbages-analytical-engine-1834-1871-trial-model` — 'On display' panel still shows **Science Museum: Mathematics: The Winton Gallery** (regression check)
- [x] Visit an object with no on-display location — panel is not shown
- [x] Run unit tests: `npm run test:unit:tape`