### PR TITLE
fix: display-ready names in Worked Alongside section on Wikidata panel

### DIFF
--- a/routes/wiki.js
+++ b/routes/wiki.js
@@ -171,7 +171,7 @@ async function fetchColleagues (employers, currentQCode, elastic, config) {
         'SELECT DISTINCT ?item WHERE {',
         `  ?item wdt:P108 wd:${employerQCode} ;`,
         '        wdt:P31 wd:Q5 .',
-        '} LIMIT 100'
+        '} LIMIT 500'
       ].join('\n');
       const url = wbk.sparqlQuery(sparql);
       const res = await fetchWithRetry(url, { signal: AbortSignal.timeout(10000) });


### PR DESCRIPTION
## Summary

- `fetchColleagues()` in `routes/wiki.js` was reading `name.value` directly from raw ES `_source`, which for Mimsy records is stored in catalogue-inverted `"Surname, Firstname"` order
- PR #2032 removed comma-transposition from `normalise.js` and moved it into `getTitle()`, but `fetchColleagues()` was missed — it never calls `getTitle()`
- Result: "Worked Alongside" section showed `Wayne, Ron` and `Wozniak, Steve` instead of `Ron Wayne` and `Steve Wozniak`

## Fix

- Adds `colleagueDisplayName()` helper mirroring `getTitle()`/`getSystemName()` logic: `Mimsy XG` records use `summary.title` (always natural display order), `Adlib Archives` records with `name.first` reconstruct `"First Last"`, others fall back to preferred-name entry
- Extends the ES `_source` query to fetch `summary` and `@admin` alongside `name` and `wikidata`
- Wikidata confirmed: all three (Jobs Q19837, Wayne Q332591, Wozniak Q483382) have `P108 = Apple Inc.` — the colleague links are correct, only the display names were broken

## Test plan

- [x] Visit `/people/cp50119` (Steve Jobs) — Wikidata panel "Worked alongside" should show `Ron Wayne` and `Steve Wozniak` as linked names
- [ ] Visit `/people/cp50120` (Ron Wayne) — should show `Steve Jobs` and `Steve Wozniak` as colleagues at Apple Inc.
- [x] Visit `/people/cp50118` (Steve Wozniak) — should show `Steve Jobs` and `Ron Wayne` as colleagues at Apple Inc., and `Steve Jobs` at Atari
- [x] No regression on org names with commas (e.g. "Science Museum, London") — `colleagueDisplayName()` uses the same system-aware logic as `getTitle()`