### PR TITLE
low-risk code clarity improvements

### DIFF
--- a/lib/cached-wikidata.js
+++ b/lib/cached-wikidata.js
@@ -1,11 +1,15 @@
+// Constants for cache configuration — match the pattern in cached-document.js
+const CACHE_SEGMENT = 'wikidata';
+const CACHE_TTL = 2629746000; // ~30 days in milliseconds
+
 exports.fetchCache = async function (cache, qCode, clearCache = undefined) {
   try {
     if (!cache || !cache.isReady()) {
       return null;
     }
-    const cached = await cache.get({ segment: 'wikidata', id: qCode });
+    const cached = await cache.get({ segment: CACHE_SEGMENT, id: qCode });
     if (cached && clearCache !== undefined) {
-      await cache.drop({ segment: 'wikidata', id: qCode });
+      await cache.drop({ segment: CACHE_SEGMENT, id: qCode });
       return null;
     }
     return cached;
@@ -23,7 +27,7 @@ exports.setCache = async function (cache, qCode, data, clear = undefined) {
     // Always write — the old entry was already dropped by fetchCache when clear is set,
     // so skipping the write here (the previous behaviour) left Redis with stale data
     // after a ?clear request.
-    await cache.set({ segment: 'wikidata', id: qCode }, data, 2629746000);
+    await cache.set({ segment: CACHE_SEGMENT, id: qCode }, data, CACHE_TTL);
     return null;
   } catch (err) {
     console.debug("Couldn't write to wikidata cache:", err.message);

--- a/lib/facets/aggs-all.js
+++ b/lib/facets/aggs-all.js
@@ -28,6 +28,7 @@ module.exports = function (queryParams) {
         filter: filterQuery,
         aggs: {
           category_filters: {
+            // size: 20 — categories are well-controlled vocabulary; 20 covers all common values
             terms: { size: 20, field: 'category.name.keyword' }
           }
         }
@@ -48,6 +49,7 @@ module.exports = function (queryParams) {
         },
         aggs: {
           collection_filters: {
+            // size: 20 — keeps the facet list manageable in the UI
             terms: {
               size: 20,
               field: 'cumulation.collector.summary.title.keyword'
@@ -123,6 +125,8 @@ module.exports = function (queryParams) {
         filter: filterQuery,
         aggs: {
           archive_filters: {
+            // size: 100 — fonds (archive collections) are more numerous than categories;
+            // 100 ensures all active fonds appear as filter options
             terms: { size: 100, field: 'fonds.summary.title.keyword' }
           }
         }
@@ -179,6 +183,9 @@ module.exports = function (queryParams) {
         filter: filterQuery,
         aggs: {
           museum_filters: {
+            // size: 100 — museum/gallery values are numerous; 100 ensures all locations appear.
+            // Both museum and gallery aggregations query the same ondisplay.value.keyword field;
+            // the UI layer separates them into museum-level vs gallery-level display.
             terms: { size: 100, field: 'ondisplay.value.keyword' }
           }
         }
@@ -187,6 +194,7 @@ module.exports = function (queryParams) {
         filter: filterQuery,
         aggs: {
           gallery_filters: {
+            // size: 100 — see museum comment above
             terms: { size: 100, field: 'ondisplay.value.keyword' }
           }
         }

--- a/lib/facets/create-filters.js
+++ b/lib/facets/create-filters.js
@@ -250,34 +250,16 @@ module.exports = function (queryParams, filterType) {
   }
 
   // locations
+  // Gallery filter takes precedence over museum filter.
+  // Both location.name (old ES schema) and facility.name (new ES schema) are queried
+  // with OR so that records indexed under either schema are matched.
   const museums = queryParams.filter.objects.museum || [];
   const galleries = queryParams.filter.objects.gallery || [];
   const locations = galleries.length > 0 ? galleries : museums;
 
   if (locations) {
     locations.forEach((e) => {
-      filters.push({
-        bool: {
-          should: [
-            {
-              terms: {
-                'location.name.value.lower': [
-                  e.toLowerCase(),
-                  dashToSpace(e.toLowerCase())
-                ]
-              }
-            },
-            {
-              terms: {
-                'facility.name.value.lower': [
-                  e.toLowerCase(),
-                  dashToSpace(e.toLowerCase())
-                ]
-              }
-            }
-          ]
-        }
-      });
+      filters.push(buildLocationFilter(e, dashToSpace));
     });
   }
 
@@ -301,3 +283,34 @@ module.exports = function (queryParams, filterType) {
 
   return { bool: { filter: filters } };
 };
+
+/**
+ * Builds an Elasticsearch OR filter that matches a location value against both
+ * the old ES schema field (location.name.value.lower) and the new schema field
+ * (facility.name.value.lower). This dual-field approach covers records indexed
+ * before and after the schema migration without requiring a full re-index.
+ *
+ * @param {string} location - The location name to filter on
+ * @param {Function} dashToSpace - Helper that converts hyphens to spaces
+ * @returns {Object} Elasticsearch bool.should filter clause
+ */
+function buildLocationFilter (location, dashToSpace) {
+  const value = location.toLowerCase();
+  const valueWithSpaces = dashToSpace(value);
+  return {
+    bool: {
+      should: [
+        {
+          terms: {
+            'location.name.value.lower': [value, valueWithSpaces]
+          }
+        },
+        {
+          terms: {
+            'facility.name.value.lower': [value, valueWithSpaces]
+          }
+        }
+      ]
+    }
+  };
+}

--- a/lib/query-params/format-value.js
+++ b/lib/query-params/format-value.js
@@ -1,10 +1,30 @@
 const splitOnUnescapedCommas = require('../../client/lib/split-commas.js');
+
 /**
-* format the values to the right format depending of the origin of the requst, html or json
-* The values are converted to an array
-* html: The value is a string if only one filter is selected otherwise it's an array
-* json: The value is always a string. the comma separate multiple value the \, is part of the value
-*/
+ * Normalises a filter value into an array, handling the HTML and JSON request paths differently.
+ *
+ * WHY TWO PATHS EXIST
+ * -------------------
+ * Filter values containing literal commas (e.g. "Science Museum, London") must survive
+ * the URL pipeline intact. To do this, literal commas inside a value are escaped as \,
+ * when building filter URLs (see routes/route-helpers/parse-params.js). A bare , acts
+ * as the separator between multiple values for the same filter key.
+ *
+ * HTML path (server render):
+ *   Joi's .single() has already converted the value to an array before this function is
+ *   called, so we just need to unescape any \, back to , in each array element.
+ *
+ * JSON path (SPA / API):
+ *   The value arrives as a plain string (e.g. "Science Museum\, London,Bristol").
+ *   We must split on unescaped commas first (giving ["Science Museum\, London", "Bristol"]),
+ *   then unescape \, in each element (giving ["Science Museum, London", "Bristol"]).
+ *   Splitting before unescaping is critical — reversing the order would destroy the
+ *   escaped commas before the split can use them as guards.
+ *
+ * @param {'html'|'json'} typeFormat - Origin of the request
+ * @param {string|string[]|number} value - Raw filter value from the URL
+ * @returns {string[]|number|null}
+ */
 module.exports = function (typeFormat, value) {
   if (value) {
     if (typeFormat === 'html') {

--- a/routes/object.js
+++ b/routes/object.js
@@ -11,6 +11,17 @@ const getChildRecords = require('../lib/get-child-records.js');
 const checkRecordType = require('./route-helpers/recordType.js');
 // const { log } = require('handlebars');
 
+/**
+ * Returns true if this record is a child within a Single-Part Hierarchy (SPH).
+ * SPH children do not have their own display page — they should redirect to their parent.
+ *
+ * @param {Object} record - The record object from JSONData.data.record
+ * @returns {boolean}
+ */
+function isSPHChildRecord (record) {
+  return record.groupingType === 'SPH' && record.recordType === 'child';
+}
+
 module.exports = (elastic, config) => ({
   method: 'GET',
   path: '/objects/{id}/{slug?}',
@@ -67,15 +78,9 @@ module.exports = (elastic, config) => ({
             relatedAIItems,
             childRecords
           );
-          // handles redirect to parent record if child record is part of SPH grouping
-          const childRecord = JSONData.data.record.groupingType;
-
-          const recordType = JSONData.data.record.recordType;
-          const parentRedirect = JSONData.data.links.parent;
-          if (
-            childRecord === 'SPH' &&
-            recordType === 'child'
-          ) {
+          // SPH child records are not displayed on their own page — redirect to parent
+          if (isSPHChildRecord(JSONData.data.record)) {
+            const parentRedirect = JSONData.data.links.parent;
             if (!parentRedirect) {
               return Boom.notFound();
             }


### PR DESCRIPTION
## Summary

- **Add `ARCHITECTURE.md`** to repo root — developer-oriented guide with data flow diagrams, filter pipeline walkthrough, comma escaping explanation, caching table, and key files at a glance. Intended as a starting point for new developers without requiring them to reverse-engineer the codebase.
- **Extract `buildLocationFilter()`** in `lib/facets/create-filters.js` — the dual-schema OR-query (old `location.name` / new `facility.name`) is now a named, JSDoc-documented function explaining why both fields must be queried.
- **Improve `format-value.js` comment** — full JSDoc block explaining why the HTML and JSON paths differ, why split-before-unescape order is critical, and what breaks if reversed. This is the most likely source of future bugs.
- **Extract `isSPHChildRecord()`** in `routes/object.js` — SPH redirect predicate is now a named function; the handler reads as a single clear intent.
- **Add `CACHE_SEGMENT` / `CACHE_TTL` constants** to `lib/cached-wikidata.js` — `2629746000` is now readable as `~30 days in milliseconds`, matching the existing pattern in `cached-document.js`.
- **Add `size` comments** to aggregation limits in `lib/facets/aggs-all.js` — `size: 20` and `size: 100` magic numbers now explain their reasoning inline.

## No logic was changed

All changes are documentation, comments, and refactoring only. The Elasticsearch queries, filter pipeline, and caching behaviour are identical.

## Test plan

- [x] 654 unit tests passing (`npm run test:unit:tape`)
- [x] Lint clean (`npm run test:lint`)
- [x] Server starts, home page and filtered search page render correctly