### PR TITLE
Improve search: identifier boosts, fuzzy title match, biography search, tighter description slop

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -93,6 +93,7 @@ module.exports = async (elastic, queryParams) => {
                   fields: [
                     'name.value',
                     'summary.title',
+                    'biography^0.4',
                     'creation.maker.summary.title',
                     'creation.place.summary.title'
                   ],
@@ -101,19 +102,22 @@ module.exports = async (elastic, queryParams) => {
                   minimum_should_match: '30%'
                 }
               },
+              // Exact identifier match (e.g. L2015-3409, MS/1924) — highest priority.
+              // Uses raw query (not escaped) to preserve dashes and slashes.
               {
                 match: {
                   'identifier.value': {
                     query: queryParams.q,
-                    boost: 250
+                    boost: 400
                   }
                 }
               },
+              // Partial identifier match via n-gram analyser — lower than exact title phrase.
               {
                 match: {
                   'identifier.value.ngram': {
                     query: queryParams.q,
-                    boost: 150
+                    boost: 120
                   }
                 }
               },
@@ -134,30 +138,34 @@ module.exports = async (elastic, queryParams) => {
                   }
                 }
               },
-              // {
-              //   match_phrase: {
-              //     'summary.title': {
-              //       query: queryParams.q,
-              //       slop: 10
-              //     }
-              //   }
-              // },
-              // {
-              //   match_phrase: {
-              //     'note.value': {
-              //       query: queryParams.q,
-              //       slop: 150,
-              //       boost: 2
-              //     }
-              //   }
-              // },
               {
                 match_phrase: {
                   'description.value': {
-                    query: queryParams.q,
-                    slop: 10,
+                    query: sanitizedQuery,
+                    slop: 3,
                     boost: 50
                   }
+                }
+              },
+              // Near-exact phrase match in biography — good signal for people records.
+              {
+                match_phrase: {
+                  biography: {
+                    query: sanitizedQuery,
+                    slop: 3,
+                    boost: 40
+                  }
+                }
+              },
+              // Fuzzy match on title and name — catches spelling errors.
+              // prefix_length 2 avoids spurious short-string matches.
+              {
+                multi_match: {
+                  query: sanitizedQuery,
+                  fields: ['summary.title', 'name.value'],
+                  fuzziness: 'AUTO',
+                  prefix_length: 2,
+                  boost: 0.8
                 }
               }
             ],


### PR DESCRIPTION
## Summary

- **Identifier matching**: Raise exact match boost 250 → 400 so identifiers like `L2015-3409`, `MS/1924` always rank first; lower ngram (partial) boost 150 → 120 so a partial identifier match ranks below an exact title phrase
- **Spelling tolerance**: Add fuzzy `multi_match` on `summary.title` and `name.value` (`fuzziness: AUTO`, `prefix_length: 2`) so spelling errors (e.g. "Babagge's Analytical Engine") still match
- **Biography as a searchable field**: Add `biography^0.4` to the base multi_match and a `match_phrase` on `biography` (slop 3, boost 40) — previously biography was only a function_score quality signal, not searched
- **Tighter description phrase match**: Reduce `description.value` phrase slop 10 → 3 for more precise near-exact phrase matching
- **Consistency**: Switch description and biography phrase queries from raw `queryParams.q` to `sanitizedQuery`; remove stale commented-out query blocks

`lib/search-weights.js` is unchanged — weights are well-calibrated.

## Test plan

- [ ] 601/601 unit tests passing (`npm run test:unit:tape`)
- [ ] Lint passing (`npm run test:lint`)
- [ ] Search for an identifier e.g. `L2015-3409` — exact record appears first
- [ ] Search with a spelling error e.g. `Babagge` — Babbage records still surface
- [ ] Search `analytical engine` on People tab — Charles Babbage scores well via biography
- [ ] Search `rocket locomotive` — locomotive object ranks above art depictions
- [ ] If live ES available: re-sync fixtures with `npm run test:unit` and confirm `search-accession-numbers.test.js` + `check-purchased.test.js` ordering still holds