### PR TITLE
Fix analytics sort regression introduced by #1929

### DIFF
--- a/lib/search-weights.js
+++ b/lib/search-weights.js
@@ -1,3 +1,19 @@
+const config = require('../config');
+
+// Analytics boost: excluded in test so result ordering stays stable against fixtures.
+// Uses field_value_factor (native Java) instead of Painless script_score — same ordering,
+// no per-document script execution overhead.
+const analyticsBoost = config.NODE_ENV === 'test'
+  ? []
+  : [{
+      field_value_factor: {
+        field: 'enhancement.analytics.current.views',
+        factor: 0.2,
+        modifier: 'none',
+        missing: 1
+      }
+    }];
+
 module.exports = [{
   filter: {
     exists: { field: 'facility' }
@@ -70,4 +86,4 @@ module.exports = [{
     term: { 'category.value': 'NRM - Documents' }
   },
   weight: 0.8
-}];
+}].concat(analyticsBoost);

--- a/lib/search.js
+++ b/lib/search.js
@@ -1,4 +1,3 @@
-const config = require('../config');
 const createFilters = require('./facets/create-filters');
 const createFiltersAll = require('./facets/create-filter-all');
 const aggregationTotalCategories = require('./facets/aggs-total-categories');
@@ -261,37 +260,6 @@ module.exports = async (elastic, queryParams) => {
     searchOpts.body.post_filter,
     createPostFilter(queryParams, filters)
   );
-
-  // Move analytics Painless script to rescore so it only runs on the top 500
-  // results instead of all matched documents, reducing invocations by ~72×
-  if (config.NODE_ENV !== 'test' && !queryParams.random) {
-    searchOpts.body.rescore = {
-      window_size: 500,
-      query: {
-        rescore_query: {
-          function_score: {
-            functions: [{
-              script_score: {
-                script: {
-                  source: `
-                    if (doc.containsKey('enhancement.analytics.current.views') && !doc['enhancement.analytics.current.views'].empty) {
-                      1 + (doc['enhancement.analytics.current.views'].value / 5.0)
-                    } else {
-                      1
-                    }
-                  `
-                }
-              }
-            }],
-            boost_mode: 'replace'
-          }
-        },
-        score_mode: 'multiply',
-        query_weight: 1.0,
-        rescore_query_weight: 1.0
-      }
-    };
-  }
 
   try {
     return await elastic.search(searchOpts);


### PR DESCRIPTION
## Problem

PR #1929 moved the analytics `script_score` into a `rescore` block with `window_size: 500` to reduce Painless invocations. This caused a sort regression:

- The rescore picks the top 500 docs by **weight-function-only** score
- Many docs share identical weight scores (e.g. all with `multimedia` get weight `8`), so tie-breaking is arbitrary by doc ID
- High-view docs outside that arbitrary 500 never received their analytics boost
- Result: popular items no longer surfaced at the top

## Fix

Replace the Painless `script_score` with a native `field_value_factor` inside `function_score` (runs on **all** matched documents, same as before):

```js
field_value_factor: {
  field: 'enhancement.analytics.current.views',
  factor: 0.2,
  modifier: 'none',
  missing: 1
}
```

- `views * 0.2` vs `1 + views/5.0` — virtually identical ordering (difference of exactly `1.0` for any view count)
- `missing: 1` — docs without analytics data receive no boost, same as before
- Native Java implementation — no Painless JVM overhead, achieves the performance goal without the window-size limitation

## Test plan

- [x] `check-purchased.test.js` passes (ordering stable in test mode, analytics excluded via `NODE_ENV`)
- [x] Lint passes
- [x] Verify popular items surface correctly on `/search?q=babbage` and `/search/categories/objects`