### PR TITLE
Fix forward slashes in filter values breaking URL path routing

### DIFF
--- a/lib/helpers/paramify.js
+++ b/lib/helpers/paramify.js
@@ -15,10 +15,10 @@ module.exports = function paramify (q) {
         paramString += '/' + 'rotational';
       } else if (typeof q[el] === 'object') {
         paramString += '/' + removeFilter(el) + '/' + q[el].reduce((acc, b, i) => {
-          return acc + (i !== 0 ? '+' : '') + b.split(' ').join('-');
+          return acc + (i !== 0 ? '+' : '') + b.split(' ').join('-').split('/').join('%252F');
         }, '');
       } else {
-        paramString += '/' + removeFilter(el) + '/' + q[el];
+        paramString += '/' + removeFilter(el) + '/' + String(q[el]).split('/').join('%252F');
       }
     }
   });

--- a/routes/route-helpers/parse-params.js
+++ b/routes/route-helpers/parse-params.js
@@ -36,9 +36,9 @@ module.exports = function (urlParams) {
           urlCats[i] = 'categories';
         }
         if (urlCats[i + 1] && urlCats[i + 1].indexOf('+') > -1) {
-          categories[urlCats[i]] = urlCats[i + 1].split('+');
+          categories[urlCats[i]] = urlCats[i + 1].split('+').map(v => v.replace(/%2[Ff]/g, '/'));
         } else if (urlCats[i] !== 'search') {
-          categories[urlCats[i]] = urlCats[i + 1];
+          categories[urlCats[i]] = urlCats[i + 1] && urlCats[i + 1].replace(/%2[Ff]/g, '/');
         }
       }
     }

--- a/test/paramify.test.js
+++ b/test/paramify.test.js
@@ -13,6 +13,20 @@ test(file + 'paramify transforms query', (t) => {
   t.end();
 });
 
+test(file + 'paramify double-encodes forward slashes in values as %252f', (t) => {
+  t.equal(
+    paramify({ collection: ['buckingham movie museum/john burgoyne-johnson collection'] }),
+    '/collection/buckingham-movie-museum%252fjohn-burgoyne-johnson-collection',
+    'forward slash in array value double-encoded as %252f (survives Hapi %25 decode)'
+  );
+  t.equal(
+    paramify({ collection: 'buckingham movie museum/john burgoyne-johnson collection' }),
+    '/collection/buckingham movie museum%252fjohn burgoyne-johnson collection',
+    'forward slash in single string value double-encoded as %252f'
+  );
+  t.end();
+});
+
 test(file + 'paramify encodes values with space-dash-space correctly', (t) => {
   t.equal(
     paramify({ object_type: ['box - container'] }),

--- a/test/parse-params.test.js
+++ b/test/parse-params.test.js
@@ -198,6 +198,20 @@ test('values with triple-dash (encoded space-dash-space)', function (t) {
   t.end();
 });
 
+test('filter values with %2f are decoded back to forward slash', function (t) {
+  t.deepEqual(
+    parseParameters({ filters: 'collection/buckingham-movie-museum%2fjohn-burgoyne-johnson-collection' }),
+    { params: { type: 'all' }, categories: { collection: 'Buckingham Movie Museum/john Burgoyne Johnson Collection' } },
+    '%2f in collection value decoded to / before title-casing'
+  );
+  t.deepEqual(
+    parseParameters({ filters: 'objects/object_type/camera-accessory%2fplate' }),
+    { params: { type: 'objects' }, categories: { object_type: 'camera-accessory/plate' } },
+    '%2f in excluded filter type value decoded to / (no title-casing)'
+  );
+  t.end();
+});
+
 test('categories with triple-dash are title-cased correctly (space-dash-space preserved)', function (t) {
   t.deepEqual(
     parseParameters({ filters: 'objects/categories/science---technology' }),


### PR DESCRIPTION
## Summary

- Filter values containing a literal `/` (e.g. `"buckingham movie museum/john burgoyne-johnson collection"`) were returning zero results because the slash became a URL path separator
- `paramify.js` now double-encodes `/` as `%252F` — Hapi 21 decodes `%25` → `%` leaving `%2f` as a literal string in `request.params`, so `split('/')` in `parse-params.js` no longer splits on it
- `parse-params.js` decodes the resulting `%2f` back to `/` before further processing

## Root cause detail

`%2F` (single-encoded) doesn't work because `@hapi/call`'s `Decode.decode()` fully decodes all percent-encoded chars in path params before the route handler runs — so `%2F` becomes a literal `/` and the split breaks as before. Double-encoding (`%252F` → Hapi decodes `%25` → `%`, leaving `%2f`) survives the decode step intact.

## Test plan

- [x] `/search/collection/buckingham-movie-museum%252fjohn-burgoyne-johnson-collection` → 50 results (19 pages) ✓
- [x] `/search/collection/tony-ray-jones-collection` → still works (no regression) ✓
- [x] `/search/categories/medical-glass-ware` → still works (no regression) ✓
- [x] 503/503 unit tests pass