### PR TITLE
Fix Wikidata sub-call crashes and add wikibaseCall deduplication

### DIFF
--- a/lib/wikidataQueries.js
+++ b/lib/wikidataQueries.js
@@ -59,20 +59,35 @@ function formatDate (data, qCode = undefined, key = undefined) {
   return isNaN(date.getTime()) ? null : date.toLocaleDateString('en-GB');
 }
 
+// Deduplicates concurrent fetches for the same Wikidata URL.
+// Multiple properties on a page can reference the same QCode, so without
+// this each reference fires its own outbound HTTP request simultaneously.
+const wbkInFlight = new Map();
+
 async function wikibaseCall (wikibaseEntities) {
-  try {
-    const result = await fetch(wikibaseEntities, { signal: AbortSignal.timeout(10000) })
-      .then((response) => response.json())
-      .catch((error) => {
-        console.error('Fetch error:', error);
-        return null;
-      });
-    if (!result) return undefined;
-    const { entities } = result;
-    return entities;
-  } catch (error) {
-    console.error('Error configuring data', error);
-  }
+  const existing = wbkInFlight.get(wikibaseEntities);
+  if (existing) return existing;
+
+  const promise = (async () => {
+    try {
+      const result = await fetch(wikibaseEntities, { signal: AbortSignal.timeout(10000) })
+        .then((response) => response.json())
+        .catch((error) => {
+          console.error('Fetch error:', error);
+          return null;
+        });
+      if (!result) return undefined;
+      const { entities } = result;
+      return entities;
+    } catch (error) {
+      console.error('Error configuring data', error);
+    } finally {
+      wbkInFlight.delete(wikibaseEntities);
+    }
+  })();
+
+  wbkInFlight.set(wikibaseEntities, promise);
+  return promise;
 }
 // utility function used in extractNestedQCodeData below
 async function configureNestedData (
@@ -92,7 +107,7 @@ async function configureNestedData (
 
     if (additionalDetails) {
       const entities = await wikibaseCall(additionalDetails);
-      const claimValue = entities[qCodeData]?.labels?.en?.value;
+      const claimValue = entities?.[qCodeData]?.labels?.en?.value;
       if (claimValue) {
         claimsValues = [...claimsValues, extract(claimValue)];
       }
@@ -201,7 +216,7 @@ module.exports = {
             'json'
           );
           entities = await wikibaseCall(companyDetails);
-          contextValue = entities[fieldId]?.labels?.en?.value;
+          contextValue = entities?.[fieldId]?.labels?.en?.value;
         } catch (error) {
           console.error(`Error configuring data for ${qualifier}:`, error);
         }
@@ -226,7 +241,7 @@ module.exports = {
         const companyEntities = await wikibaseCall(companyDetails);
 
         // find company label
-        company = companyEntities[qualifiersId]?.labels?.en?.value;
+        company = companyEntities?.[qualifiersId]?.labels?.en?.value;
 
         // position + company + dates as string
 


### PR DESCRIPTION
## Summary

Fixes three crash sites and adds request deduplication to `wikibaseCall`.

### Crash fixes (optional chaining)

When `wikibaseCall` returns `undefined` (e.g. Wikidata returns an HTML rate-limit page instead of JSON), three callers accessed properties without guarding for `undefined`:

| Location | Before | After |
|---|---|---|
| `configureNestedData` | `entities[qCodeData]?.labels` | `entities?.[qCodeData]?.labels` |
| `extraContext` (position) | `entities[fieldId]?.labels` | `entities?.[fieldId]?.labels` |
| `extraContext` (company) | `companyEntities[qualifiersId]?.labels` | `companyEntities?.[qualifiersId]?.labels` |

These produced the `TypeError: Cannot read properties of undefined` errors seen in the logs.

### wikibaseCall inFlight deduplication

Multiple properties on the same Wikidata page can reference the same QCode. Previously each reference fired its own concurrent HTTP request. Now concurrent calls for the same URL share one outbound fetch, reducing the number of simultaneous requests to the Wikidata API.

## Test plan

- [x] 594/594 unit tests pass
- [x] Semistandard lint passes on changed file