### PR TITLE
Tune nginx proxy buffer and timeout settings for EB

### DIFF
--- a/.platform/nginx/conf.d/01_proxy_settings.conf
+++ b/.platform/nginx/conf.d/01_proxy_settings.conf
@@ -1,11 +1,15 @@
 # .platform/nginx/conf.d/01_proxy_settings.conf
 
 # Proxy Settings
-proxy_buffer_size         256k;    # For response headers
-proxy_buffers             32 256k; # 32 buffers of 256k = 8MB total
-proxy_busy_buffers_size   512k;    # Buffers marked "busy"
-proxy_read_timeout        300s;    # 5 minutes
-proxy_connect_timeout     75s;    
+# Buffers sized for ~1MB max JSON API payload held in memory (avoids temp file spill).
+# If you see 'upstream sent too big header' in nginx logs, increase proxy_buffer_size to 128k.
+# If responses start spilling to disk (check proxy_temp_path logs), bump proxy_buffers up.
+proxy_buffer_size         64k;     # Response headers (generous)
+proxy_buffers             16 64k;  # 16 × 64k = 1MB total — matches max payload
+proxy_busy_buffers_size   128k;    # Must be <= total buffer size
+proxy_read_timeout        90s;     # 3× the ~30s worst-case API response time
+proxy_connect_timeout     15s;     # Internal EB connection should be fast
+proxy_send_timeout        60s;     # Time between successive client reads
 
 
 # Fix types_hash warnings: 'could not build optimal types_hash'


### PR DESCRIPTION
## Summary

- Reduce proxy buffers from 8MB to 1MB, sized for actual ~1MB max JSON API payload
- Reduce `proxy_read_timeout` from 300s to 90s (3× the ~30s worst-case response time)
- Reduce `proxy_connect_timeout` from 75s to 15s (internal EB connection should be near-instant)
- Add missing `proxy_send_timeout 60s`
- Add troubleshooting comments for common nginx buffer-related errors

## Test plan

- [ ] Deploy to a staging EB environment and verify nginx reloads without errors
- [ ] Confirm large JSON API responses (~1MB) are served correctly
- [ ] Confirm slow API responses (~30s) do not time out
- [ ] Check nginx error logs for any `upstream sent too big header` or temp file warnings