### PR TITLE
Fix Wikidata panel formatting regressions

### DIFF
--- a/templates/partials/records/wiki-info.html
+++ b/templates/partials/records/wiki-info.html
@@ -52,13 +52,6 @@
   <p style="margin-top: 8px; font-size: smaller;"><a href="{{wikiData.wikipediaUrl}}" rel="noopener noreferrer">Read more on Wikipedia →</a></p>
   {{/if}}
   --}}
-  {{#if wikiData.alsoInCollection}}
-  <p style="margin-top: 0.5em;"><strong>Also in our collection:</strong>
-    {{#each wikiData.alsoInCollection}}
-    <a href="{{this.url}}">{{this.name}}</a>{{#unless @last}}, {{/unless}}
-    {{/each}}
-  </p>
-  {{/if}}
   {{#if wikiData.externalIdentifiers}}
   <article class="property">
     <h3>External Identifiers</h3>
@@ -68,6 +61,13 @@
       {{/each}}
     </ul>
   </article>
+  {{/if}}
+  {{#if wikiData.alsoInCollection}}
+  <p style="margin-top: 0.5em;"><strong>Also in our collection:</strong>
+    {{#each wikiData.alsoInCollection}}
+    <a href="{{this.url}}">{{this.name}}</a>{{#unless @last}}, {{/unless}}
+    {{/each}}
+  </p>
   {{/if}}
   <div class="panel panel--wikidata">
         <p style="font-size: smaller"><i>We’re testing a new feature to display  third party images and information on our people and


### PR DESCRIPTION
## Summary

- **Remove grey boxes** from External Identifiers and 'Also in our collection' — both were using `class="panel"` which triggered the CSS sibling-selector cascade (`.panel + .panel { background: grey(85) }` etc.), creating unwanted grey backgrounds
- **External Identifiers**: replace `div.panel` with `<article class="property">` + `<h3>` + `<ul class="wikidata-list">` + `<li class="wikidata-list-item">` — matches the heading and list-item size of every other property block (Position Held, Award Received, etc.)
- **Also in our collection**: replace `div.panel` with a plain `<p>` — correct body text size, no box
- **Identifier link format**: label shown as plain text, only the value is linked (e.g. `VIAF: 84237107`)
- **Order**: External Identifiers now appears above 'Also in our collection'

## Test plan

- [x] Hard-reload a person page with Wikidata data (e.g. Steve Jobs `/people/cp50119/steve-jobs?clear=true`)
- [x] External Identifiers heading matches "Position Held" / "Award Received" size — no grey box
- [x] External Identifiers items match list-item size (e.g. "chief executive officer (1995–1997)")
- [x] "Also in our collection" is plain body text size — no grey box — sits below External Identifiers
- [x] Disclaimer grey box unchanged (single box at bottom as before)