### PR TITLE
Fix measurements not displaying on child/part records

### DIFF
--- a/lib/jsonapi-response.js
+++ b/lib/jsonapi-response.js
@@ -414,6 +414,7 @@ function getChildRecords (data, childRecordsArr, config) {
       if (match) {
         const {
           measurements,
+          component,
           description,
           material,
           title,
@@ -475,6 +476,7 @@ function getChildRecords (data, childRecordsArr, config) {
             attributes: {
               ...record,
               measurements,
+              component,
               description,
               material,
               name,

--- a/lib/transforms/json-to-html-data.js
+++ b/lib/transforms/json-to-html-data.js
@@ -530,6 +530,20 @@ function getMeasurements (data) {
       }
     });
   }
+
+  // fallback: use catalogue dimensions summary when no other measurements rendered
+  if (values.length === 0 && data.attributes.measurements && data.type === 'objects') {
+    if (data.attributes.measurements.dimensions) {
+      data.attributes.measurements.dimensions.forEach((el) => {
+        if (el.type === 'catalogue dimensions' && el.value) {
+          el.value.split('; ').forEach((part) => {
+            values.push(part + '<br>');
+          });
+        }
+      });
+    }
+  }
+
   return values.length ? { key: 'Measurements', value: values.join('') } : null;
 }
 


### PR DESCRIPTION
## Summary

Child records with non-"overall" part measured values (e.g. "open (max)", "closed", "one tape") were not displaying their measurements on the parent object page.

Examples:
- `/objects/co8457936/roy-ashtons-make-up-chest` — part 2000-5000/7/1 was missing "open (max): 320 mm x 480 mm x 800 mm, 111 kg" and "closed: 440 mm x 435 mm x 240 mm, 11.1 kg"
- `/objects/co427453/computer-tapes-used-for-recording-rainfall-1955-1965` — parts 1997-938/1 and 1997-938/2 were missing their measurements

## Root cause

The Elasticsearch data stores measurements in two formats depending on the part measured value:

1. **Records with part measured = "overall"** have a top-level `measurements.display` string (e.g. `"overall: 300 mm x 430 mm x 10 mm"`). The existing code handled this correctly.

2. **Records with other part measured values** (e.g. "open (max)", "closed", "one tape") do **not** have `measurements.display`. Instead, their measurement data is stored in either:
   - A `component` array with per-component `measurements.display` strings, OR
   - A `measurements.dimensions` entry with `type: "catalogue dimensions"` containing a pre-formatted summary value string (e.g. `"closed: 440 mm x 435 mm x 240 mm, 11.1 kg; open (max): 320 mm x 480 mm x 800 mm, 111 kg"`)

   Both of these paths were broken for child records:

   **a)** `getChildRecords()` in `jsonapi-response.js` was not extracting the `component` field from the ES source document, so component measurements were silently dropped for all child records.

   **b)** `getMeasurements()` in `json-to-html-data.js` only handled dimension entries with individual `dimension`/`units` fields (e.g. `{ dimension: "height", units: "mm", value: "320" }`). It did not handle the `catalogue dimensions` summary entries which have a different shape: `{ type: "catalogue dimensions", value: "closed: 440 mm x 435 mm x 240 mm, 11.1 kg" }`.

## Changes

- **`lib/jsonapi-response.js`** — Extract and pass through `component` from the ES source in `getChildRecords()`, so component-level measurements render on child record cards.
- **`lib/transforms/json-to-html-data.js`** — Add a fallback in `getMeasurements()` that uses `catalogue dimensions` summary entries when no other measurement data has been rendered. Semicolon-separated values are split onto separate lines.

## Test plan

- [x] All 608 unit tests pass
- [x] Linting passes
- [ ] Verify measurements display on child card for `/objects/co8457936/roy-ashtons-make-up-chest` (part 2000-5000/7/1)
- [x] Verify measurements display on child cards for `/objects/co427453/computer-tapes-used-for-recording-rainfall-1955-1965` (parts 1997-938/1 and 1997-938/2)
- [x] Verify existing "overall" measurements on other child records are unaffected