### PR TITLE
feat: smart labelling for organisation vs person on people pages

### DIFF
--- a/fixtures/attributes.js
+++ b/fixtures/attributes.js
@@ -1,5 +1,6 @@
 module.exports = [
   '@admin',
+  '@datatype',
   'barcode',
   'autocomplete',
   'birth',

--- a/lib/transforms/data-layer.js
+++ b/lib/transforms/data-layer.js
@@ -6,7 +6,7 @@ module.exports = function (type, facts) {
     if (type === 'people') {
       result.recordType = 'people';
 
-      if (data.key === 'occupation') {
+      if (data.key === 'occupation' || data.key === 'industry') {
         result.recordOccupation = data.value.map(function (o) {
           return o.value.replace(',', ''); // delete comma added for display on view
         });
@@ -16,7 +16,7 @@ module.exports = function (type, facts) {
         result.recordNationality = data.value;
       }
 
-      if (data.key === 'born in') {
+      if (data.key === 'born in' || data.key === 'based') {
         result.recordBorn = data.value;
       }
     }

--- a/lib/transforms/get-values.js
+++ b/lib/transforms/get-values.js
@@ -232,14 +232,15 @@ module.exports = {
 
   isOrganisation (data) {
     return (
-      getNestedProperty(data, 'attributes.type.sub_type.0') ===
-        'organisation' ||
+      getNestedProperty(data, 'attributes.@datatype.actual') === 'organisation' ||
+      getNestedProperty(data, 'attributes.type.sub_type.0') === 'organisation' ||
       getNestedProperty(data, 'attributes.type.type') === 'institution'
     );
   },
 
   isPerson (data) {
     return (
+      getNestedProperty(data, 'attributes.@datatype.actual') === 'person' ||
       getNestedProperty(data, 'attributes.type.sub_type.0') === 'person' ||
       getNestedProperty(data, 'attributes.type.type') === 'person'
     );

--- a/templates/partials/search/filters-people.html
+++ b/templates/partials/search/filters-people.html
@@ -2,11 +2,11 @@
 
 {{#if filters.occupation.length}}
   {{#if (activeFacet selectedFilters 'occupation')}}
-    <div class="filter filter--active filter--open" data-filter="Occupation">
-      <a href="{{lookup links.clearFacet "filter[occupation]"}}" class="filter__name">Occupation</a>
+    <div class="filter filter--active filter--open" data-filter="Industry">
+      <a href="{{lookup links.clearFacet "filter[occupation]"}}" class="filter__name">Industry</a>
   {{else}}
-    <div class="filter filter--open" data-filter="Occupation">
-      <a href="{{lookup links.clearFacet "filter[occupation]"}}" class="filter__name">Occupation</a>
+    <div class="filter filter--open" data-filter="Industry">
+      <a href="{{lookup links.clearFacet "filter[occupation]"}}" class="filter__name">Industry</a>
   {{/if}}
     <div class="filter__options">
       <ul>
@@ -20,11 +20,11 @@
 
 {{#if filters.place_born.length}}
   {{#if (activeFacet selectedFilters 'birth[place]')}}
-    <div class="filter filter--active filter--open" data-filter="Place born">
-      <a href="{{lookup links.clearFacet "filter[birth[place]]"}}" class="filter__name">Place born</a>
+    <div class="filter filter--active filter--open" data-filter="Place of origin">
+      <a href="{{lookup links.clearFacet "filter[birth[place]]"}}" class="filter__name">Place of origin</a>
   {{else}}
-    <div class="filter filter--open" data-filter="Place born">
-      <a href="{{lookup links.clearFacet "filter[birth[place]]"}}" class="filter__name">Place born</a>
+    <div class="filter filter--open" data-filter="Place of origin">
+      <a href="{{lookup links.clearFacet "filter[birth[place]]"}}" class="filter__name">Place of origin</a>
   {{/if}}
     <div class="filter__options">
       <ul>

--- a/test/transforms/data-layer.test.js
+++ b/test/transforms/data-layer.test.js
@@ -58,3 +58,26 @@ test('data-layer return right object for people', (t) => {
   t.equal(layer, expected, 'The layer for people is ok');
   t.end();
 });
+
+test('data-layer return right object for organisations (industry key)', (t) => {
+  t.plan(1);
+  const data = [
+    {
+      key: 'industry',
+      value: [{ value: 'railway company' }]
+    },
+    {
+      key: 'based',
+      value: 'England, United Kingdom'
+    }
+  ];
+
+  const layer = dataLayer('people', data);
+  const expected = JSON.stringify({
+    recordType: 'people',
+    recordOccupation: ['railway company'],
+    recordBorn: 'England, United Kingdom'
+  });
+  t.equal(layer, expected, 'The layer for organisations uses industry key correctly');
+  t.end();
+});


### PR DESCRIPTION
Closes #2024

## Summary
- `@datatype` added to the JSON API attributes list so `isOrganisation`/`isPerson` can correctly read `@datatype.actual` — the previous check against `attributes.type.sub_type` never matched for Mimsy (cp*) records, so organisations were always treated as people
- Organisation records now show **INDUSTRY** for occupation and **BASED** for birth place; person records continue to show **OCCUPATION** and **BORN IN**
- Search facet labels on `/search/people` updated: **Occupation → Industry**, **Place born → Place of origin**
- Analytics data-layer updated to capture `'industry'` and `'based'` keys alongside the existing `'occupation'` / `'born in'` checks

## Test plan
- [x] `/people/cp1627/great-western-railway` shows `INDUSTRY: Railway company` and `BASED: England, United Kingdom`
- [x] `/people/cp134086` (person) still shows `OCCUPATION` and `BORN IN`
- [x] `/search/people` facet sidebar shows `Industry` and `Place of origin`
- [x] Unit tests pass (`data-layer.test.js` — 3 tests)