### PR TITLE
Temporarily hide VIAF ID from wikidata panel

### DIFF
--- a/fixtures/wikibasePropertiesConfig.js
+++ b/fixtures/wikibasePropertiesConfig.js
@@ -74,6 +74,7 @@ module.exports = {
   Children: { property: 'P40', action: [display, nest, displayLinked] },
   Relatives: { property: 'P1038', action: [nest, display, displayLinked] },
   'Educated At': { property: 'P69', action: [nest, display] },
-  'Notable Work': { property: 'P800', action: [nest, display] },
-  'VIAF ID': { property: 'P214', action: [display, isExternalLink] }
+  'Notable Work': { property: 'P800', action: [nest, display] }
+  // 'VIAF ID': { property: 'P214', action: [display, isExternalLink] }
+
 };


### PR DESCRIPTION
Comments out the VIAF ID entry in `wikibasePropertiesConfig.js` so it is excluded from processing and no longer shown in the wikidata sidebar. Entry is commented rather than deleted so it can be easily re-enabled.