### PR TITLE
Move analytics Painless script to rescore block (~72x fewer invocations)

### DIFF
--- a/lib/search-weights.js
+++ b/lib/search-weights.js
@@ -1,22 +1,3 @@
-const config = require('../config');
-
-// Analytics boost: excluded in test so result ordering stays stable against fixtures
-const analyticsBoost = config.NODE_ENV === 'test'
-  ? []
-  : [{
-      script_score: {
-        script: {
-          source: `
-            if (doc.containsKey('enhancement.analytics.current.views') && !doc['enhancement.analytics.current.views'].empty) {
-              1 + (doc['enhancement.analytics.current.views'].value / 5.0)
-            } else {
-              1
-            }
-          `
-        }
-      }
-    }];
-
 module.exports = [{
   filter: {
     exists: { field: 'facility' }
@@ -89,4 +70,4 @@ module.exports = [{
     term: { 'category.value': 'NRM - Documents' }
   },
   weight: 0.8
-}].concat(analyticsBoost);
+}];

--- a/lib/search.js
+++ b/lib/search.js
@@ -1,3 +1,4 @@
+const config = require('../config');
 const createFilters = require('./facets/create-filters');
 const createFiltersAll = require('./facets/create-filter-all');
 const aggregationTotalCategories = require('./facets/aggs-total-categories');
@@ -260,6 +261,37 @@ module.exports = async (elastic, queryParams) => {
     searchOpts.body.post_filter,
     createPostFilter(queryParams, filters)
   );
+
+  // Move analytics Painless script to rescore so it only runs on the top 500
+  // results instead of all matched documents, reducing invocations by ~72×
+  if (config.NODE_ENV !== 'test' && !queryParams.random) {
+    searchOpts.body.rescore = {
+      window_size: 500,
+      query: {
+        rescore_query: {
+          function_score: {
+            functions: [{
+              script_score: {
+                script: {
+                  source: `
+                    if (doc.containsKey('enhancement.analytics.current.views') && !doc['enhancement.analytics.current.views'].empty) {
+                      1 + (doc['enhancement.analytics.current.views'].value / 5.0)
+                    } else {
+                      1
+                    }
+                  `
+                }
+              }
+            }],
+            boost_mode: 'replace'
+          }
+        },
+        score_mode: 'multiply',
+        query_weight: 1.0,
+        rescore_query_weight: 1.0
+      }
+    };
+  }
 
   try {
     return await elastic.search(searchOpts);


### PR DESCRIPTION
## Summary

- Slow logs showed browse queries (no `q`, `match_all`) taking 5+ seconds with 15k–36k hits
- Root cause: Painless `script_score` (analytics boost) was running on every matched document
- Fix: move the analytics script from `function_score` into a `rescore` block with `window_size: 500`

This reduces Painless invocations from ~36,000 to ~500 per query on large result sets — a **72× reduction** — while keeping the same formula (`1 + views/5.0`) and the same scoring behaviour for the top 500 results (10 pages at size 50).

The 13 native `weight` functions remain in `function_score` unchanged (they use bitset-cached filter queries and are very cheap).

## Changes

- `lib/search-weights.js` — remove `analyticsBoost` from exported array (moved to rescore in search.js)
- `lib/search.js` — add `rescore` block with analytics Painless script; excluded in test mode and random queries

## Test plan

- [x] All 594 unit tests pass (`npm run test:unit:tape`)
- [x] Lint passes (`semistandard`)
- [x] Verify popular items still surface on `/search?q=babbage` and `/search/categories/art`
- [x] Monitor ES slow logs after deployment — browse + date-filter queries should drop from ~5s to <1s