### PR TITLE
fix: exclude semicolon-joined literal values from place and maker facets

### DIFF
--- a/lib/facets/aggs-all.js
+++ b/lib/facets/aggs-all.js
@@ -87,7 +87,7 @@ module.exports = function (queryParams) {
         },
         aggs: {
           maker_filters: {
-            terms: { field: 'creation.maker.summary.title.keyword' }
+            terms: { field: 'creation.maker.summary.title.keyword', exclude: '.*;.*' }
           }
         }
       },
@@ -109,7 +109,7 @@ module.exports = function (queryParams) {
         filter: filterQuery,
         aggs: {
           place_filters: {
-            terms: { field: 'creation.place.summary.title.keyword' }
+            terms: { field: 'creation.place.summary.title.keyword', exclude: '.*;.*' }
           }
         }
       },


### PR DESCRIPTION
## Summary

- Adds `exclude: '.*;.*'` to the `place_filters` and `maker_filters` terms aggregations in `lib/facets/aggs-all.js`
- Mimsy catalogue records store multiple place/maker values in a single semicolon-separated literal entry (e.g. `"London, Greater London, England, United Kingdom; Tonbridge, Kent, England, United Kingdom"`), which was surfacing as a facet bucket in the UI
- The 64+ affected records remain fully discoverable via their individual resolved reference entries (e.g. `"London"`, `"Tonbridge"`) which are already indexed separately — no records become undiscoverable
- Same pattern applied to maker facet (e.g. `"British Railways; Jas Truscott and Son Limited"`)

## Root cause

The indexing pipeline correctly creates separate reference entries for each resolved place/maker authority, but also preserves the raw catalogue string as a single literal entry. The `terms` aggregation picks up all `summary.title` values including these concatenated literals, producing unwanted composite facet values.

The fix is application-level (no re-index required). Removing the literals entirely is not the right approach as they serve as provenance and full-text search fallback.

## Test plan

- [x] Navigate to a search page with the Place facet expanded and confirm no values containing `;` appear
- [x] Navigate to a search page with the Maker facet expanded and confirm no values like `"British Railways; Jas Truscott and Son Limited"` appear
- [x] Confirm records previously bucketed under a semicolon value (e.g. NRM railway notices) still appear under individual place facets like `"London"` and `"Tonbridge"`