### PR TITLE
Add offline regression tests for /wiki route

### DIFF
--- a/test/fixtures/wikidata/apple-Q312.json
+++ b/test/fixtures/wikidata/apple-Q312.json
@@ -1,0 +1,74 @@
+{
+  "entities": {
+    "Q312": {
+      "id": "Q312",
+      "type": "item",
+      "labels": {
+        "en": { "language": "en", "value": "Apple Inc." }
+      },
+      "claims": {
+        "P154": [{
+          "mainsnak": {
+            "snaktype": "value",
+            "property": "P154",
+            "datavalue": { "value": "Apple_logo_black.svg", "type": "string" }
+          }
+        }],
+        "P571": [{
+          "mainsnak": {
+            "snaktype": "value",
+            "property": "P571",
+            "datavalue": {
+              "value": { "time": "+1976-04-01T00:00:00Z", "precision": 11 },
+              "type": "time"
+            }
+          }
+        }],
+        "P1830": [{
+          "mainsnak": {
+            "snaktype": "value",
+            "property": "P1830",
+            "datavalue": {
+              "value": { "entity-type": "item", "id": "Q24740" },
+              "type": "wikibase-entityid"
+            }
+          },
+          "qualifiers": {
+            "P580": [{
+              "snaktype": "value",
+              "property": "P580",
+              "datavalue": { "value": { "time": "+2001-01-01T00:00:00Z" }, "type": "time" }
+            }]
+          }
+        }],
+        "P169": [{
+          "mainsnak": {
+            "snaktype": "value",
+            "property": "P169",
+            "datavalue": {
+              "value": { "entity-type": "item", "id": "Q5136071" },
+              "type": "wikibase-entityid"
+            }
+          },
+          "qualifiers": {
+            "P580": [{
+              "snaktype": "value",
+              "property": "P580",
+              "datavalue": { "value": { "time": "+2011-01-01T00:00:00Z" }, "type": "time" }
+            }]
+          }
+        }],
+        "P127": [{
+          "mainsnak": {
+            "snaktype": "value",
+            "property": "P127",
+            "datavalue": {
+              "value": { "entity-type": "item", "id": "Q94" },
+              "type": "wikibase-entityid"
+            }
+          }
+        }]
+      }
+    }
+  }
+}

--- a/test/fixtures/wikidata/batch-labels.json
+++ b/test/fixtures/wikidata/batch-labels.json
@@ -1,0 +1,24 @@
+{
+  "entities": {
+    "Q312": {
+      "id": "Q312",
+      "labels": { "en": { "language": "en", "value": "Apple Inc." } }
+    },
+    "Q2651": {
+      "id": "Q2651",
+      "labels": { "en": { "language": "en", "value": "iPhone" } }
+    },
+    "Q24740": {
+      "id": "Q24740",
+      "labels": { "en": { "language": "en", "value": "iTunes" } }
+    },
+    "Q5136071": {
+      "id": "Q5136071",
+      "labels": { "en": { "language": "en", "value": "Tim Cook" } }
+    },
+    "Q94": {
+      "id": "Q94",
+      "labels": { "en": { "language": "en", "value": "Alphabet Inc." } }
+    }
+  }
+}

--- a/test/fixtures/wikidata/steve-jobs-Q19837.json
+++ b/test/fixtures/wikidata/steve-jobs-Q19837.json
@@ -1,0 +1,72 @@
+{
+  "entities": {
+    "Q19837": {
+      "id": "Q19837",
+      "type": "item",
+      "labels": {
+        "en": { "language": "en", "value": "Steve Jobs" }
+      },
+      "claims": {
+        "P18": [{
+          "mainsnak": {
+            "snaktype": "value",
+            "property": "P18",
+            "datavalue": { "value": "Steve_Jobs.jpg", "type": "string" }
+          }
+        }],
+        "P108": [{
+          "mainsnak": {
+            "snaktype": "value",
+            "property": "P108",
+            "datavalue": {
+              "value": { "entity-type": "item", "id": "Q312" },
+              "type": "wikibase-entityid"
+            }
+          },
+          "qualifiers": {
+            "P580": [{
+              "snaktype": "value",
+              "property": "P580",
+              "datavalue": { "value": { "time": "+1997-01-01T00:00:00Z" }, "type": "time" }
+            }],
+            "P582": [{
+              "snaktype": "value",
+              "property": "P582",
+              "datavalue": { "value": { "time": "+2011-01-01T00:00:00Z" }, "type": "time" }
+            }]
+          }
+        }],
+        "P800": [{
+          "mainsnak": {
+            "snaktype": "value",
+            "property": "P800",
+            "datavalue": {
+              "value": { "entity-type": "item", "id": "Q2651" },
+              "type": "wikibase-entityid"
+            }
+          }
+        }],
+        "P569": [{
+          "mainsnak": {
+            "snaktype": "value",
+            "property": "P569",
+            "datavalue": {
+              "value": { "time": "+1955-02-24T00:00:00Z", "precision": 11 },
+              "type": "time"
+            }
+          }
+        }],
+        "P570": [{
+          "mainsnak": {
+            "snaktype": "value",
+            "property": "P570",
+            "datavalue": {
+              "value": { "time": "+2011-10-05T00:00:00Z", "precision": 11 },
+              "type": "time"
+            }
+          }
+        }]
+      }
+    }
+  }
+}

--- a/test/wiki-response.test.js
+++ b/test/wiki-response.test.js
@@ -1,0 +1,247 @@
+'use strict';
+
+/**
+ * Regression tests for the /wiki/{qCode} route.
+ *
+ * These tests verify the shape and content of the processed Wikidata response
+ * for Steve Jobs (Q19837) and Apple Inc. (Q312), using controlled fixtures so
+ * they run offline without hitting the live Wikidata API.
+ *
+ * Fixtures live in test/fixtures/wikidata/.
+ * They use fetch-mock to intercept calls to wikidata.org, and sinon to stub
+ * the Elasticsearch client (used to find matching collection records).
+ *
+ * Run with: npm run test:unit:tape
+ */
+
+const sinon = require('sinon');
+const fetchMock = require('fetch-mock');
+const testWithServer = require('./helpers/test-with-server');
+const cache = require('../bin/cache');
+const config = require('../config');
+
+const steveJobsFixture = require('./fixtures/wikidata/steve-jobs-Q19837.json');
+const appleFixture = require('./fixtures/wikidata/apple-Q312.json');
+const batchLabelsFixture = require('./fixtures/wikidata/batch-labels.json');
+
+// Point global.fetch at a persistent fetch-mock sandbox so the wiki route
+// never makes real HTTP calls. Matchers are registered in specificity order
+// (first match wins); the final catch-all returns the batch labels fixture for
+// any other wikidata.org call (e.g. the getManyEntities batch fetch).
+const sandboxFetch = fetchMock.sandbox();
+global.fetch = sandboxFetch;
+
+// Q19837 primary entity fetch (single ID, full props)
+sandboxFetch.get(/ids=Q19837/, steveJobsFixture);
+// Q312 primary entity fetch — 'ids=Q312&' identifies a single-ID request.
+// Batch calls use pipe-separated IDs encoded as %7C, e.g. 'ids=Q312%7CQ24740'.
+sandboxFetch.get((url) => url.includes('ids=Q312&'), appleFixture);
+// Catch-all: batch label fetches (getManyEntities) and any other wikidata.org call
+sandboxFetch.get(/wikidata\.org/, batchLabelsFixture);
+
+// Test config: include a rootUrl so related links can be assembled correctly
+const testConfig = Object.assign({}, config, {
+  rootUrl: 'https://collection.sciencemuseumgroup.org.uk',
+  auth: false
+});
+
+// Stub cache to simulate a miss, forcing full Wikidata processing each test.
+// Returns a restore function to call after the test.
+function stubCacheMiss () {
+  const isReady = sinon.stub(cache, 'isReady').returns(true);
+  const get = sinon.stub(cache, 'get').resolves(null);
+  const set = sinon.stub(cache, 'set').resolves();
+  return () => { isReady.restore(); get.restore(); set.restore(); };
+}
+
+// ─── Steve Jobs (Q19837) ───────────────────────────────────────────────────
+
+testWithServer('wiki Q19837: returns 200 with JSON body', { config: testConfig }, async (t, ctx) => {
+  t.plan(2);
+  const restore = stubCacheMiss();
+  t.teardown(restore);
+  sinon.stub(ctx.elastic, 'search').resolves({ body: { hits: { hits: [] } } });
+
+  const res = await ctx.server.inject({ method: 'GET', url: '/wiki/Q19837' });
+  t.equal(res.statusCode, 200, 'status 200');
+  t.doesNotThrow(() => JSON.parse(res.payload), 'payload is valid JSON');
+  t.end();
+});
+
+testWithServer('wiki Q19837: image (P18) is a Wikimedia Commons URL', { config: testConfig }, async (t, ctx) => {
+  t.plan(2);
+  const restore = stubCacheMiss();
+  t.teardown(restore);
+  sinon.stub(ctx.elastic, 'search').resolves({ body: { hits: { hits: [] } } });
+
+  const res = await ctx.server.inject({ method: 'GET', url: '/wiki/Q19837' });
+  const body = JSON.parse(res.payload);
+
+  t.ok(body.P18, 'P18 (Image) is present');
+  t.ok(
+    typeof body.P18 === 'string' && body.P18.includes('wikimedia.org'),
+    `P18 is a wikimedia.org URL: ${body.P18}`
+  );
+  t.end();
+});
+
+testWithServer('wiki Q19837: employer (P108) includes "Apple Inc." and date range', { config: testConfig }, async (t, ctx) => {
+  t.plan(3);
+  const restore = stubCacheMiss();
+  t.teardown(restore);
+  sinon.stub(ctx.elastic, 'search').resolves({ body: { hits: { hits: [] } } });
+
+  const res = await ctx.server.inject({ method: 'GET', url: '/wiki/Q19837' });
+  const body = JSON.parse(res.payload);
+
+  t.ok(body.P108 && Array.isArray(body.P108.value), 'P108 (Employer) is present with value array');
+  const val = body.P108.value[0] && body.P108.value[0].value;
+  t.ok(val && val.includes('Apple Inc.'), `value includes "Apple Inc.": "${val}"`);
+  t.ok(val && val.includes('1997') && val.includes('2011'), `value includes date range 1997-2011: "${val}"`);
+  t.end();
+});
+
+testWithServer('wiki Q19837: employer (P108) has related link when collection record found', { config: testConfig }, async (t, ctx) => {
+  t.plan(2);
+  const restore = stubCacheMiss();
+  t.teardown(restore);
+  // Return cp20600 when ES is queried for Apple's wikidata URL (Q312)
+  sinon.stub(ctx.elastic, 'search').callsFake(async (opts) => {
+    const queryStr = JSON.stringify(opts.body);
+    return {
+      body: {
+        hits: {
+          hits: queryStr.includes('Q312') ? [{ _id: 'cp20600' }] : []
+        }
+      }
+    };
+  });
+
+  const res = await ctx.server.inject({ method: 'GET', url: '/wiki/Q19837' });
+  const body = JSON.parse(res.payload);
+
+  t.ok(body.P108 && body.P108.value[0], 'P108 has a value entry');
+  t.ok(
+    body.P108.value[0].related && body.P108.value[0].related.includes('/people/cp20600'),
+    `employer entry links to /people/cp20600: "${body.P108.value[0].related}"`
+  );
+  t.end();
+});
+
+testWithServer('wiki Q19837: notable work (P800) is present with a label', { config: testConfig }, async (t, ctx) => {
+  t.plan(3);
+  const restore = stubCacheMiss();
+  t.teardown(restore);
+  sinon.stub(ctx.elastic, 'search').resolves({ body: { hits: { hits: [] } } });
+
+  const res = await ctx.server.inject({ method: 'GET', url: '/wiki/Q19837' });
+  const body = JSON.parse(res.payload);
+
+  t.ok(body.P800, 'P800 (Notable Work) is present');
+  t.ok(Array.isArray(body.P800.value), 'P800 value is an array');
+  t.ok(body.P800.value[0] && body.P800.value[0].value, `P800 value[0] has a label: "${body.P800.value[0] && body.P800.value[0].value}"`);
+  t.end();
+});
+
+// ─── Apple Inc. (Q312 / collection record cp20600) ────────────────────────
+
+testWithServer('wiki Q312: returns 200 with JSON body', { config: testConfig }, async (t, ctx) => {
+  t.plan(2);
+  const restore = stubCacheMiss();
+  t.teardown(restore);
+  sinon.stub(ctx.elastic, 'search').resolves({ body: { hits: { hits: [] } } });
+
+  const res = await ctx.server.inject({ method: 'GET', url: '/wiki/Q312' });
+  t.equal(res.statusCode, 200, 'status 200');
+  t.doesNotThrow(() => JSON.parse(res.payload), 'payload is valid JSON');
+  t.end();
+});
+
+testWithServer('wiki Q312: logo (P154) is a Wikimedia Commons URL', { config: testConfig }, async (t, ctx) => {
+  t.plan(2);
+  const restore = stubCacheMiss();
+  t.teardown(restore);
+  sinon.stub(ctx.elastic, 'search').resolves({ body: { hits: { hits: [] } } });
+
+  const res = await ctx.server.inject({ method: 'GET', url: '/wiki/Q312' });
+  const body = JSON.parse(res.payload);
+
+  t.ok(body.P154, 'P154 (Logo) is present');
+  t.ok(
+    typeof body.P154 === 'string' && body.P154.includes('wikimedia.org'),
+    `P154 is a wikimedia.org URL: ${body.P154}`
+  );
+  t.end();
+});
+
+testWithServer('wiki Q312: inception (P571) includes 1976', { config: testConfig }, async (t, ctx) => {
+  t.plan(2);
+  const restore = stubCacheMiss();
+  t.teardown(restore);
+  sinon.stub(ctx.elastic, 'search').resolves({ body: { hits: { hits: [] } } });
+
+  const res = await ctx.server.inject({ method: 'GET', url: '/wiki/Q312' });
+  const body = JSON.parse(res.payload);
+
+  t.ok(body.P571 && Array.isArray(body.P571.value), 'P571 (Inception) is present');
+  const val = body.P571.value[0] && body.P571.value[0].value;
+  t.ok(val && String(val).includes('1976'), `inception value includes 1976: "${val}"`);
+  t.end();
+});
+
+testWithServer('wiki Q312: owner of (P1830) includes "iTunes"', { config: testConfig }, async (t, ctx) => {
+  t.plan(2);
+  const restore = stubCacheMiss();
+  t.teardown(restore);
+  sinon.stub(ctx.elastic, 'search').resolves({ body: { hits: { hits: [] } } });
+
+  const res = await ctx.server.inject({ method: 'GET', url: '/wiki/Q312' });
+  const body = JSON.parse(res.payload);
+
+  t.ok(body.P1830 && Array.isArray(body.P1830.value), 'P1830 (Owner Of) is present');
+  const val = body.P1830.value[0] && body.P1830.value[0].value;
+  t.ok(val && val.includes('iTunes'), `owner of value includes "iTunes": "${val}"`);
+  t.end();
+});
+
+testWithServer('wiki Q312: chief executive officers (P169) includes "Tim Cook"', { config: testConfig }, async (t, ctx) => {
+  t.plan(2);
+  const restore = stubCacheMiss();
+  t.teardown(restore);
+  sinon.stub(ctx.elastic, 'search').resolves({ body: { hits: { hits: [] } } });
+
+  const res = await ctx.server.inject({ method: 'GET', url: '/wiki/Q312' });
+  const body = JSON.parse(res.payload);
+
+  t.ok(body.P169 && Array.isArray(body.P169.value), 'P169 (CEO) is present');
+  const val = body.P169.value[0] && body.P169.value[0].value;
+  t.ok(val && val.includes('Tim Cook'), `CEO value includes "Tim Cook": "${val}"`);
+  t.end();
+});
+
+testWithServer('wiki Q312: CEO (P169) has related link when collection record found', { config: testConfig }, async (t, ctx) => {
+  t.plan(2);
+  const restore = stubCacheMiss();
+  t.teardown(restore);
+  // Return a fake collection record when ES is queried for Tim Cook's wikidata URL (Q5136071)
+  sinon.stub(ctx.elastic, 'search').callsFake(async (opts) => {
+    const queryStr = JSON.stringify(opts.body);
+    return {
+      body: {
+        hits: {
+          hits: queryStr.includes('Q5136071') ? [{ _id: 'cp99999' }] : []
+        }
+      }
+    };
+  });
+
+  const res = await ctx.server.inject({ method: 'GET', url: '/wiki/Q312' });
+  const body = JSON.parse(res.payload);
+
+  t.ok(body.P169 && body.P169.value[0], 'P169 (CEO) has a value entry');
+  t.ok(
+    body.P169.value[0].related && body.P169.value[0].related.includes('/people/cp99999'),
+    `CEO entry links to /people/cp99999: "${body.P169.value[0].related}"`
+  );
+  t.end();
+});


### PR DESCRIPTION
## Summary

- Adds `test/wiki-response.test.js` — 24 offline regression tests for the `/wiki/{qCode}` route covering **Steve Jobs (Q19837)** and **Apple Inc. (Q312)**
- Adds `test/fixtures/wikidata/` — three minimal JSON fixtures (primary entities + batch labels) so tests never hit the live Wikidata API

## Tests cover

| Field | Steve Jobs (Q19837) | Apple (Q312) |
|-------|---------------------|--------------|
| Image / Logo | P18 is a Wikimedia Commons URL | P154 is a Wikimedia Commons URL |
| Employer / CEO | P108 includes "Apple Inc. (1997-2011)" | P169 includes "Tim Cook (2011)" |
| Collection link | P108 entry has `related` → `/people/cp20600` when ES returns a hit | P169 entry has `related` → `/people/cpXXXXX` when ES returns a hit |
| Notable Work | P800 has a label | — |
| Inception | — | P571 includes "1976" |
| Owner Of | — | P1830 includes "iTunes (2001)" |

## Test plan

- [x] `npm run test:unit:tape` — all 24 pass offline (no Redis, no Elasticsearch, no Wikidata API)
- [x] Tests verified to still pass after Phase 3 refactoring (PR #1968)