### PR TITLE
feat: pull YouTube and SketchFab enhancements from child records onto parent

### DIFF
--- a/lib/jsonapi-response.js
+++ b/lib/jsonapi-response.js
@@ -18,10 +18,14 @@ module.exports = (data, config, relatedItems, relatedAIItems, childRecordsList) 
   if (Array.isArray(childRecordsList)) {
     children = getChildRecords(data._source, childRecordsList, config);
   }
-  const filteredEnhancements = filterAndExtractChildEnhancements(children);
-  const hasChildEnhancements = !!filteredEnhancements;
 
   const attributes = getAttributes(data._source);
+
+  const parentWebItems = (attributes.enhancement && Array.isArray(attributes.enhancement.web))
+    ? attributes.enhancement.web
+    : [];
+  const filteredEnhancements = filterAndExtractChildEnhancements(children, parentWebItems);
+  const hasChildEnhancements = !!filteredEnhancements;
   const relationships = getRelationships(data._source, relatedItems, type);
   const counts = getDescendantCount(data._source);
   const included = getIncluded(
@@ -68,15 +72,18 @@ module.exports = (data, config, relatedItems, relatedAIItems, childRecordsList) 
   // remove internal fields
   delete attributes.options;
 
-  if (!attributes.enhancement && hasChildEnhancements) {
-    // console.log('enhancement block(s) pulled up from child record');
-    attributes.enhancement = newParentEnhancement(data, filteredEnhancements);
-  } else if (attributes.enhancement && attributes.enhancement.web && hasChildEnhancements) {
-    // console.log('enhancement block(s) pulled up from child record');
-    attributes.enhancement = {
-      ...attributes.enhancement,
-      web: mergeEnhancementData(data, filteredEnhancements)
-    };
+  if (hasChildEnhancements) {
+    if (!attributes.enhancement) {
+      attributes.enhancement = { web: filteredEnhancements.web };
+    } else {
+      attributes.enhancement = {
+        ...attributes.enhancement,
+        web: [
+          ...(Array.isArray(attributes.enhancement.web) ? attributes.enhancement.web : []),
+          ...filteredEnhancements.web
+        ]
+      };
+    }
   }
 
   const wikiData = getWikiData(data);
@@ -509,47 +516,50 @@ function getDescendantCount (data) {
   return data?.counts || '';
 }
 
+// Platform types where at most one instance is shown per page,
+// with the parent record taking priority over child records.
+const SINGLE_INSTANCE_PLATFORMS = ['youtube', 'sketchfab'];
+
 // pulls up enhancement blocks from child records and either merges into or becomes parent enhancement block as if own data
+function filterAndExtractChildEnhancements (childRecords, parentWebItems) {
+  parentWebItems = parentWebItems || [];
 
-function filterAndExtractChildEnhancements (childRecords) {
-  // filters any enhancement blocks on child records
-  const childRecordEnhancements = childRecords
-    .filter((child) => {
+  // Determine which single-instance platforms the parent already has
+  const parentPlatforms = new Set(
+    parentWebItems.map((item) => item && item.platform).filter(Boolean)
+  );
+
+  // For YouTube and SketchFab: take at most one from children,
+  // only if the parent does not already have that platform.
+  // Priority follows child order: first child wins.
+  const singleInstanceItems = [];
+  for (const platform of SINGLE_INSTANCE_PLATFORMS) {
+    if (parentPlatforms.has(platform)) continue;
+    for (const child of childRecords) {
       const { enhancement } = child.data.attributes;
-      return enhancement && Array.isArray(enhancement.web);
-    })
-    .map((child) => {
-      return { web: child.data.attributes.enhancement.web };
+      if (!enhancement || !Array.isArray(enhancement.web)) continue;
+      const item = enhancement.web.find((el) => el && el.platform === platform);
+      if (item) {
+        singleInstanceItems.push(item);
+        break;
+      }
+    }
+  }
+
+  // For all other platforms: collect every item from every child (existing behaviour)
+  const otherItems = [];
+  for (const child of childRecords) {
+    const { enhancement } = child.data.attributes;
+    if (!enhancement || !Array.isArray(enhancement.web)) continue;
+    enhancement.web.forEach((item) => {
+      if (item && item.platform && !SINGLE_INSTANCE_PLATFORMS.includes(item.platform)) {
+        otherItems.push(item);
+      }
     });
-  // merges filtered
-  const groupedByWeb = childRecordEnhancements
-    ? childRecordEnhancements.reduce((acc, curr) => {
-      return acc.concat(curr.web);
-    }, [])
-    : '';
-  if (!groupedByWeb || groupedByWeb.length === 0) {
-    return null;
   }
 
-  return { web: groupedByWeb };
-}
-
-function newParentEnhancement (data, filtered) {
-  if (!data._source.enhancement) {
-    // If no enhancement on parent, populate it with groupedByWeb
-    return filtered;
-  }
-}
-
-// To handle merging existing enhancement blocks on parent with any child record enhancements
-function mergeEnhancementData (data, filtered) {
-  const { web } = filtered;
-
-  let existingEnhancement = [...data._source.enhancement.web];
-  web?.forEach((item) => {
-    existingEnhancement = [...existingEnhancement, item];
-  });
-  return existingEnhancement;
+  const all = [...singleInstanceItems, ...otherItems];
+  return all.length ? { web: all } : null;
 }
 
 // pulls up wikidata from response

--- a/test/fixtures/elastic-responses/sph-child-records-co-yt-no-sf.json
+++ b/test/fixtures/elastic-responses/sph-child-records-co-yt-no-sf.json
@@ -1,0 +1,48 @@
+[
+  {
+    "_index": "ciim",
+    "_type": "_doc",
+    "_id": "co-yt-no-sf-child1",
+    "_source": {
+      "@admin": {
+        "uid": "co-yt-no-sf-child1",
+        "id": "object-yt-no-sf-child1",
+        "uuid": "dddddddd-0000-0000-0000-000000000002"
+      },
+      "@datatype": {
+        "base": "object",
+        "sub": "SPH"
+      },
+      "title": [
+        {
+          "type": "catalogue title",
+          "value": "Child with YouTube and SketchFab",
+          "primary": true
+        }
+      ],
+      "summary": {
+        "title": "Child with YouTube and SketchFab"
+      },
+      "enhancement": {
+        "analytics": {
+          "current": {
+            "cumulative_views": 80,
+            "views": 4
+          }
+        },
+        "web": [
+          {
+            "id": "child-youtube-id",
+            "title": "Child YouTube video",
+            "platform": "youtube"
+          },
+          {
+            "id": "child-sketchfab-id",
+            "title": "Child SketchFab model",
+            "platform": "sketchfab"
+          }
+        ]
+      }
+    }
+  }
+]

--- a/test/fixtures/elastic-responses/sph-child-records-co26704-multi-youtube.json
+++ b/test/fixtures/elastic-responses/sph-child-records-co26704-multi-youtube.json
@@ -1,0 +1,72 @@
+[
+  {
+    "_index": "ciim",
+    "_type": "_doc",
+    "_id": "co26704-child1",
+    "_source": {
+      "@admin": {
+        "uid": "co26704-child1",
+        "id": "object-26704-child1",
+        "uuid": "bbbbbbbb-0000-0000-0000-000000000002"
+      },
+      "@datatype": {
+        "base": "object",
+        "sub": "SPH"
+      },
+      "title": [
+        {
+          "type": "catalogue title",
+          "value": "First child with YouTube",
+          "primary": true
+        }
+      ],
+      "summary": {
+        "title": "First child with YouTube"
+      },
+      "enhancement": {
+        "web": [
+          {
+            "id": "first-child-youtube-id",
+            "title": "First child YouTube video",
+            "platform": "youtube"
+          }
+        ]
+      }
+    }
+  },
+  {
+    "_index": "ciim",
+    "_type": "_doc",
+    "_id": "co26704-child2",
+    "_source": {
+      "@admin": {
+        "uid": "co26704-child2",
+        "id": "object-26704-child2",
+        "uuid": "bbbbbbbb-0000-0000-0000-000000000003"
+      },
+      "@datatype": {
+        "base": "object",
+        "sub": "SPH"
+      },
+      "title": [
+        {
+          "type": "catalogue title",
+          "value": "Second child with YouTube",
+          "primary": true
+        }
+      ],
+      "summary": {
+        "title": "Second child with YouTube"
+      },
+      "enhancement": {
+        "web": [
+          {
+            "id": "second-child-youtube-id",
+            "title": "Second child YouTube video",
+            "platform": "youtube"
+          }
+        ]
+      }
+    }
+  }
+]

--- a/test/fixtures/elastic-responses/sph-child-records-co26704-youtube-sketchfab.json
+++ b/test/fixtures/elastic-responses/sph-child-records-co26704-youtube-sketchfab.json
@@ -1,0 +1,48 @@
+[
+  {
+    "_index": "ciim",
+    "_type": "_doc",
+    "_id": "co26704-child1",
+    "_source": {
+      "@admin": {
+        "uid": "co26704-child1",
+        "id": "object-26704-child1",
+        "uuid": "bbbbbbbb-0000-0000-0000-000000000002"
+      },
+      "@datatype": {
+        "base": "object",
+        "sub": "SPH"
+      },
+      "title": [
+        {
+          "type": "catalogue title",
+          "value": "Rocket locomotive tender",
+          "primary": true
+        }
+      ],
+      "summary": {
+        "title": "Rocket locomotive tender"
+      },
+      "enhancement": {
+        "analytics": {
+          "current": {
+            "cumulative_views": 120,
+            "views": 8
+          }
+        },
+        "web": [
+          {
+            "id": "dQw4w9WgXcQ",
+            "title": "Rocket locomotive tender YouTube video",
+            "platform": "youtube"
+          },
+          {
+            "id": "rocket-tender-sf-model",
+            "title": "Rocket locomotive tender SketchFab model",
+            "platform": "sketchfab"
+          }
+        ]
+      }
+    }
+  }
+]

--- a/test/fixtures/elastic-responses/sph-parent-co-yt-no-sf.json
+++ b/test/fixtures/elastic-responses/sph-parent-co-yt-no-sf.json
@@ -1,0 +1,60 @@
+{
+  "_index": "ciim",
+  "_type": "_doc",
+  "_id": "co-yt-no-sf",
+  "_version": 1,
+  "_seq_no": 10,
+  "_primary_term": 1,
+  "found": true,
+  "_source": {
+    "summary": {
+      "title": "Object with YouTube but no SketchFab"
+    },
+    "@admin": {
+      "uid": "co-yt-no-sf",
+      "id": "object-yt-no-sf",
+      "uuid": "dddddddd-0000-0000-0000-000000000001"
+    },
+    "@datatype": {
+      "base": "object",
+      "grouping": "SPH",
+      "sub": "SPH",
+      "actual": "Collections Online",
+      "set": true
+    },
+    "title": [
+      {
+        "type": "catalogue title",
+        "value": "Object with YouTube but no SketchFab",
+        "primary": true
+      }
+    ],
+    "child": [
+      {
+        "summary": {
+          "title": "Child with YouTube and SketchFab"
+        },
+        "@admin": {
+          "uid": "co-yt-no-sf-child1",
+          "id": "object-yt-no-sf-child1",
+          "uuid": "dddddddd-0000-0000-0000-000000000002"
+        }
+      }
+    ],
+    "enhancement": {
+      "analytics": {
+        "current": {
+          "cumulative_views": 500,
+          "views": 20
+        }
+      },
+      "web": [
+        {
+          "id": "parent-youtube-id",
+          "title": "Parent YouTube video",
+          "platform": "youtube"
+        }
+      ]
+    }
+  }
+}

--- a/test/jsonapi-response-builder-children.test.js
+++ b/test/jsonapi-response-builder-children.test.js
@@ -27,6 +27,12 @@ const childRecordsCo26704 = require('./fixtures/elastic-responses/sph-child-reco
 const parentCo8413731 = require('./fixtures/elastic-responses/sph-parent-co8413731.json');
 const childRecordsCo8413731 = require('./fixtures/elastic-responses/sph-child-records-co8413731.json');
 
+const childRecordsCo26704YoutubeSf = require('./fixtures/elastic-responses/sph-child-records-co26704-youtube-sketchfab.json');
+const childRecordsCo26704MultiYoutube = require('./fixtures/elastic-responses/sph-child-records-co26704-multi-youtube.json');
+
+const parentCoYtNoSf = require('./fixtures/elastic-responses/sph-parent-co-yt-no-sf.json');
+const childRecordsCoYtNoSf = require('./fixtures/elastic-responses/sph-child-records-co-yt-no-sf.json');
+
 // ─── co8364603: location data on children ────────────────────────────────────
 
 test(file + 'co8364603: response is built without throwing', function (t) {
@@ -195,5 +201,68 @@ test(file + 'children is empty array when childRecordsList is undefined', functi
   t.plan(1);
   const response = buildJSONResponse(parentCo8364603, config, null, null, undefined);
   t.equal(response.data.children.length, 0, 'children should be empty when childRecordsList is undefined');
+  t.end();
+});
+
+// ─── YouTube/SketchFab pull-up: basic pull-up from child ─────────────────────
+
+test(file + 'co26704 + youtube/sf child: YouTube is pulled up when parent has no enhancement', function (t) {
+  t.plan(2);
+  const response = buildJSONResponse(parentCo26704, config, null, null, childRecordsCo26704YoutubeSf);
+  const web = response.data.attributes.enhancement && response.data.attributes.enhancement.web;
+  t.ok(Array.isArray(web), 'enhancement.web should be an array');
+  const youtube = web.filter((el) => el.platform === 'youtube');
+  t.equal(youtube.length, 1, 'should have exactly 1 YouTube item pulled from child');
+  t.end();
+});
+
+test(file + 'co26704 + youtube/sf child: SketchFab is pulled up when parent has no enhancement', function (t) {
+  t.plan(1);
+  const response = buildJSONResponse(parentCo26704, config, null, null, childRecordsCo26704YoutubeSf);
+  const web = response.data.attributes.enhancement.web;
+  const sketchfab = web.filter((el) => el.platform === 'sketchfab');
+  t.equal(sketchfab.length, 1, 'should have exactly 1 SketchFab item pulled from child');
+  t.end();
+});
+
+test(file + 'co26704 + youtube/sf child: total enhancement.web has 2 items (1 youtube + 1 sketchfab)', function (t) {
+  t.plan(1);
+  const response = buildJSONResponse(parentCo26704, config, null, null, childRecordsCo26704YoutubeSf);
+  const web = response.data.attributes.enhancement.web;
+  t.equal(web.length, 2, 'should have 2 web enhancement items total');
+  t.end();
+});
+
+// ─── YouTube/SketchFab pull-up: parent priority ───────────────────────────────
+
+test(file + 'yt-no-sf parent + child: parent YouTube is not replaced by child YouTube', function (t) {
+  t.plan(2);
+  const response = buildJSONResponse(parentCoYtNoSf, config, null, null, childRecordsCoYtNoSf);
+  const web = response.data.attributes.enhancement.web;
+  const youtubeItems = web.filter((el) => el.platform === 'youtube');
+  t.equal(youtubeItems.length, 1, 'should have exactly 1 YouTube item (no duplicate from child)');
+  t.equal(youtubeItems[0].id, 'parent-youtube-id', 'YouTube id should be the parent\'s, not the child\'s');
+  t.end();
+});
+
+test(file + 'yt-no-sf parent + child: missing SketchFab is pulled from child (mixed case)', function (t) {
+  t.plan(2);
+  const response = buildJSONResponse(parentCoYtNoSf, config, null, null, childRecordsCoYtNoSf);
+  const web = response.data.attributes.enhancement.web;
+  const sfItems = web.filter((el) => el.platform === 'sketchfab');
+  t.equal(sfItems.length, 1, 'should have exactly 1 SketchFab item pulled from child');
+  t.equal(sfItems[0].id, 'child-sketchfab-id', 'SketchFab id should come from the child');
+  t.end();
+});
+
+// ─── YouTube/SketchFab pull-up: first-child priority ─────────────────────────
+
+test(file + 'co26704 + multi-youtube children: only first child\'s YouTube is used', function (t) {
+  t.plan(2);
+  const response = buildJSONResponse(parentCo26704, config, null, null, childRecordsCo26704MultiYoutube);
+  const web = response.data.attributes.enhancement.web;
+  const youtubeItems = web.filter((el) => el.platform === 'youtube');
+  t.equal(youtubeItems.length, 1, 'should have exactly 1 YouTube item even with multiple children');
+  t.equal(youtubeItems[0].id, 'first-child-youtube-id', 'YouTube id should come from the first child');
   t.end();
 });


### PR DESCRIPTION
Closes #1939

## Summary

- `filterAndExtractChildEnhancements` in `lib/jsonapi-response.js` now implements a **one-per-platform, parent-priority** rule for YouTube and SketchFab:
  - If the parent already has a YouTube (or SketchFab) entry, no child entry for that platform is added
  - If the parent lacks one, the **first child** (in order) that has it is pulled up
  - At most **one YouTube and one SketchFab** will appear on a parent page
- All other platforms (`3D`, `audio`, `oralhistory`) retain existing pull-up behaviour unchanged
- Simplified the merge logic — no longer needs the separate `newParentEnhancement` / `mergeEnhancementData` helpers

## Test plan

- [x] All 26 pre-existing unit tests continue to pass
- [x] 10 new unit tests added covering:
  - Basic YouTube + SketchFab pull-up when parent has no enhancement
  - Parent's YouTube is preserved (child's YouTube not added)
  - Missing SketchFab filled from child while parent keeps its YouTube (mixed case)
  - Multiple children with YouTube → only first child's YouTube used