### PR TITLE
fix: prevent premature date filter search and improve WCAG 2.1 compliance

### DIFF
--- a/client/routes/search.js
+++ b/client/routes/search.js
@@ -259,16 +259,23 @@ function listeners (ctx, next) {
   }
 
   /**
-   * Search when one of the input date onblur
+   * Search when focus leaves the date range container entirely.
+   * Using focusout on the container (rather than blur on each input) prevents
+   * a premature search firing when the user tabs from the "From" field to the
+   * "To" field — we only run the search once both fields have been filled.
    */
-  const filtersDate = document.querySelectorAll(
-    '.filter:not(.filter--uncollapsible) [type=number]'
+  const filtersDateContainers = document.querySelectorAll(
+    '.filter:not(.filter--uncollapsible) .filter__daterange'
   );
-  for (i = 0; i < filtersDate.length; i++) {
-    filtersDate[i].addEventListener('blur', function () {
-      filterResults(ctx, page);
+  for (i = 0; i < filtersDateContainers.length; i++) {
+    filtersDateContainers[i].addEventListener('focusout', function (e) {
+      // relatedTarget is the element receiving focus; if it's still inside this
+      // date range container the user is just moving between from/to, so skip.
+      if (!this.contains(e.relatedTarget)) {
+        filterResults(ctx, page);
+      }
     });
-    filtersDate[i].addEventListener('keydown', function (e) {
+    filtersDateContainers[i].addEventListener('keydown', function (e) {
       if (e.key === 'Enter' || e.keyCode === 13) {
         e.preventDefault();
         filterResults(ctx, page);

--- a/templates/partials/search/filters-all.html
+++ b/templates/partials/search/filters-all.html
@@ -225,10 +225,10 @@
 <div class="filter filter--open" data-filter="Dates">
 {{/if}}
   <a href="{{lookup links.clearFacet "dates"}}" class="filter__name">Date</a>
-  <div class="filter__options filter__daterange">
-    <label>From year <input type="number" placeholder="e.g. 1600" name="filter[date[from]]"
-        value="{{lookup selectedFilters "date[from]"}}" /></label>
-    <label>To year <input type="number" placeholder="e.g. 2016" name="filter[date[to]]"
-        value="{{lookup selectedFilters "date[to]"}}" /></label>
+  <div class="filter__options filter__daterange" role="group" aria-label="Date range">
+    <label for="date-filter-from">From year <input type="number" id="date-filter-from" placeholder="e.g. 1600" name="filter[date[from]]"
+        value="{{lookup selectedFilters "date[from]"}}" min="1" max="9999" /></label>
+    <label for="date-filter-to">To year <input type="number" id="date-filter-to" placeholder="e.g. 2016" name="filter[date[to]]"
+        value="{{lookup selectedFilters "date[to]"}}" min="1" max="9999" /></label>
   </div>
 </div>

--- a/templates/partials/search/filters-objects.html
+++ b/templates/partials/search/filters-objects.html
@@ -181,8 +181,8 @@
   <div class="filter filter--open" data-filter="Dates">
 {{/if}}
   <a href="{{lookup links.clearFacet "dates"}}" class="filter__name">Date</a>
-  <div class="filter__options filter__daterange">
-    <label>From <input type="number" placeholder="1600" name="filter[date[from]]" value="{{lookup selectedFilters "date[from]"}}"/></label>
-    <label>To <input type="number" placeholder="2016" name="filter[date[to]]" value="{{lookup selectedFilters "date[to]"}}"/></label>
+  <div class="filter__options filter__daterange" role="group" aria-label="Date range">
+    <label for="date-filter-from">From year <input type="number" id="date-filter-from" placeholder="e.g. 1600" name="filter[date[from]]" value="{{lookup selectedFilters "date[from]"}}" min="1" max="9999" /></label>
+    <label for="date-filter-to">To year <input type="number" id="date-filter-to" placeholder="e.g. 2016" name="filter[date[to]]" value="{{lookup selectedFilters "date[to]"}}" min="1" max="9999" /></label>
   </div>
 </div>

--- a/templates/partials/search/filters-people.html
+++ b/templates/partials/search/filters-people.html
@@ -60,8 +60,8 @@
   <div class="filter filter--open" data-filter="Dates">
 {{/if}}
   <a href="{{lookup links.clearFacet "dates"}}" class="filter__name">Date (born / died)</a>
-  <div class="filter__options filter__daterange">
-    <label>From <input type="number" placeholder="1600" name="date[from]" value="{{lookup selectedFilters "date[from]"}}"/></label>
-    <label>To <input type="number" placeholder="2016" name="date[to]" value="{{lookup selectedFilters "date[to]"}}"/></label>
+  <div class="filter__options filter__daterange" role="group" aria-label="Date range (born / died)">
+    <label for="date-filter-from">From year <input type="number" id="date-filter-from" placeholder="e.g. 1600" name="date[from]" value="{{lookup selectedFilters "date[from]"}}" min="1" max="9999" /></label>
+    <label for="date-filter-to">To year <input type="number" id="date-filter-to" placeholder="e.g. 2016" name="date[to]" value="{{lookup selectedFilters "date[to]"}}" min="1" max="9999" /></label>
   </div>
 </div>


### PR DESCRIPTION
## Summary

- **Bug fix**: tabbing from the "From year" field to the "To year" field was triggering a search immediately (before the user could enter the second value). Fixed by replacing per-input `blur` listeners with a single `focusout` on the `.filter__daterange` container — the search only fires when focus leaves the container entirely, or on Enter.
- **WCAG 2.1**: addressed several accessibility issues on the date range inputs across all three search filter templates (`filters-all`, `filters-objects`, `filters-people`).

## WCAG changes

| Criterion | Issue | Fix |
|---|---|---|
| 1.3.1 Info & Relationships | No programmatic grouping for the two related inputs | `role="group"` + `aria-label` on container |
| 4.1.2 Name, Role, Value | Label association was implicit only | Explicit `for`/`id` pairing added to all inputs |
| 2.4.6 Labels | "From" / "To" alone were ambiguous (objects + people templates) | Expanded to "From year" / "To year" |
| Input constraints | No `min`/`max` on number inputs | Added `min="1" max="9999"` |

## Files changed

- `client/routes/search.js` — blur → focusout fix
- `templates/partials/search/filters-all.html`
- `templates/partials/search/filters-objects.html`
- `templates/partials/search/filters-people.html`

## Test plan

- [x] Open Objects search, expand Date filter, type a "From" year and tab to "To" — confirm no search fires until leaving the "To" field (or pressing Enter)
- [x] Enter only a "From" year and click elsewhere — confirm search fires with just the from filter
- [x] Enter both years and press Enter — confirm search fires with both filters applied
- [x] Run screen reader (VoiceOver/NVDA) over the date range inputs — confirm group label and individual labels are announced correctly