### PR TITLE
Consolidate article feed endpoints into a single fixture

### DIFF
--- a/fixtures/article-endpoints.js
+++ b/fixtures/article-endpoints.js
@@ -1,0 +1,47 @@
+// Article feed endpoints on each museum website
+module.exports = [
+  {
+    label: 'National Science and Media Museum',
+    url: 'https://www.scienceandmediamuseum.org.uk/collection-media/collection-usage/objects'
+  },
+  {
+    label: 'Science and Industry Museum',
+    url: 'https://www.scienceandindustrymuseum.org.uk/collection-media/collection-usage/objects'
+  },
+  {
+    label: 'Science Museum',
+    url: 'https://www.sciencemuseum.org.uk/collection-media/collection-usage/objects'
+  },
+  {
+    label: 'Railway Museum',
+    url: 'https://www.railwaymuseum.org.uk/collection-media/collection-usage/objects'
+  },
+  {
+    label: 'Science Museum Blog',
+    url: 'https://blog.sciencemuseum.org.uk/wp-json/collection-media/collection-usage'
+  },
+  // {
+  //   label: 'Learning Resources',
+  //   url: 'https://learning.sciencemuseumgroup.org.uk/wp-json/collection-media/collection-usage'
+  // },
+  {
+    label: 'Railway Museum Blog',
+    url: 'https://blog.railwaymuseum.org.uk/wp-json/collection-media/collection-usage'
+  },
+  {
+    label: 'Science and Media Museum Blog',
+    url: 'https://blog.scienceandmediamuseum.org.uk/wp-json/collection-media/collection-usage'
+  },
+  {
+    label: 'Science and Industry Museum Blog',
+    url: 'https://blog.scienceandindustrymuseum.org.uk/wp-json/collection-media/collection-usage'
+  },
+  {
+    label: 'Science Museum Group',
+    url: 'https://www.sciencemuseumgroup.org.uk/collection-media/collection-usage/objects'
+  },
+  {
+    label: 'Science Museum Group Blog',
+    url: 'https://blog.sciencemuseumgroup.org.uk/wp-json/collection-media/collection-usage'
+  }
+];

--- a/lib/feeds.js
+++ b/lib/feeds.js
@@ -1,83 +1,8 @@
-const cache = require('../bin/cache.js');
+const { fetchAndCacheEndpoint } = require('./cached-feed.js');
+const endpoints = require('../fixtures/article-endpoints');
 
-// Article endpoints on each museum website
-const endpoints = [
-  {
-    label: 'National Science and Media Museum',
-    url: 'https://www.scienceandmediamuseum.org.uk/collection-media/collection-usage/objects'
-  },
-  {
-    label: 'Science and Industry Musem',
-    url: 'https://www.scienceandindustrymuseum.org.uk/collection-media/collection-usage/objects'
-  },
-  {
-    label: 'Science Museum',
-    url: 'https://www.sciencemuseum.org.uk/collection-media/collection-usage/objects'
-  },
-  {
-    label: 'Railway Museum',
-    url: 'https://www.railwaymuseum.org.uk/collection-media/collection-usage/objects'
-  },
-  {
-    label: 'Science Museum Blog',
-    url: 'https://blog.sciencemuseum.org.uk/wp-json/collection-media/collection-usage'
-  },
-  // {
-  //   label: 'Learning Resources',
-  //   url: 'https://learning.sciencemuseumgroup.org.uk/wp-json/collection-media/collection-usage'
-  // },
-  {
-    label: 'Railway Museum Blog',
-    url: 'https://blog.railwaymuseum.org.uk/wp-json/collection-media/collection-usage'
-  },
-  {
-    label: 'Science and Media Museum Blog',
-    url: 'https://blog.scienceandmediamuseum.org.uk/wp-json/collection-media/collection-usage'
-  },
-  {
-    label: 'Science and Industry Museum Blog',
-    url: 'https://blog.scienceandindustrymuseum.org.uk/wp-json/collection-media/collection-usage'
-  },
-  {
-    label: 'Science Museum Group',
-    url: 'https://www.sciencemuseumgroup.org.uk/collection-media/collection-usage/objects'
-  },
-  {
-    label: 'Science Museum Group Blog',
-    url: 'https://blog.sciencemuseumgroup.org.uk/wp-json/collection-media/collection-usage'
-  }
-];
-
-// Function to fetch and cache data from an endpoint
-async function fetchAndCacheEndpoint (endpoint) {
-  try {
-    const response = await fetch(endpoint.url, {
-      timeout: 8000,
-      headers: { 'User-Agent': 'SMG Collection Site 1.0' }
-    });
-
-    const data = await response.json();
-    await cacheEndpoints(cache, endpoint, data);
-  } catch (err) {
-    console.error(`Failed to fetch ${endpoint.label}:`, err.message);
-  }
-}
-
-// Function to cache data in the cache
-async function cacheEndpoints (cache, endpoint, data) {
-  try {
-    if (!cache || !cache.isReady()) {
-      return;
-    }
-    const url = endpoint.url;
-    await cache.set({ segment: 'feed', id: url }, data, 100000000);
-    console.log(`Feed successfully cached: ${endpoint.label}`);
-  } catch (err) {
-    console.error("Couldn't cache item:", err.message);
-  }
-}
-
-// Export a function to trigger caching for all endpoints
+// Pre-warm the feed cache for all endpoints at startup.
+// Runs sequentially to avoid triggering Cloudflare rate-limiting.
 module.exports = async () => {
   for (const endpoint of endpoints) {
     await fetchAndCacheEndpoint(endpoint);

--- a/routes/articles.js
+++ b/routes/articles.js
@@ -2,54 +2,7 @@ const Boom = require('@hapi/boom');
 const cacheHeaders = require('./route-helpers/cache-control');
 const getCachedArticles = require('../lib/cached-article');
 const { fetchAndCacheEndpoint } = require('../lib/cached-feed.js');
-
-// Article endpoints on each museum website
-const endpoints = [
-  {
-    label: 'National Science and Media Museum',
-    url: 'https://www.scienceandmediamuseum.org.uk/collection-media/collection-usage/objects'
-  },
-  {
-    label: 'Science and Industry Musem',
-    url: 'https://www.scienceandindustrymuseum.org.uk/collection-media/collection-usage/objects'
-  },
-  {
-    label: 'Science Museum',
-    url: 'https://www.sciencemuseum.org.uk/collection-media/collection-usage/objects'
-  },
-  {
-    label: 'Railway Museum',
-    url: 'https://www.railwaymuseum.org.uk/collection-media/collection-usage/objects'
-  },
-  {
-    label: 'Science Museum Blog',
-    url: 'https://blog.sciencemuseum.org.uk/wp-json/collection-media/collection-usage'
-  },
-  // {
-  //   label: 'Learning Resources',
-  //   url: 'https://learning.sciencemuseumgroup.org.uk/wp-json/collection-media/collection-usage'
-  // },
-  {
-    label: 'Railway Museum Blog',
-    url: 'https://blog.railwaymuseum.org.uk/wp-json/collection-media/collection-usage'
-  },
-  {
-    label: 'Science and Media Museum Blog',
-    url: 'https://blog.scienceandmediamuseum.org.uk/wp-json/collection-media/collection-usage'
-  },
-  {
-    label: 'Science and Industry Museum Blog',
-    url: 'https://blog.scienceandindustrymuseum.org.uk/wp-json/collection-media/collection-usage'
-  },
-  {
-    label: 'Science Museum Group',
-    url: 'https://www.sciencemuseumgroup.org.uk/collection-media/collection-usage/objects'
-  },
-  {
-    label: 'Science Museum Group Blog',
-    url: 'https://blog.sciencemuseumgroup.org.uk/wp-json/collection-media/collection-usage'
-  }
-];
+const endpoints = require('../fixtures/article-endpoints');
 
 // Either get the items from the endpoints, or the cache
 module.exports = (config) => ({

--- a/routes/feeds.js
+++ b/routes/feeds.js
@@ -2,54 +2,7 @@
 const Boom = require('@hapi/boom');
 const cacheHeaders = require('./route-helpers/cache-control');
 const { fetchAndCacheEndpoint } = require('../lib/cached-feed.js');
-
-// Article endpoints on each museum website
-const endpoints = [
-  {
-    label: 'National Science and Media Museum',
-    url: 'https://www.scienceandmediamuseum.org.uk/collection-media/collection-usage/objects'
-  },
-  {
-    label: 'Science and Industry Musem',
-    url: 'https://www.scienceandindustrymuseum.org.uk/collection-media/collection-usage/objects'
-  },
-  {
-    label: 'Science Museum',
-    url: 'https://www.sciencemuseum.org.uk/collection-media/collection-usage/objects'
-  },
-  {
-    label: 'Railway Museum',
-    url: 'https://www.railwaymuseum.org.uk/collection-media/collection-usage/objects'
-  },
-  {
-    label: 'Science Museum Blog',
-    url: 'https://blog.sciencemuseum.org.uk/wp-json/collection-media/collection-usage'
-  },
-  // {
-  //   label: 'Learning Resources',
-  //   url: 'https://learning.sciencemuseumgroup.org.uk/wp-json/collection-media/collection-usage'
-  // },
-  {
-    label: 'Railway Museum Blog',
-    url: 'https://blog.railwaymuseum.org.uk/wp-json/collection-media/collection-usage'
-  },
-  {
-    label: 'Science and Media Museum Blog',
-    url: 'https://blog.scienceandmediamuseum.org.uk/wp-json/collection-media/collection-usage'
-  },
-  {
-    label: 'Science and Industry Museum Blog',
-    url: 'https://blog.scienceandindustrymuseum.org.uk/wp-json/collection-media/collection-usage'
-  },
-  {
-    label: 'Science Museum Group',
-    url: 'https://www.sciencemuseumgroup.org.uk/collection-media/collection-usage/objects'
-  },
-  {
-    label: 'Science Museum Group Blog',
-    url: 'https://blog.sciencemuseumgroup.org.uk/wp-json/collection-media/collection-usage'
-  }
-];
+const endpoints = require('../fixtures/article-endpoints');
 module.exports = (config) => ({
   method: 'GET',
   path: '/feeds/refresh',


### PR DESCRIPTION
## Summary

- Moves the duplicated `endpoints` array (repeated identically in `routes/articles.js`, `routes/feeds.js`, and `lib/feeds.js`) into a single `fixtures/article-endpoints.js`
- Removes the duplicate `fetchAndCacheEndpoint` / `cacheEndpoints` implementation from `lib/feeds.js`, delegating to the canonical `lib/cached-feed.js` instead
- Fixes a typo: `"Science and Industry Musem"` → `"Science and Industry Museum"`

## Test plan

- [x] Server starts and all 10 endpoints are cached at startup (check logs for `Successfully cached ...`)
- [x] `/articles/{id}` route returns related articles as before
- [x] `/feeds/refresh` route successfully re-caches all endpoints