### PR TITLE
Add baseline quality weight for agent records

### DIFF
--- a/lib/search-weights.js
+++ b/lib/search-weights.js
@@ -42,6 +42,14 @@ const qualityWeights = [{
   },
   weight: 8
 }, {
+  // Agents (people/companies) structurally never have images, unlike objects where a
+  // missing image is a data gap. This baseline compensates for the permanent absence
+  // of the image:+8 weight so agents aren't unfairly buried in quality-weighted ranking.
+  filter: {
+    term: { '@datatype.base': 'agent' }
+  },
+  weight: 0.8
+}, {
   // Mild positive for archives so they aren't at zero in the sum. The archive analytics
   // exclusion on all-tab (below) prevents fonds inflation from child-aggregated views.
   filter: {


### PR DESCRIPTION
## Summary

- Adds `weight: 0.8` to `qualityWeights` in `lib/search-weights.js` for all agent (people/company) records
- Agents structurally never have images, so they permanently miss the `image: +8` quality signal that object records can earn — this puts them at a consistent disadvantage in quality-weighted ranking even for exact name searches
- The `weight: 0.8` baseline partially compensates without over-inflating people/company results

## Test plan

- [x] Search for a company name (e.g. `ibm`, `next`) — verify the matching agent record appears near the top
- [x] Search for a common object term (e.g. `rocket`, `camera`) — verify results are not dominated by agent records
- [x] Run `npm run test:unit:tape` — all tests pass
- [x] Run `npm run test:lint` — no linting errors