### PR TITLE
Update feed fetch User-Agent to pass Cloudflare bot detection

### DIFF
--- a/lib/cached-feed.js
+++ b/lib/cached-feed.js
@@ -26,7 +26,7 @@ exports.fetchAndCacheEndpoint = async function (endpoint) {
     try {
       const response = await fetch(endpoint.url, {
         timeout: 8000,
-        headers: { 'User-Agent': 'SMG Collection Site 1.0' }
+        headers: { 'User-Agent': 'Mozilla/5.0 (compatible; SMGCollectionBot/1.0; +https://collection.sciencemuseumgroup.org.uk)' }
       });
       const data = await response.json();
       failureCooldown.delete(endpoint.url);


### PR DESCRIPTION
The four main museum site feed endpoints (`sciencemuseum.org.uk`, `scienceandmediamuseum.org.uk`, `scienceandindustrymuseum.org.uk`, `railwaymuseum.org.uk`) have been timing out at startup because Cloudflare Bot Fight Mode is blocking the `SMG Collection Site 1.0` User-Agent string.

The WordPress blog endpoints (`/wp-json/...`) are unaffected as those subdomains have a less strict Cloudflare config.

Switches to the standard `Mozilla/5.0 (compatible; SMGCollectionBot/1.0; ...)` format which passes basic WAF bot checks while still identifying the crawler. Long-term fix is a Cloudflare IP allowlist for the production server.