### PR TITLE
feat: wikidata panel tweaks

### DIFF
--- a/client/lib/listeners/wiki-more.js
+++ b/client/lib/listeners/wiki-more.js
@@ -5,19 +5,24 @@
  *
  * Progressive enhancement for long Wikidata property lists.
  *
- * Only applies to bulleted lists (<ul class="wikidata-list" data-wiki-more>).
- * Comma-separated inline lists are intentionally excluded.
+ * BULLETED LISTS  (<ul class="wikidata-list" data-wiki-more>)
+ *   Lists with more than THRESHOLD (5) items are truncated.
+ *   A "Show N more" button is appended as a list item; clicking it reveals
+ *   all items and replaces itself with a "Show less" button.
  *
- * Lists with more than THRESHOLD items are truncated on first render.
- * A "Show N more" button is appended; clicking it reveals all items and
- * replaces itself with a "Show less" button that collapses back.
+ *   THRESHOLD must match the value in lib/wikiPropertySort.js so that the
+ *   fold happens at the same boundary as the server-side sort that promotes
+ *   linked items to the top of long lists.
  *
- * THRESHOLD must match the value in lib/wikiPropertySort.js so that the
- * fold happens at the same boundary as the server-side sort that promotes
- * linked items to the top of long lists.
+ * INLINE LISTS  (<ul data-wiki-more> without .wikidata-list)
+ *   Comma-separated inline lists with more than INLINE_THRESHOLD (12) items
+ *   are truncated. A "Show N more" button is appended inline after the last
+ *   visible item (inheriting the trailing comma from item 12). When expanded,
+ *   a "· Show less" button is appended after the final item.
  */
 
 const THRESHOLD = 5;
+const INLINE_THRESHOLD = 10;
 
 const BTN_STYLE = [
   'background: none',
@@ -29,6 +34,8 @@ const BTN_STYLE = [
   'text-decoration: underline',
   'opacity: 0.75'
 ].join(';');
+
+// ─── Bulleted list helpers ────────────────────────────────────────────────────
 
 /**
  * Build a toggle <li> button and append it to ul.
@@ -96,10 +103,79 @@ function setupList (ul) {
   appendToggle(ul, items, 'collapsed', originalDisplay);
 }
 
+// ─── Inline list helpers ──────────────────────────────────────────────────────
+
+/**
+ * Build an inline toggle <li> button and append it to ul.
+ * In the collapsed state the button inherits the trailing ", " from item 12,
+ * producing "…item12, Show N more…".
+ * In the expanded state a " · " separator is prepended to the button li text.
+ *
+ * @param {HTMLUListElement} ul
+ * @param {HTMLElement[]} items - the full ordered list of content <li> elements
+ * @param {'collapsed'|'expanded'} state - which button to render
+ */
+function appendInlineToggle (ul, items, state) {
+  const hiddenCount = items.length - INLINE_THRESHOLD;
+  const li = document.createElement('li');
+  li.style.display = 'inline';
+  li.className = 'wikidata-inline-more-btn';
+
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.style.cssText = BTN_STYLE;
+
+  if (state === 'collapsed') {
+    btn.textContent = 'Show ' + hiddenCount + ' more\u2026';
+    btn.setAttribute('aria-expanded', 'false');
+    btn.setAttribute('aria-label', 'Show all ' + items.length + ' items');
+    btn.addEventListener('click', function () {
+      for (let i = INLINE_THRESHOLD; i < items.length; i++) {
+        items[i].classList.remove('wikidata-inline-hidden');
+      }
+      li.remove();
+      appendInlineToggle(ul, items, 'expanded');
+    });
+  } else {
+    // Prepend a separator so the button reads "lastitem · Show less"
+    li.appendChild(document.createTextNode('\u00a0\u00b7 '));
+    btn.textContent = 'Show less';
+    btn.setAttribute('aria-expanded', 'true');
+    btn.setAttribute('aria-label', 'Show fewer items');
+    btn.addEventListener('click', function () {
+      for (let i = INLINE_THRESHOLD; i < items.length; i++) {
+        items[i].classList.add('wikidata-inline-hidden');
+      }
+      li.remove();
+      appendInlineToggle(ul, items, 'collapsed');
+    });
+  }
+
+  li.appendChild(btn);
+  ul.appendChild(li);
+}
+
+/**
+ * Set up Show More / Show Less for a single inline comma-separated list.
+ *
+ * @param {HTMLUListElement} ul
+ */
+function setupInlineList (ul) {
+  const items = Array.from(ul.querySelectorAll('li'));
+  if (items.length <= INLINE_THRESHOLD) return;
+
+  for (let i = INLINE_THRESHOLD; i < items.length; i++) {
+    items[i].classList.add('wikidata-inline-hidden');
+  }
+
+  appendInlineToggle(ul, items, 'collapsed');
+}
+
+// ─── Entry point ──────────────────────────────────────────────────────────────
+
 /**
  * Scan a container element (typically the #wikiInfo section) and set up
- * Show More / Show Less for every bulleted wikidata list found within it.
- * Comma-separated inline lists (ul without .wikidata-list) are skipped.
+ * Show More / Show Less for every wikidata list found within it.
  *
  * Called by get-wiki-data.js after the Handlebars template is rendered.
  *
@@ -107,9 +183,16 @@ function setupList (ul) {
  */
 module.exports = function setupWikiMore (container) {
   if (!container) return;
-  // Only target bulleted lists — .wikidata-list excludes inline comma lists.
+
+  // Bulleted lists (.wikidata-list)
   const lists = container.querySelectorAll('ul.wikidata-list[data-wiki-more]');
   for (let i = 0; i < lists.length; i++) {
     setupList(lists[i]);
+  }
+
+  // Inline comma-separated lists (no .wikidata-list class)
+  const inlineLists = container.querySelectorAll('ul[data-wiki-more]:not(.wikidata-list)');
+  for (let i = 0; i < inlineLists.length; i++) {
+    setupInlineList(inlineLists[i]);
   }
 };

--- a/client/styles/components/_panel.scss
+++ b/client/styles/components/_panel.scss
@@ -117,3 +117,7 @@
     }
   }
 }
+
+.wikidata-inline-hidden {
+  display: none !important;
+}

--- a/client/templates.js
+++ b/client/templates.js
@@ -508,6 +508,10 @@ Handlebars.registerHelper(
   'extractQCode',
   require('../templates/helpers/extractQCode.js')
 );
+Handlebars.registerHelper(
+  'pluralizeLabel',
+  require('../templates/helpers/pluralizeLabel.js')
+);
 
 Handlebars.registerPartial(
   'records/record-sph-images',

--- a/templates/helpers/pluralizeLabel.js
+++ b/templates/helpers/pluralizeLabel.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/**
+ * Handlebars helper: pluralizeLabel
+ *
+ * Converts a label containing "(s)" to its singular or plural form based on count.
+ *
+ * pluralizeLabel('Employer(s)', 1) → 'Employer'
+ * pluralizeLabel('Employer(s)', 3) → 'Employers'
+ * pluralizeLabel('Award Received', 5) → 'Award Received'  (unchanged, no (s) pattern)
+ */
+module.exports = function pluralizeLabel (label, count) {
+  if (typeof label !== 'string') return label;
+  return label.replace(/\(s\)/g, count === 1 ? '' : 's');
+};

--- a/templates/helpers/wikiInfoTransform.js
+++ b/templates/helpers/wikiInfoTransform.js
@@ -1,9 +1,23 @@
 // Priority order for wiki property display.
 // Keys listed here appear first (in this order); all others follow in original order.
-const PRIORITY = ['P112', 'P127', 'P169', 'P108', 'P1056', 'P800'];
+const PRIORITY = [
+  // 'P571',  // Inception     — currently hidden, uncomment to reinstate
+  // 'P1448', // Official Name — currently hidden, uncomment to reinstate
+  'P112', 'P127', 'P169', 'P108', 'P1056', 'P800'
+];
+
+// Properties excluded from the display panel.
+// Comment out individual lines to reinstate a section.
+const SKIP = new Set([
+  'P571', // Inception
+  'P1448', // Official Name
+  'P138' // Named After
+]);
 
 module.exports = (obj) => {
-  const entries = Object.entries(obj).map(([key, value]) => ({ key, value }));
+  const entries = Object.entries(obj)
+    .filter(([key]) => !SKIP.has(key))
+    .map(([key, value]) => ({ key, value }));
   const priority = entries.filter(e => PRIORITY.includes(e.key));
   const rest = entries.filter(e => !PRIORITY.includes(e.key));
   priority.sort((a, b) => PRIORITY.indexOf(a.key) - PRIORITY.indexOf(b.key));

--- a/templates/partials/records/wiki-info.html
+++ b/templates/partials/records/wiki-info.html
@@ -37,7 +37,7 @@
   {{#if (isArray this.value.value)}}
   {{#unless (wikidataExcludeField this.value)}}
   <article class="property">
-    <h3>{{this.value.label}}</h3>
+    <h3>{{pluralizeLabel this.value.label this.value.value.length}}</h3>
     <ul class='{{#if (isWikiList this.value.value)}}wikidata-list{{/if}}' data-wiki-more>
       {{#each this.value.value}}
 
@@ -70,10 +70,10 @@
     <h3>External Identifiers</h3>
     <ul class="wikidata-list">
       {{#each wikiData.externalIdentifiers}}
-      <li class="wikidata-list-item">{{this.label}}: <a href="{{this.url}}" rel="noopener noreferrer">{{this.value}}</a></li>
+      <li class="wikidata-list-item">{{this.label}}: <a href="{{this.url}}" rel="noopener noreferrer">{{this.value}} <svg class="icon" aria-hidden="true"><use xlink:href="/assets/icons/symbol/svg/sprite.symbol.svg#external"></use></svg></a></li>
       {{/each}}
       {{#if (extractQCode wikiData.wikidataUrl)}}
-      <li class="wikidata-list-item">Wikidata: <a href="{{wikiData.wikidataUrl}}" rel="noopener noreferrer">{{extractQCode wikiData.wikidataUrl}}</a></li>
+      <li class="wikidata-list-item">Wikidata: <a href="{{wikiData.wikidataUrl}}" rel="noopener noreferrer">{{extractQCode wikiData.wikidataUrl}} <svg class="icon" aria-hidden="true"><use xlink:href="/assets/icons/symbol/svg/sprite.symbol.svg#external"></use></svg></a></li>
       {{/if}}
     </ul>
   </article>


### PR DESCRIPTION
## Summary
- External link icon added to all External Identifier links (VIAF, Wikidata Q-code)
- `pluralizeLabel` helper: heading labels with `(s)` suffix (e.g. `Employer(s)`) now correctly show singular/plural based on item count
- `wikiInfoTransform`: `SKIP` set hides Inception, Official Name, Named After — each is a single commented line to reinstate
- Inline comma-separated lists truncate at 10 items with a "Show N more…" / "· Show less" toggle (mirrors existing bulleted list show-more behaviour)

## Test plan
- [x] Visit a person with Wikidata panel — External Identifiers show `↗` icon on each link
- [x] Person with multiple employers shows "Employers" heading; single employer shows "Employer"
- [x] Visit `/people/cp87525` — Has Subsidiary truncates to 10 with "Show 18 more…"; expand/collapse works
- [x] Inception, Official Name, Named After sections are not shown