### PR TITLE
fix: strip attribution notes from creation items in JSON API response

### DIFF
--- a/lib/jsonapi-response.js
+++ b/lib/jsonapi-response.js
@@ -21,6 +21,21 @@ module.exports = (data, config, relatedItems, relatedAIItems, childRecordsList) 
 
   const attributes = getAttributes(data._source);
 
+  // TODO: Remove this block once attribution notes have been removed from the Elasticsearch index itself.
+  // Strips `attribution.note` from creation maker/place items to prevent internal cataloguer
+  // notes (e.g. "project cataloguer") from leaking into the public JSON API response.
+  if (attributes.creation) {
+    ['maker', 'place'].forEach((key) => {
+      if (Array.isArray(attributes.creation[key])) {
+        attributes.creation[key].forEach((item) => {
+          if (item['@link'] && item['@link'].attribution) {
+            delete item['@link'].attribution.note;
+          }
+        });
+      }
+    });
+  }
+
   const parentWebItems = (attributes.enhancement && Array.isArray(attributes.enhancement.web))
     ? attributes.enhancement.web
     : [];


### PR DESCRIPTION
## Summary
- Internal cataloguer notes (e.g. `"project cataloguer"`) stored in `creation.maker/place[@link].attribution.note` were leaking into the public JSON API response
- Strips `attribution.note` from creation maker and place items at response-build time in `lib/jsonapi-response.js`
- Includes a TODO comment to remove the block once notes are cleaned from the Elasticsearch index itself

## Test plan
- [x] Visit `/api/objects/co71938` with `Accept: application/json` header and confirm `attribution.note` no longer appears on maker items
- [x] Verify other creation fields (dates, roles, attribution type) are unaffected