### PR TITLE
fix: hide Made fact on people/organisation record pages

### DIFF
--- a/lib/transforms/json-to-html-data.js
+++ b/lib/transforms/json-to-html-data.js
@@ -237,7 +237,7 @@ function getFacts (resource, links) {
   const nationality = getValues.getNationality(resource.data);
   const born = getValues.getBorn(resource.data, links);
   const makers = getValues.getMakers(resource);
-  const made = getMade(resource, links);
+  const made = resource.data.type !== 'people' ? getMade(resource, links) : null;
   const fonds = getFondsFact(resource);
 
   return [occupation, nationality, born, made, fonds]

--- a/test/filter-links.test.js
+++ b/test/filter-links.test.js
@@ -146,6 +146,38 @@ test('bad date range test', (t) => {
   t.end();
 });
 
+test('Made fact is not shown on people records', (t) => {
+  t.plan(1);
+
+  const resource = {
+    data: {
+      type: 'people',
+      attributes: {
+        name: [{ value: 'Great Western Railway', primary: true }],
+        creation: {
+          date: [{ value: '1900' }]
+        }
+      },
+      links: { root: 'http://localhost:8000' },
+      record: {}
+    },
+    included: [
+      {
+        type: 'place',
+        attributes: {
+          role: { value: 'user' },
+          summary: { title: 'Railway Hotel, Taunton' }
+        }
+      }
+    ]
+  };
+  const JSONData = JSONToHTML(resource);
+  const made = JSONData.fact.find(el => el.key === 'Made');
+
+  t.notOk(made, 'Made fact is absent from people records');
+  t.end();
+});
+
 test('collection link with forward slash in name encodes slash as %252F', (t) => {
   t.plan(1);
 


### PR DESCRIPTION
## Summary

- The `Made:` fact was appearing on people and organisation record pages, showing associated places (e.g. GWR-owned hotels like "Railway Hotel, Taunton") from the top-level `place` field on agent records
- These are *related places* with a role of `user` — not manufacture metadata. `creation.place` is the correct field for manufacturing location and only exists on object records
- One-line guard in `getFacts` skips `getMade` for `people` records, following the same `data.type !== 'people'` pattern already used on lines 637 and 652

## Changes

- `lib/transforms/json-to-html-data.js` — skip `getMade` when `resource.data.type === 'people'`
- `test/filter-links.test.js` — new test asserting Made fact is absent from people records

## Test plan

- [x] `npm run test:unit:tape` — all tests pass (12/12 in filter-links)
- [x] Visit `/people/cp1627/great-western-railway` — no `MADE:` row in the facts section
- [x] Visit an object record with a place — `MADE:` still appears as expected