### PR TITLE
Fix Wikidata fetch crashes, add 10s timeout and request deduplication

### DIFF
--- a/lib/wikidataQueries.js
+++ b/lib/wikidataQueries.js
@@ -61,9 +61,14 @@ function formatDate (data, qCode = undefined, key = undefined) {
 
 async function wikibaseCall (wikibaseEntities) {
   try {
-    const { entities } = await fetch(wikibaseEntities)
+    const result = await fetch(wikibaseEntities, { signal: AbortSignal.timeout(10000) })
       .then((response) => response.json())
-      .catch((error) => console.error('Fetch error:', error));
+      .catch((error) => {
+        console.error('Fetch error:', error);
+        return null;
+      });
+    if (!result) return undefined;
+    const { entities } = result;
     return entities;
   } catch (error) {
     console.error('Error configuring data', error);


### PR DESCRIPTION
## Summary

- **Fix crash bug in `wikibaseCall`**: `.catch()` was returning `void`, so `const { entities } = undefined` threw immediately. Changed to return `null` from catch and guard before destructuring.
- **Fix crash bug in `routes/wiki.js`**: Same `.catch()` void pattern on the top-level fetch.
- **Add 10s timeout** (`AbortSignal.timeout(10000)`) to all Wikidata API calls. Previously no timeout was set — OS-level `ETIMEDOUT` errors could take several minutes per call, blocking async contexts and accumulating pending timers under load.
- **Add `inFlight` deduplication** in `routes/wiki.js`: concurrent requests for the same uncached Wikidata ID now share a single fetch + process cycle, rather than each independently firing 50+ sub-calls to the Wikidata API.

## What was happening in production

```
Fetch error: TypeError: fetch failed [ETIMEDOUT]
Error configuring data TypeError: Cannot destructure property 'entities' of '(intermediate value)' as it is undefined
```

These errors were appearing in rapid bursts at the same timestamp, indicating many concurrent requests all hitting the same Wikidata connectivity problem simultaneously. Each concurrent request for the same ID was independently making 50+ outbound calls, multiplying the load.

## Test plan

- [x] 576/576 unit tests pass
- [x] Semistandard lint passes