### PR TITLE
fix: unescape \, to %2C in paramify so SPA comma filters round-trip correctly

### DIFF
--- a/lib/helpers/paramify.js
+++ b/lib/helpers/paramify.js
@@ -15,10 +15,10 @@ module.exports = function paramify (q) {
         paramString += '/' + 'rotational';
       } else if (typeof q[el] === 'object') {
         paramString += '/' + removeFilter(el) + '/' + q[el].reduce((acc, b, i) => {
-          return acc + (i !== 0 ? '+' : '') + b.split(' ').join('-').split('/').join('%252F');
+          return acc + (i !== 0 ? '+' : '') + b.replace(/\\,/g, '%2C').split(' ').join('-').split('/').join('%252F');
         }, '');
       } else {
-        paramString += '/' + removeFilter(el) + '/' + String(q[el]).split('/').join('%252F');
+        paramString += '/' + removeFilter(el) + '/' + String(q[el]).replace(/\\,/g, '%2C').split('/').join('%252F');
       }
     }
   });

--- a/test/paramify.test.js
+++ b/test/paramify.test.js
@@ -27,6 +27,22 @@ test(file + 'paramify double-encodes forward slashes in values as %252f', (t) =>
   t.end();
 });
 
+test(file + 'paramify converts escaped commas (\\,) to %2C in URL so server does not double-escape', (t) => {
+  // Simulates values that came through parse-params.js comma-escaping on the client side.
+  // paramify must unescape \, → %2C so the server's parse-params only escapes once.
+  t.equal(
+    paramify({ places: 'Paddington\\, London' }),
+    '/places/paddington%2c london',
+    'string: escaped comma becomes %2C in URL (space kept as-is for string branch)'
+  );
+  t.equal(
+    paramify({ makers: ['Science Museum\\, London', 'Rolls Royce'] }),
+    '/makers/science-museum%2c-london+rolls-royce',
+    'array: escaped comma becomes %2C and spaces become dashes'
+  );
+  t.end();
+});
+
 test(file + 'paramify encodes values with space-dash-space correctly', (t) => {
   t.equal(
     paramify({ object_type: ['box - container'] }),


### PR DESCRIPTION
## Summary

- Fixes a double-escaping bug in the SPA path for filter values containing literal commas (e.g. maker "Science Museum, London", place "Paddington, London")
- `parse-params.js` is shared client/server — it escapes `,` → `\,` when running in the browser. Previously `paramify()` emitted the raw backslash into the URL, so the server ran `parse-params.js` a second time and double-escaped to `\\,`. `format-value.js` stripped one layer but left a stray `\` in the Elasticsearch term → 0 results.
- Fix: `paramify()` now converts `\,` → `%2C` before building the URL path. `uppercaseFirstChar`'s `decodeURIComponent` call decodes `%2C` → `,` centrally on the server, so `parse-params.js` only escapes once and `format-value.js` receives a clean `,`.

## Test plan

- [x] `npm run test:unit:tape` — all 56 unit tests pass (new test for the `\,` → `%2C` conversion added to `test/paramify.test.js`)
- [x] Rebuild JS bundle (`npm run build:js`) and start server
- [ ] Visit a person/organisation record with "Made:" entries whose place names contain commas — clicking a place link should return results
- [x] Clicking a maker facet pill for a maker with a comma in their name should retain correct results in SPA navigation