### PR TITLE
Phase 5: Wikidata cross-link regression tests (Apple ↔ Steve Jobs)

### DIFF
--- a/test/fixtures/wikidata/apple-Q312.json
+++ b/test/fixtures/wikidata/apple-Q312.json
@@ -58,6 +58,16 @@
             }]
           }
         }],
+        "P112": [{
+          "mainsnak": {
+            "snaktype": "value",
+            "property": "P112",
+            "datavalue": {
+              "value": { "entity-type": "item", "id": "Q19837" },
+              "type": "wikibase-entityid"
+            }
+          }
+        }],
         "P127": [{
           "mainsnak": {
             "snaktype": "value",

--- a/test/fixtures/wikidata/batch-labels.json
+++ b/test/fixtures/wikidata/batch-labels.json
@@ -19,6 +19,10 @@
     "Q94": {
       "id": "Q94",
       "labels": { "en": { "language": "en", "value": "Alphabet Inc." } }
+    },
+    "Q19837": {
+      "id": "Q19837",
+      "labels": { "en": { "language": "en", "value": "Steve Jobs" } }
     }
   }
 }

--- a/test/wiki-response.test.js
+++ b/test/wiki-response.test.js
@@ -245,3 +245,47 @@ testWithServer('wiki Q312: CEO (P169) has related link when collection record fo
   );
   t.end();
 });
+
+// ─── Cross-link: Apple Inc. → Founded By → Steve Jobs (cp50119) ───────────
+
+testWithServer('wiki Q312: founded by (P112) includes "Steve Jobs"', { config: testConfig }, async (t, ctx) => {
+  t.plan(2);
+  const restore = stubCacheMiss();
+  t.teardown(restore);
+  sinon.stub(ctx.elastic, 'search').resolves({ body: { hits: { hits: [] } } });
+
+  const res = await ctx.server.inject({ method: 'GET', url: '/wiki/Q312' });
+  const body = JSON.parse(res.payload);
+
+  t.ok(body.P112 && Array.isArray(body.P112.value), 'P112 (Founded By) is present');
+  const val = body.P112.value[0] && body.P112.value[0].value;
+  t.ok(val && val.includes('Steve Jobs'), `founded by value includes "Steve Jobs": "${val}"`);
+  t.end();
+});
+
+testWithServer('wiki Q312: founded by (P112) has related link when collection record found', { config: testConfig }, async (t, ctx) => {
+  t.plan(2);
+  const restore = stubCacheMiss();
+  t.teardown(restore);
+  // Return cp50119 when ES is queried for Steve Jobs' wikidata URL (Q19837)
+  sinon.stub(ctx.elastic, 'search').callsFake(async (opts) => {
+    const queryStr = JSON.stringify(opts.body);
+    return {
+      body: {
+        hits: {
+          hits: queryStr.includes('Q19837') ? [{ _id: 'cp50119' }] : []
+        }
+      }
+    };
+  });
+
+  const res = await ctx.server.inject({ method: 'GET', url: '/wiki/Q312' });
+  const body = JSON.parse(res.payload);
+
+  t.ok(body.P112 && body.P112.value[0], 'P112 (Founded By) has a value entry');
+  t.ok(
+    body.P112.value[0].related && body.P112.value[0].related.includes('/people/cp50119'),
+    `founded by entry links to /people/cp50119: "${body.P112.value[0].related}"`
+  );
+  t.end();
+});


### PR DESCRIPTION
## Summary

- Adds `P112` (Founded By → Q19837 Steve Jobs) to the Apple Inc. fixture (`apple-Q312.json`)
- Adds Q19837 Steve Jobs label to `batch-labels.json` for offline label resolution
- Adds 2 new regression tests to `wiki-response.test.js`:
  - `wiki Q312: founded by (P112) includes "Steve Jobs"` — verifies the label resolves correctly
  - `wiki Q312: founded by (P112) has related link when collection record found` — verifies a `/people/cp50119` link is injected when ES returns cp50119 for Q19837

Together with the pre-existing `wiki Q19837: employer (P108) has related link when collection record found` test, this covers both directions of the cross-link:
- **Apple Inc. (cp20600)** → Founded By → Steve Jobs → `/people/cp50119` ✅
- **Steve Jobs (cp50119)** → Employer(s) → Apple Inc. → `/people/cp20600` ✅

All 680 tests pass; lint is clean.

## Test plan

- [x] `npm run test:unit:tape` — 680/680 passing, 2 new tests at 665-668
- [x] `npm run test:lint` — semistandard clean