### PR TITLE
Fix filter clear buttons broken after SPA navigation on all-type pages

### DIFF
--- a/client/lib/listeners/facets-states.js
+++ b/client/lib/listeners/facets-states.js
@@ -14,7 +14,8 @@ module.exports = {
     Place: 'close',
     User: 'close',
     Archive: 'close',
-    Image: 'close'
+    Image: 'close',
+    Material: 'close'
   },
   people: {
     Dates: 'close',

--- a/templates/partials/search/filters-all.html
+++ b/templates/partials/search/filters-all.html
@@ -1,15 +1,12 @@
 <!-- IMAGE -->
 {{#if (or filters.image_license.0.count filters.has_image.0.count)}}
-{{#if (or (activeFacet selectedFilters 'imageLicense') (activeFacet selectedFilters 'hasImage'))}}
-<fieldset class="filter filter--active filter--open" data-filter="Image">
+  {{#if (or (activeFacet selectedFilters 'imageLicense') (activeFacet selectedFilters 'hasImage'))}}
+  <div class="filter filter--active filter--open" data-filter="Image">
+    <a href="{{lookup links.clearFacet "filter[images]"}}" class="filter__name">Image</a>
   {{else}}
-  <fieldset class="filter filter--open" data-filter="Image">
-    {{/if}}
-    <a href="{{lookup links.clearFacet "filter[images]"}}" class="filter__name">
-      <legend>
-        Image
-      </legend>
-    </a>
+  <div class="filter filter--open" data-filter="Image">
+    <a href="{{lookup links.clearFacet "filter[images]"}}" class="filter__name">Image</a>
+  {{/if}}
     <div class="filter__options">
       <ul>
         {{#each filters.has_image}}
@@ -24,218 +21,165 @@
         {{/each}}
       </ul>
     </div>
-  </fieldset>
-  {{/if}}
+  </div>
+{{/if}}
 
-  <!-- CATEGGORY -->
-  {{#if filters.category.length}}
+<!-- CATEGORY -->
+{{#if filters.category.length}}
   {{#if (activeFacet selectedFilters 'categories')}}
-  <fieldset class="filter filter--open filter--active" data-filter="Category">
-    <a href="{{lookup links.clearFacet "filter[categories]"}}" class="filter__name">
-      <legend>
-        Category
-      </legend>
-    </a>
-    {{else}}
-    <fieldset class="filter filter--open" data-filter="Category">
-      <a href="" class="filter__name">
-        <legend>
-          Category
-        </legend>
-      </a>
-      {{/if}}
-      <div class="filter__options">
-        <ul>
-          {{#each filters.category}}
-          <li><label><input type="checkbox" class="filter__box" name="filter[categories]" value="{{value}}" {{isselected
-                ../selectedFilters "categories" value}} />{{value}}<span class="filter__count">{{formatnumber
-                count}}</span></label></li>
-          {{/each}}
-        </ul>
-      </div>
-    </fieldset>
-    {{/if}}
+  <div class="filter filter--open filter--active" data-filter="Category">
+    <a href="{{lookup links.clearFacet "filter[categories]"}}" class="filter__name">Category</a>
+  {{else}}
+  <div class="filter filter--open" data-filter="Category">
+    <a href="" class="filter__name">Category</a>
+  {{/if}}
+    <div class="filter__options">
+      <ul>
+        {{#each filters.category}}
+        <li><label><input type="checkbox" class="filter__box" name="filter[categories]" value="{{value}}" {{isselected
+              ../selectedFilters "categories" value}} />{{value}}<span class="filter__count">{{formatnumber
+              count}}</span></label></li>
+        {{/each}}
+      </ul>
+    </div>
+  </div>
+{{/if}}
 
-    <!-- COLLECTION -->
-    {{#if filters.collection.length}}
-    {{#if (activeFacet selectedFilters 'collection')}}
-    <fieldset class="filter filter--open filter--active" data-filter="Collection">
-      <a href="{{lookup links.clearFacet "filter[collection]"}}" class="filter__name">
-        <legend>
-          Collection
-        </legend>
-      </a>
-      {{else}}
-      <fieldset class="filter filter--open" data-filter="Collection">
-        <a href="" class="filter__name">
-          <legend>
-            Collection
-          </legend>
-        </a>
-        {{/if}}
-        <div class="filter__options">
-          <ul>
-            {{#each filters.collection}}
-            <li><label><input type="checkbox" class="filter__box" name="filter[collection]" value="{{value}}"
-                  {{isselected ../selectedFilters "collection" value}} />{{value}}<span
-                  class="filter__count">{{formatnumber count}}</span></label></li>
+<!-- COLLECTION -->
+{{#if filters.collection.length}}
+  {{#if (activeFacet selectedFilters 'collection')}}
+  <div class="filter filter--open filter--active" data-filter="Collection">
+    <a href="{{lookup links.clearFacet "filter[collection]"}}" class="filter__name">Collection</a>
+  {{else}}
+  <div class="filter filter--open" data-filter="Collection">
+    <a href="" class="filter__name">Collection</a>
+  {{/if}}
+    <div class="filter__options">
+      <ul>
+        {{#each filters.collection}}
+        <li><label><input type="checkbox" class="filter__box" name="filter[collection]" value="{{value}}"
+              {{isselected ../selectedFilters "collection" value}} />{{value}}<span
+              class="filter__count">{{formatnumber count}}</span></label></li>
+        {{/each}}
+      </ul>
+    </div>
+  </div>
+{{/if}}
+
+<!-- ON DISPLAY: MUSEUM -->
+{{#if filters.museum.length}}
+  {{#if (activeFacet selectedFilters 'museum')}}
+  <div class="filter filter--active filter--open" data-filter="Museum">
+    <a href="{{lookup links.clearFacet "filter[museum]"}}" class="filter__name">On Display</a>
+  {{else}}
+  <div class="filter filter--open" data-filter="Museum">
+    <a href="{{lookup links.clearFacet "filter[museum]"}}" class="filter__name">On Display</a>
+  {{/if}}
+    <div class="filter__options">
+      <ul>
+        {{#each filters.museum}}
+        <li><label><input type="checkbox" class="filter__box filter__museum__{{classname value}}"
+              name="filter[museum]" value="{{value}}" {{isselected ../selectedFilters "museum" value
+              galleries}} />{{displayValue}}<span class="filter__count">{{formatnumber count}}</span></label></li>
+        <li>
+          <ul class="nested-galleries">
+            {{#each galleries}}
+            <li><label><input type="checkbox" class="filter__box filter__gallery__{{classname ../value}}"
+                  name="filter[gallery]" value="{{key}}" {{isselected ../../selectedFilters "gallery"
+                  key}} />{{key}}<span class="filter__count">{{doc_count}}</span></label></li>
             {{/each}}
           </ul>
-        </div>
-      </fieldset>
-      {{/if}}
+        </li>
+        {{/each}}
+      </ul>
+    </div>
+  </div>
+{{/if}}
 
-      <!-- ON DISPLAY: MUSEUM -->
-      {{#if filters.museum.length}}
-      {{#if (activeFacet selectedFilters 'museum')}}
-      <fieldset class="filter filter--active filter--open" data-filter="Museum">
-        <a href="{{lookup links.clearFacet "filter[museum]"}}" class="filter__name">
-          <legend>
-            On Display
-          </legend>
-        </a>
-        {{else}}
-        <fieldset class="filter filter--open" data-filter="Museum">
-          <a href="{{lookup links.clearFacet "filter[museum]"}}" class="filter__name">
-            <legend>
-              On Display
-            </legend>
-          </a>
-          {{/if}}
-          <div class="filter__options">
-            <ul>
-              {{#each filters.museum}}
-              <li><label><input type="checkbox" class="filter__box filter__museum__{{classname value}}"
-                    name="filter[museum]" value="{{value}}" {{isselected ../selectedFilters "museum" value
-                    galleries}} />{{displayValue}}<span class="filter__count">{{formatnumber count}}</span></label></li>
-              <li>
-                <ul class="nested-galleries">
-                  {{#each galleries}}
-                  <li><label><input type="checkbox" class="filter__box filter__gallery__{{classname ../value}}"
-                        name="filter[gallery]" value="{{key}}" {{isselected ../../selectedFilters "gallery"
-                        key}} />{{key}}<span class="filter__count">{{doc_count}}</span></label></li>
-                  {{/each}}
-                </ul>
-              </li>
-              {{/each}}
-            </ul>
-          </div>
-        </fieldset>
-        {{/if}}
+<!-- TYPE -->
+{{#if filters.object_type.length}}
+  {{#if (activeFacet selectedFilters 'object_type')}}
+  <div class="filter filter--open filter--active" data-filter="Type">
+    <a href="{{lookup links.clearFacet "filter[object_type]"}}" class="filter__name">Object type</a>
+  {{else}}
+  <div class="filter filter--open" data-filter="Type">
+    <a href="{{lookup links.clearFacet "filter[object_type]"}}" class="filter__name">Object type</a>
+  {{/if}}
+    <div class="filter__options">
+      <ul>
+        {{#each filters.object_type}}
+        <li><label><input type="checkbox" class="filter__box" name="filter[object_type]" value="{{value}}"
+              {{isselected ../selectedFilters "object_type" value}} />{{value}}<span
+              class="filter__count">{{formatnumber count}}</span></label></li>
+        {{/each}}
+      </ul>
+    </div>
+  </div>
+{{/if}}
 
-        <!-- TYPE -->
-        {{#if filters.object_type.length}}
-        {{#if (activeFacet selectedFilters 'object_type')}}
-        <fieldset class="filter filter--open filter--active" data-filter="Type">
-          <a href="{{lookup links.clearFacet "filter[object_type]"}}" class="filter__name">
-            <legend>
-              Object type
-            </legend>
-          </a>
-          {{else}}
-          <fieldset class="filter filter--open" data-filter="Type">
-            <a href="{{lookup links.clearFacet "filter[object_type]"}}" class="filter__name">
-              <legend>
-                Object type
-              </legend>
-            </a>
-            {{/if}}
-            <div class="filter__options">
-              <ul>
-                {{#each filters.object_type}}
-                <li><label><input type="checkbox" class="filter__box" name="filter[object_type]" value="{{value}}"
-                      {{isselected ../selectedFilters "object_type" value}} />{{value}}<span
-                      class="filter__count">{{formatnumber count}}</span></label></li>
-                {{/each}}
-              </ul>
-            </div>
-          </fieldset>
-          {{/if}}
+<!-- MATERIAL -->
+{{#if filters.material.length}}
+  {{#if (activeFacet selectedFilters 'material')}}
+  <div class="filter filter--active filter--open" data-filter="Material">
+    <a href="{{lookup links.clearFacet "filter[material]"}}" class="filter__name">Material</a>
+  {{else}}
+  <div class="filter filter--open" data-filter="Material">
+    <a href="{{lookup links.clearFacet "filter[material]"}}" class="filter__name">Material</a>
+  {{/if}}
+    <div class="filter__options">
+      <ul>
+        {{#each filters.material}}
+          <li><label><input type="checkbox" class="filter__box" name="filter[material]" value="{{value}}" {{isselected ../selectedFilters "material" value}}/>{{value}}<span class="filter__count">{{formatnumber count}}</span></label></li>
+        {{/each}}
+      </ul>
+    </div>
+  </div>
+{{/if}}
 
-          <!-- MATERIAL -->
-          {{#if filters.material.length}}
-            {{#if (activeFacet selectedFilters 'material')}}
-              <div class="filter filter--active filter--open" data-filter="Material">
-                <a href="{{lookup links.clearFacet "filter[material]"}}" class="filter__name">Material</a>
-            {{else}}
-              <div class="filter" data-filter="Material">
-                <a href="{{lookup links.clearFacet "filter[material]"}}" class="filter__name">Material</a>
-            {{/if}}
-              <div class="filter__options">
-                <ul>
-                  {{#each filters.material}}
-                    <li><label><input type="checkbox" class="filter__box" name="filter[material]" value="{{value}}" {{isselected ../selectedFilters "material" value}}/>{{value}}<span class="filter__count">{{formatnumber count}}</span></label></li>
-                  {{/each}}
-                </ul>
-              </div>
-            </div>
-          {{/if}}
+<!-- MAKER -->
+{{#if filters.maker.length}}
+  {{#if (activeFacet selectedFilters 'makers')}}
+  <div class="filter filter--open filter--active" data-filter="Maker">
+    <a href="{{lookup links.clearFacet "filter[makers]"}}" class="filter__name">Maker</a>
+  {{else}}
+  <div class="filter filter--open" data-filter="Maker">
+    <a href="{{lookup links.clearFacet "filter[makers]"}}" class="filter__name">Maker</a>
+  {{/if}}
+    <div class="filter__options">
+      <ul>
+        {{#each filters.maker}}
+        <li><label><input type="checkbox" class="filter__box" name="filter[makers]" value="{{value}}"
+              {{isselected ../selectedFilters "makers" value}} />{{value}}<span
+              class="filter__count">{{formatnumber count}}</span></label></li>
+        {{/each}}
+      </ul>
+    </div>
+  </div>
+{{/if}}
 
-          <!-- MAKER -->
-          {{#if filters.maker.length}}
-          {{#if (activeFacet selectedFilters 'makers')}}
-          <fieldset class="filter filter--open filter--active" data-filter="Maker">
-            <a href="{{lookup links.clearFacet "filter[makers]"}}" class="filter__name">
-              <legend>
-                Maker
-              </legend>
-            </a>
-            {{else}}
-            <fieldset class="filter filter--open" data-filter="Maker">
-              <a href="{{lookup links.clearFacet "filter[makers]"}}" class="filter__name">
-                <legend>
-                  Maker
-                </legend>
-              </a>
-              {{/if}}
-              <div class="filter__options">
-                <ul>
-                  {{#each filters.maker}}
-                  <li><label><input type="checkbox" class="filter__box" name="filter[makers]" value="{{value}}"
-                        {{isselected ../selectedFilters "makers" value}} />{{value}}<span
-                        class="filter__count">{{formatnumber count}}</span></label></li>
-                  {{/each}}
-                </ul>
-              </div>
-            </fieldset>
-            {{/if}}
+<!-- PLACE -->
+{{#if filters.place.length}}
+  {{#if (activeFacet selectedFilters 'places')}}
+  <div class="filter filter--active filter--open" data-filter="Place">
+    <a href="{{lookup links.clearFacet "filter[places]"}}" class="filter__name">Place of origin</a>
+  {{else}}
+  <div class="filter filter--open" data-filter="Place">
+    <a href="{{lookup links.clearFacet "filter[places]"}}" class="filter__name">Place of origin</a>
+  {{/if}}
+    <div class="filter__options">
+      <ul>
+        {{#each filters.place}}
+        <li><label><input type="checkbox" class="filter__box" name="filter[places]" value="{{value}}"
+              {{isselected ../selectedFilters "places" value}} />{{value}}<span
+              class="filter__count">{{formatnumber count}}</span></label></li>
+        {{/each}}
+      </ul>
+    </div>
+  </div>
+{{/if}}
 
-            <!-- PLACE -->
-            {{#if filters.place.length}}
-            {{#if (activeFacet selectedFilters 'places')}}
-            <fieldset class="filter filter--active filter--open" data-filter="Place">
-              <legend>
-                <a href="{{lookup links.clearFacet "filter[places]"}}" class="filter__name">
-                  <legend>
-
-                    Place of origin
-                  </legend>
-
-                </a>
-                {{else}}
-                <fieldset class="filter filter--open" data-filter="Place">
-                  <a href="{{lookup links.clearFacet "filter[places]"}}" class="filter__name">
-                    <legend>
-
-                      Place of origin
-                    </legend>
-
-                  </a>
-                  {{/if}}
-                  <div class="filter__options">
-                    <ul>
-                      {{#each filters.place}}
-                      <li><label><input type="checkbox" class="filter__box" name="filter[places]" value="{{value}}"
-                            {{isselected ../selectedFilters "places" value}} />{{value}}<span
-                            class="filter__count">{{formatnumber count}}</span></label></li>
-                      {{/each}}
-                    </ul>
-                  </div>
-                </fieldset>
-                {{/if}}
-
-                <!-- USER -->
-                <!-- {{#if filters.user.length}}
+<!-- USER -->
+<!-- {{#if filters.user.length}}
   {{#if (activeFacet selectedFilters 'user')}}
     <div class="filter filter--active filter--open" data-filter="User">
       <a href="{{lookup links.clearFacet "filter[user]"}}" class="filter__name">User</a>
@@ -253,49 +197,38 @@
   </div>
 {{/if}} -->
 
-                <!-- ARCHIVE -->
-                {{#if filters.archive.length}}
-                {{#if (activeFacet selectedFilters 'archive')}}
-                <fieldset class="filter filter--active filter--open" data-filter="Archive">
-                  <a href="{{lookup links.clearFacet "filter[archive]"}}" class="filter__name">Archive</a>
-                  {{else}}
-                  <fieldset class="filter filter--open" data-filter="Archive">
-                    <a href="{{lookup links.clearFacet "filter[archive]"}}" class="filter__name">
-                      <legend>
-                        Archive
-                      </legend>
+<!-- ARCHIVE -->
+{{#if filters.archive.length}}
+  {{#if (activeFacet selectedFilters 'archive')}}
+  <div class="filter filter--active filter--open" data-filter="Archive">
+    <a href="{{lookup links.clearFacet "filter[archive]"}}" class="filter__name">Archive</a>
+  {{else}}
+  <div class="filter filter--open" data-filter="Archive">
+    <a href="{{lookup links.clearFacet "filter[archive]"}}" class="filter__name">Archive</a>
+  {{/if}}
+    <div class="filter__options">
+      <ul>
+        {{#each filters.archive}}
+        <li><label><input type="checkbox" class="filter__box" name="filter[archive]" value="{{value}}"
+              {{isselected ../selectedFilters "archive" value}} />{{value}}<span
+              class="filter__count">{{formatnumber count}}</span></label></li>
+        {{/each}}
+      </ul>
+    </div>
+  </div>
+{{/if}}
 
-                    </a>
-                    {{/if}}
-                    <div class="filter__options">
-                      <ul>
-                        {{#each filters.archive}}
-                        <li><label><input type="checkbox" class="filter__box" name="filter[archive]" value="{{value}}"
-                              {{isselected ../selectedFilters "archive" value}} />{{value}}<span
-                              class="filter__count">{{formatnumber count}}</span></label></li>
-                        {{/each}}
-                      </ul>
-                    </div>
-                  </fieldset>
-                  {{/if}}
-
-                  <!-- DATE -->
-                  {{#if (or (lookup selectedFilters "date[from]") (lookup selectedFilters "date[to]"))}}
-                  <fieldset class="filter filter--active filter--open" data-filter="Dates">
-                    {{ else }}
-                    <fieldset class="filter filter--open" data-filter="Dates">
-                      {{/if}}
-                      <a href="{{lookup links.clearFacet "dates"}}" class="filter__name">
-                        <legend>
-                          Date
-                        </legend>
-
-
-                      </a>
-                      <div class="filter__options filter__daterange">
-                        <label>From year <input type="number" placeholder="e.g. 1600" name="filter[date[from]]"
-                            value="{{lookup selectedFilters "date[from]"}}" /></label>
-                        <label>To year <input type="number" placeholder="e.g. 2016" name="filter[date[to]]"
-                            value="{{lookup selectedFilters "date[to]"}}" /></label>
-                      </div>
-                    </fieldset>
+<!-- DATE -->
+{{#if (or (lookup selectedFilters "date[from]") (lookup selectedFilters "date[to]"))}}
+<div class="filter filter--active filter--open" data-filter="Dates">
+{{else}}
+<div class="filter filter--open" data-filter="Dates">
+{{/if}}
+  <a href="{{lookup links.clearFacet "dates"}}" class="filter__name">Date</a>
+  <div class="filter__options filter__daterange">
+    <label>From year <input type="number" placeholder="e.g. 1600" name="filter[date[from]]"
+        value="{{lookup selectedFilters "date[from]"}}" /></label>
+    <label>To year <input type="number" placeholder="e.g. 2016" name="filter[date[to]]"
+        value="{{lookup selectedFilters "date[to]"}}" /></label>
+  </div>
+</div>


### PR DESCRIPTION
## Summary

- **Bug 1 (intermittent filter clear)**: Filter × buttons worked on initial page load but failed after any SPA navigation (clearing a filter or selecting a checkbox value). Root cause: `filters-all.html` used `<fieldset>` + `<legend>` nested inside `<a>`, which is invalid HTML. The full-page parser and the `innerHTML` fragment parser handle it differently — the fragment parser hoists `<legend>` out of `<a>` to satisfy fieldset's content model, leaving the `<a>` empty. Clicking the visible label text then doesn't bubble through `<a>`, so the `deleteFiltersFacets` listener never fires. Fix: replace all `<fieldset>` + `<legend>` with `<div>` + plain text directly in `<a class="filter__name">`, matching the working pattern already used in `filters-objects.html`.

- **Bug 2 (Place of Origin missing header)**: Active Place of Origin filter showed no styled header. Root cause: an extra outer `<legend>` (without the `filter__name` class) was wrapping the `<a>`, so the active-header CSS (dark background, × icon) never applied to the visible text. Fixed automatically by the `<div>` conversion above.

- **Material state tracking**: Added `Material: 'close'` to `facetsStates.all` so `displayFacet` can properly manage the Material filter's open/close state on all-type pages (it was already tracked for objects-type pages but missing from the all section).

## Files changed

- `templates/partials/search/filters-all.html` — converted all `<fieldset>` + `<legend>` to `<div>` + plain text; removed extra `<legend>` wrapper on Place of origin active state; fixed Material non-active state to include `filter--open` class
- `client/lib/listeners/facets-states.js` — added `Material: 'close'` to `all` section

## Test plan

- [x] Navigate to `/search/collection/zoltan-glass-collection/makers/zoltan-glass` — clear Collection filter → should go to `/search/makers/zoltan-glass`
- [x] On that page, clear Maker filter → should go to `/search`
- [x] Navigate to a URL with a Place of Origin filter active (e.g. `/search/places/germany`) — confirm "Place of origin" header is visible with dark background and × icon
- [x] Add a type filter (e.g. `/search/collection/zoltan-glass-collection/makers/zoltan-glass/object_type/photograph`) then clear each active filter in turn — all should work
- [x] `npm run test:lint` passes