### PR TITLE
Fix collection link on record pages not encoding forward slash

### DIFF
--- a/lib/transforms/json-to-html-data.js
+++ b/lib/transforms/json-to-html-data.js
@@ -433,7 +433,7 @@ function getCollection (data, links) {
       link:
         links.root +
         '/search/collection/' +
-        getValues.formatLink(values.toString())
+        getValues.formatLink(values.toString().split('/').join('%252F'))
     };
   } else {
     return null;

--- a/test/filter-links.test.js
+++ b/test/filter-links.test.js
@@ -145,3 +145,32 @@ test('bad date range test', (t) => {
   t.equal(made.date.link, 'http://localhost:8000/search/date[from]/1912/date[to]/1912', 'uses one date if only one is good');
   t.end();
 });
+
+test('collection link with forward slash in name encodes slash as %252F', (t) => {
+  t.plan(1);
+
+  const resource = {
+    data: {
+      type: 'objects',
+      attributes: {
+        cumulation: {
+          collector: [
+            { summary: { title: 'Buckingham Movie Museum/John Burgoyne-Johnson Collection' } }
+          ]
+        }
+      },
+      links: { root: 'http://localhost:8000' },
+      record: {}
+    },
+    included: []
+  };
+  const JSONData = JSONToHTML(resource);
+  const collection = JSONData.details.find(el => el && el.key === 'Collection');
+
+  t.equal(
+    collection.link,
+    'http://localhost:8000/search/collection/buckingham-movie-museum%252fjohn-burgoyne-johnson-collection',
+    'forward slash in collection name is double-encoded as %252F'
+  );
+  t.end();
+});


### PR DESCRIPTION
## Summary

- Follow-up to #1952: that PR fixed `paramify.js` (used for facet checkbox navigation) but missed a second code path in `json-to-html-data.js`
- `getCollection()` builds the \"Collection\" fact link on object detail pages using `getValues.formatLink()` directly — which only converts spaces→dashes and lowercases, it does **not** encode `/`
- For collection names like `"Buckingham Movie Museum/John Burgoyne-Johnson Collection"`, this produced an unencoded slash in the URL (`/search/collection/buckingham-movie-museum/john-burgoyne-johnson-collection`), causing `parse-params` to split on it and return zero results
- Fix: pre-encode `/` as `%252F` before passing to `formatLink`, matching the same double-encoding approach used in `paramify.js`

## Test plan

- [x] Object detail page for a record in the Buckingham Movie Museum/John Burgoyne-Johnson Collection now generates collection link as `…buckingham-movie-museum%252fjohn-burgoyne-johnson-collection` ✓
- [x] Navigating that link returns 933 results ✓
- [x] New unit test in `test/filter-links.test.js` covering the `%252F` encoding ✓
- [x] All existing tests pass ✓