### PR TITLE
fix: guard undefined/invalid inputs in museum-mapping and wiki route

### DIFF
--- a/lib/museum-mapping.js
+++ b/lib/museum-mapping.js
@@ -15,5 +15,6 @@ const longMuseums = {
 };
 
 exports.toLong = function (mus) {
+  if (!mus) return mus;
   return shortMuseums[mus] || shortMuseums[longMuseums[decodeURIComponent(mus.toLowerCase().split('-').join(' '))]] || mus;
 };

--- a/lib/wikidataQueries.js
+++ b/lib/wikidataQueries.js
@@ -78,6 +78,11 @@ async function wikibaseCall (wikibaseEntities, signal = undefined) {
             console.error(`Wikidata label fetch returned ${response.status} for ${wikibaseEntities}`);
             return null;
           }
+          const ct = response.headers.get('content-type') || '';
+          if (!ct.includes('application/json') && !ct.includes('text/javascript')) {
+            console.error(`Wikidata label fetch returned non-JSON content type (${ct}) for ${wikibaseEntities}`);
+            return null;
+          }
           return response.json();
         })
         .catch((error) => {

--- a/routes/wiki.js
+++ b/routes/wiki.js
@@ -369,6 +369,10 @@ module.exports = (elastic, config) => ({
       try {
         const { wikidata } = req.params;
 
+        if (!/^Q\d+$/i.test(wikidata)) {
+          return h.response('Invalid Wikidata ID').code(400);
+        }
+
         const cachedWikidataJson = await fetchCache(cache, wikidata);
 
         if (cachedWikidataJson !== null && cachedWikidataJson !== undefined) {
@@ -402,6 +406,11 @@ module.exports = (elastic, config) => ({
               fetchResult = await wikidataCircuitBreaker.call(async () => {
                 const res = await fetchWithRetry(data, { signal: AbortSignal.timeout(10000) });
                 if (!res) return null;
+                const ct = res.headers.get('content-type') || '';
+                if (!ct.includes('application/json') && !ct.includes('text/javascript')) {
+                  console.error(`[wiki] Wikidata returned non-JSON response (${ct}) for ${wikidata}`);
+                  return null;
+                }
                 return res.json();
               });
             } catch (err) {

--- a/test/parse-params.test.js
+++ b/test/parse-params.test.js
@@ -63,7 +63,7 @@ test('parsing lowercase url params', function (t) {
 });
 
 test('parsing museum params', function (t) {
-  t.plan(7);
+  t.plan(8);
 
   t.deepEqual(
     parseParameters({ filters: 'objects/museum/scm' }),
@@ -116,6 +116,10 @@ test('parsing museum params', function (t) {
       categories: { museum: 'Science and Industry Museum' }
     },
     'should convert museum name to correct case'
+  );
+  t.doesNotThrow(
+    function () { parseParameters({ filters: 'objects/museum' }); },
+    'should not throw when museum value is missing'
   );
   t.end();
 });

--- a/test/wiki-response.test.js
+++ b/test/wiki-response.test.js
@@ -15,6 +15,15 @@
  */
 
 const sinon = require('sinon');
+
+// fetch-mock v10 requires global Request/Response/Headers to be present.
+// Node.js v16 doesn't have them built-in, so polyfill from node-fetch.
+// Must be set before requiring fetch-mock so it picks them up at load time.
+const nodeFetch = require('node-fetch');
+if (!global.Request) global.Request = nodeFetch.Request;
+if (!global.Response) global.Response = nodeFetch.Response;
+if (!global.Headers) global.Headers = nodeFetch.Headers;
+
 const fetchMock = require('fetch-mock');
 const testWithServer = require('./helpers/test-with-server');
 const cache = require('../bin/cache');
@@ -364,5 +373,41 @@ testWithServer('wiki Q19837: colleagues absent when no collection records match'
   const body = JSON.parse(res.payload);
 
   t.notOk(body.colleagues, 'colleagues is absent when no collection records match');
+  t.end();
+});
+
+// ─── Input validation ─────────────────────────────────────────────────────────
+
+testWithServer('wiki: invalid entity ID returns 400', { config: testConfig }, async (t, ctx) => {
+  t.plan(3);
+
+  const invalidIds = ['Hans_Christian_Ørsted', 'cabaça', 'not-a-qcode'];
+  for (const id of invalidIds) {
+    const res = await ctx.server.inject({ method: 'GET', url: `/wiki/${encodeURIComponent(id)}` });
+    t.equal(res.statusCode, 400, `${id} returns 400`);
+  }
+  t.end();
+});
+
+// ─── HTML error page handling ─────────────────────────────────────────────────
+
+testWithServer('wiki: HTML response from Wikidata returns 503', { config: testConfig }, async (t, ctx) => {
+  t.plan(1);
+  const restore = stubCacheMiss();
+  t.teardown(restore);
+  sinon.stub(ctx.elastic, 'search').resolves({ body: { hits: { hits: [] } } });
+
+  const htmlFetch = fetchMock.sandbox();
+  htmlFetch.get(/wikidata\.org/, {
+    status: 200,
+    body: '<!DOCTYPE html><html><body>Bot protection</body></html>',
+    headers: { 'content-type': 'text/html' }
+  });
+  const prevFetch = global.fetch;
+  global.fetch = htmlFetch;
+  t.teardown(() => { global.fetch = prevFetch; });
+
+  const res = await ctx.server.inject({ method: 'GET', url: '/wiki/Q19837' });
+  t.equal(res.statusCode, 503, 'HTML Wikidata response yields 503');
   t.end();
 });


### PR DESCRIPTION
## Summary

Fixes three production errors identified in Elastic Beanstalk logs:

- **museum-mapping crash**: `toLong()` called with `undefined` when a `/search` URL contains a bare `/museum` segment with no value (e.g. `/search/objects/museum`). Added a null guard — returns the value as-is instead of crashing.
- **Invalid Wikidata entity IDs**: Slugs like `Hans_Christian_Ørsted`, `cabaça`, `Manuel_da_Nóbrega` were being passed to the `/wiki/{wikidata}` route, causing a cascade of errors (invalid entity id → null URL → fetch crash). Added upfront validation: params not matching `/^Q\d+$/i` now return 400 immediately.
- **Wikidata HTML bot-protection responses**: Cloudflare/Wikidata occasionally returns a `200 OK` with an HTML page instead of JSON (bot detection). Added `Content-Type` check before calling `.json()` in both `routes/wiki.js` and `lib/wikidataQueries.js` — returns null gracefully instead of throwing a `SyntaxError`.

Also fixes a pre-existing test breakage: `test/wiki-response.test.js` was silently broken on Node v16 because fetch-mock v10 requires `global.Request/Response/Headers` to be set before it is `require`d. Polyfills these from `node-fetch` in the correct order.

## Test plan

- [x] `npm run test:unit:tape` — all 71 tests pass (34 parse-params + 37 wiki-response)
- [x] `/search/objects/museum` returns 200 (no crash)
- [x] `/wiki/not-a-qcode` returns 400
- [x] `/wiki/Q937` returns 200