### PR TITLE
Fix TypeError when child record has no description

### DIFF
--- a/lib/transforms/json-to-html-data.js
+++ b/lib/transforms/json-to-html-data.js
@@ -1002,7 +1002,7 @@ function isPriorityCard (childRecords, record, description) {
   const singleChildWebDescription =
     childRecords.filter(
       (child) =>
-        child.data.attributes.description.web && child.data.attributes.web
+        child.data.attributes.description?.web && child.data.attributes.web
     ).length === 1;
   const boosted = !!record.data.attributes.boost;
   const primaryDescriptionLength =


### PR DESCRIPTION
## Summary
- Fixes 503 errors on object pages caused by `TypeError: Cannot read properties of undefined (reading 'web')`
- In `isPriorityCard`, iterating over child records accessed `child.data.attributes.description.web` without guarding against a missing `description` attribute
- Added optional chaining (`?.`) to safely handle child records with no description

## Test plan
- [x] Deploy and verify object pages with child records that have no description no longer return 503s
- [x] All 509 unit tests pass locally