### PR TITLE
Fix TypeError when child record has empty title array

### DIFF
--- a/lib/jsonapi-response.js
+++ b/lib/jsonapi-response.js
@@ -429,7 +429,7 @@ function getChildRecords (data, childRecordsArr, config) {
 
         const id = match._source['@admin'].uid;
         const searchType = parentType === 'group' ? parentType : 'object';
-        const checkTitle = title ? title?.[0].value : summary?.title;
+        const checkTitle = title ? title?.[0]?.value : summary?.title;
         const links = {
           self: `${config.rootUrl}/objects/${id}/${slug(
             checkTitle


### PR DESCRIPTION
## Summary

- Crash in `lib/jsonapi-response.js` `getChildRecords()` when a child record has `title: []` (an empty array)
- `title ? title?.[0].value : summary?.title` — `[]` is truthy so it takes the first branch, `title[0]` returns `undefined`, and `undefined.value` throws `TypeError: Cannot read properties of undefined (reading 'value')`
- Fix: `title?.[0]?.value` — the added `?.` before `.value` short-circuits to `undefined` rather than throwing, falling through to `undefined || summary?.title` at runtime via `slug()`

## Root cause

This surfaces on any object page whose SPH/MPH children have an empty `title` array in the index. The error is caught by the route handler and returned as a 503.

## Test plan

- [x] Visit an object page with child records where at least one child has an empty title array — should render without error
- [x] Run unit tests: `npm run test:unit:tape`