### PR TITLE
Fix maker filter broken for names containing commas

### DIFF
--- a/lib/query-params/format-value.js
+++ b/lib/query-params/format-value.js
@@ -8,7 +8,11 @@ const splitOnUnescapedCommas = require('../../client/lib/split-commas.js');
 module.exports = function (typeFormat, value) {
   if (value) {
     if (typeFormat === 'html') {
-      return typeof value === 'string' ? [value] : value;
+      const v = typeof value === 'string' ? [value] : value;
+      if (!Array.isArray(v)) return v;
+      return v.map(function (item) {
+        return typeof item === 'string' ? item.replace(/\\,/g, ',') : item;
+      });
     }
     if (typeFormat === 'json' && !Array.isArray(value)) {
       if (typeof value === 'number') {
@@ -18,6 +22,11 @@ module.exports = function (typeFormat, value) {
           return v.replace(/\\,/g, ',');
         });
       }
+    }
+    if (Array.isArray(value)) {
+      return value.map(function (item) {
+        return typeof item === 'string' ? item.replace(/\\,/g, ',') : item;
+      });
     }
     return value;
   } else {

--- a/lib/transforms/create-selected-filters.js
+++ b/lib/transforms/create-selected-filters.js
@@ -26,12 +26,14 @@ module.exports = function (queryParams) {
       selectedFilters[removeFilterString(el)] =
         selectedFilters[removeFilterString(el)] || {};
       params[el].forEach(function (e) {
-        selectedFilters[removeFilterString(el)][dashToSpace(e)] = true;
+        const unescaped = typeof e === 'string' ? e.replace(/\\,/g, ',') : e;
+        selectedFilters[removeFilterString(el)][dashToSpace(unescaped)] = true;
       });
     } else {
       selectedFilters[removeFilterString(el)] =
         selectedFilters[removeFilterString(el)] || {};
-      selectedFilters[removeFilterString(el)][params[el]] = true;
+      const unescaped = typeof params[el] === 'string' ? params[el].replace(/\\,/g, ',') : params[el];
+      selectedFilters[removeFilterString(el)][unescaped] = true;
     }
   });
 

--- a/routes/route-helpers/parse-params.js
+++ b/routes/route-helpers/parse-params.js
@@ -58,6 +58,15 @@ module.exports = function (urlParams) {
       categories[cat] = museumMap.toLong(categories[cat]);
     } else if (exclude.indexOf(cat) === -1) {
       categories[cat] = utils.uppercaseFirstChar(categories[cat]);
+      // Escape literal commas so they are not treated as value separators
+      // when the value is later processed by splitOnUnescapedCommas (JSON API format)
+      if (typeof categories[cat] === 'string') {
+        categories[cat] = categories[cat].replace(/,/g, '\\,');
+      } else if (Array.isArray(categories[cat])) {
+        categories[cat] = categories[cat].map(function (v) {
+          return typeof v === 'string' ? v.replace(/,/g, '\\,') : v;
+        });
+      }
     }
   }
   return { params, categories };

--- a/test/facets/create-filter-object.test.js
+++ b/test/facets/create-filter-object.test.js
@@ -5,6 +5,69 @@ const createQueryParams = require('../../lib/query-params/query-params');
 const dir = __dirname.split('/')[__dirname.split('/').length - 1];
 const file = dir + __filename.replace(__dirname, '') + ' > ';
 
+test(file + 'Maker filter with comma in name is not split when building ES query', (t) => {
+  // Simulates the value after parse-params + uppercaseFirstChar + comma escaping
+  // e.g. URL: /search/objects/makers/science-museum,-london -> 'Science Museum\\, London'
+  const query = { 'filter[makers]': 'Science Museum\\, London' };
+
+  const htmlQueryParams = createQueryParams('html', { query, params: { type: 'objects' } });
+  t.deepEqual(
+    htmlQueryParams.filter.objects.makers,
+    ['Science Museum, London'],
+    'HTML: maker name with escaped comma is unescaped to a single value'
+  );
+  const htmlFilters = createFilters(htmlQueryParams, 'object');
+  const makerFilter = htmlFilters.bool.filter.find((f) => f.terms && f.terms['creation.maker.summary.title.lower']);
+  t.ok(makerFilter, 'HTML: maker terms filter is present');
+  t.ok(
+    makerFilter.terms['creation.maker.summary.title.lower'].includes('science museum, london'),
+    'HTML: ES terms includes the full maker name with comma, not split parts'
+  );
+  t.notOk(
+    makerFilter.terms['creation.maker.summary.title.lower'].includes('science museum'),
+    'HTML: ES terms does not contain the incorrectly split first part'
+  );
+
+  const jsonQueryParams = createQueryParams('json', { query, params: { type: 'objects' } });
+  t.deepEqual(
+    jsonQueryParams.filter.objects.makers,
+    ['Science Museum, London'],
+    'JSON string input: maker name with escaped comma is unescaped to a single value'
+  );
+  const jsonFilters = createFilters(jsonQueryParams, 'object');
+  const jsonMakerFilter = jsonFilters.bool.filter.find((f) => f.terms && f.terms['creation.maker.summary.title.lower']);
+  t.ok(jsonMakerFilter, 'JSON string input: maker terms filter is present');
+  t.ok(
+    jsonMakerFilter.terms['creation.maker.summary.title.lower'].includes('science museum, london'),
+    'JSON string input: ES terms includes the full maker name with comma, not split parts'
+  );
+
+  // Simulates the route handler path: URL path categories go through filterSchema('html') resultSchema
+  // which uses Joi .single() to wrap the string into an array before createQueryParams is called.
+  // This is what actually happens when a JSON API client requests /search/objects/makers/science-museum,-london
+  const queryWithArray = { 'filter[makers]': ['Science Museum\\, London'] };
+  const jsonArrayQueryParams = createQueryParams('json', { query: queryWithArray, params: { type: 'objects' } });
+  t.deepEqual(
+    jsonArrayQueryParams.filter.objects.makers,
+    ['Science Museum, London'],
+    'JSON array input (URL path route): array with escaped comma is unescaped to a single value'
+  );
+  const jsonArrayFilters = createFilters(jsonArrayQueryParams, 'object');
+  const jsonArrayMakerFilter = jsonArrayFilters.bool.filter.find((f) => f.terms && f.terms['creation.maker.summary.title.lower']);
+  t.ok(jsonArrayMakerFilter, 'JSON array input: maker terms filter is present');
+  t.ok(
+    jsonArrayMakerFilter.terms['creation.maker.summary.title.lower'].includes('science museum, london'),
+    'JSON array input: ES terms includes the full maker name without backslash'
+  );
+  t.notOk(
+    jsonArrayMakerFilter.terms['creation.maker.summary.title.lower'].some((v) => v.includes('\\')),
+    'JSON array input: ES terms do not contain backslash characters'
+  );
+
+  t.plan(11);
+  t.end();
+});
+
 test(file + 'The filters date are included in the array filter', (t) => {
   const query = queryString.parse('q=ada&filter%5Bdate%5Bfrom%5D%5D=1800&page%5Bsize%5D=50');
   const queryParams = createQueryParams('html', { query, params: { type: 'objects' } });

--- a/test/parse-params.test.js
+++ b/test/parse-params.test.js
@@ -212,6 +212,25 @@ test('filter values with %2f are decoded back to forward slash', function (t) {
   t.end();
 });
 
+test('filter values with commas in names have commas escaped for safe JSON API use', function (t) {
+  t.deepEqual(
+    parseParameters({ filters: 'objects/makers/science-museum,-london' }),
+    { params: { type: 'objects' }, categories: { makers: 'Science Museum\\, London' } },
+    'maker name with comma is escaped as \\, to prevent splitting in JSON API format'
+  );
+  t.deepEqual(
+    parseParameters({ filters: 'objects/makers/ray-jones,-tony' }),
+    { params: { type: 'objects' }, categories: { makers: 'Ray Jones\\, Tony' } },
+    'person-style maker name with comma is escaped'
+  );
+  t.deepEqual(
+    parseParameters({ filters: 'objects/makers/science-museum,-london+rolls-royce' }),
+    { params: { type: 'objects' }, categories: { makers: ['Science Museum\\, London', 'Rolls Royce'] } },
+    'multiple makers: comma-containing name is escaped, plain name is unchanged'
+  );
+  t.end();
+});
+
 test('categories with triple-dash are title-cased correctly (space-dash-space preserved)', function (t) {
   t.deepEqual(
     parseParameters({ filters: 'objects/categories/science---technology' }),

--- a/test/search-objects-filters.test.js
+++ b/test/search-objects-filters.test.js
@@ -77,6 +77,25 @@ testWithServer(file + 'Should accept params in filter[PARAM_NAME] format for obj
   t.end();
 });
 
+testWithServer(file + 'Should handle maker filter with comma in name via URL path (HTML and JSON API)', {}, async (t, ctx) => {
+  t.plan(2);
+
+  const htmlRes = await ctx.server.inject({
+    method: 'GET',
+    url: '/search/objects/makers/science-museum,-london',
+    headers: { Accept: 'text/html' }
+  });
+  t.equal(htmlRes.statusCode, 200, 'HTML request for maker with comma in name returns 200');
+
+  const jsonRes = await ctx.server.inject({
+    method: 'GET',
+    url: '/search/objects/makers/science-museum,-london',
+    headers: { Accept: 'application/vnd.api+json' }
+  });
+  t.equal(jsonRes.statusCode, 200, 'JSON API request for maker with comma in name returns 200');
+  t.end();
+});
+
 testWithServer(file + 'Should handle object_type filter with space-dash-space values in URL', {}, async (t, ctx) => {
   t.plan(2);
 


### PR DESCRIPTION
## Summary

Closes #1803

Makers with commas in their name (e.g. "Science Museum, London", "Ray Jones, Tony") returned no results when navigating via SPA (JSON API path) because the comma was treated as a value separator.

Two separate bugs were identified and fixed:

**Bug 1:** In the JSON API path, `splitOnUnescapedCommas()` split the unescaped comma in `"Science Museum, London"` into two separate ES filter terms (`"Science Museum"` AND `"London"`), which must both match simultaneously — returning no results.

**Bug 2:** The route handler's `resultSchema` always validates URL-path categories through `filterSchema('html')`, which uses Joi `.single()` to convert the string into an array _before_ `createQueryParams` is called. When `formatValue('json', array)` received this pre-converted array it skipped both processing branches and returned the value unchanged, leaving a literal backslash in the ES query terms (e.g. `science museum\, london`).

## Changes

- **`routes/route-helpers/parse-params.js`** — escape literal commas as `\,` after `uppercaseFirstChar`, so `splitOnUnescapedCommas` treats the full name as a single token
- **`lib/query-params/format-value.js`** — unescape `\,` in the HTML path; add `Array.isArray()` guard to also unescape when the value has already been Joi-converted to an array (the JSON API + URL path combination that exposed bug #2)
- **`lib/transforms/create-selected-filters.js`** — unescape `\,` for display (page title, filter pills, checkbox state)

## Test plan

- [x] Unit tests: `npm run test:unit:tape` — all pass (654 tests)
- [x] Parse-params tests cover comma escaping for single maker, person-style name, and multi-value with comma-containing name
- [x] `create-filter-object` tests cover both string input (JSON API pure) and array input (URL path + JSON API) paths, verifying ES terms contain `science museum, london` without backslash
- [x] Server integration test covers HTML and JSON API requests to `/search/objects/makers/science-museum,-london` returning 200
- [x] Manually verify `/search/makers/science-museum,-london` returns results (6605 archive records with this maker confirmed in local index)