### PR TITLE
fix: exclude semicolon-joined literal values from all human-readable facets

### DIFF
--- a/lib/facets/aggs-all.js
+++ b/lib/facets/aggs-all.js
@@ -60,7 +60,8 @@ module.exports = function (queryParams) {
             // size: 20 — keeps the facet list manageable in the UI
             terms: {
               size: 20,
-              field: 'cumulation.collector.summary.title.keyword'
+              field: 'cumulation.collector.summary.title.keyword',
+              exclude: '.*;.*'
             }
           }
         }
@@ -73,9 +74,7 @@ module.exports = function (queryParams) {
         },
         aggs: {
           sub_group_filters: {
-            terms: {
-              field: 'subgroup.summary.title.keyword'
-            }
+            terms: { field: 'subgroup.summary.title.keyword', exclude: '.*;.*' }
           }
         }
       },
@@ -109,7 +108,7 @@ module.exports = function (queryParams) {
         },
         aggs: {
           object_type_filters: {
-            terms: { field: 'name.value.keyword' }
+            terms: { field: 'name.value.keyword', exclude: '.*;.*' }
           }
         }
       },
@@ -125,7 +124,7 @@ module.exports = function (queryParams) {
         filter: filterQuery,
         aggs: {
           user_filters: {
-            terms: { field: 'agent.summary.title.keyword' }
+            terms: { field: 'agent.summary.title.keyword', exclude: '.*;.*' }
           }
         }
       },
@@ -135,7 +134,7 @@ module.exports = function (queryParams) {
           archive_filters: {
             // size: 100 — fonds (archive collections) are more numerous than categories;
             // 100 ensures all active fonds appear as filter options
-            terms: { size: 100, field: 'fonds.summary.title.keyword' }
+            terms: { size: 100, field: 'fonds.summary.title.keyword', exclude: '.*;.*' }
           }
         }
       },
@@ -143,7 +142,7 @@ module.exports = function (queryParams) {
         filter: filterQuery,
         aggs: {
           occupation_filters: {
-            terms: { field: 'occupation.value.keyword' }
+            terms: { field: 'occupation.value.keyword', exclude: '.*;.*' }
           }
         }
       },
@@ -151,7 +150,7 @@ module.exports = function (queryParams) {
         filter: filterQuery,
         aggs: {
           place_born_filters: {
-            terms: { field: 'birth.place.name.value.keyword' }
+            terms: { field: 'birth.place.name.value.keyword', exclude: '.*;.*' }
           }
         }
       },
@@ -175,7 +174,7 @@ module.exports = function (queryParams) {
         filter: filterQuery,
         aggs: {
           material_filters: {
-            terms: { field: 'material.value.keyword' }
+            terms: { field: 'material.value.keyword', exclude: '.*;.*' }
           }
         }
       },
@@ -194,7 +193,7 @@ module.exports = function (queryParams) {
             // size: 100 — museum/gallery values are numerous; 100 ensures all locations appear.
             // Both museum and gallery aggregations query the same ondisplay.value.keyword field;
             // the UI layer separates them into museum-level vs gallery-level display.
-            terms: { size: 100, field: 'ondisplay.value.keyword' }
+            terms: { size: 100, field: 'ondisplay.value.keyword', exclude: '.*;.*' }
           }
         }
       },
@@ -203,7 +202,7 @@ module.exports = function (queryParams) {
         aggs: {
           gallery_filters: {
             // size: 100 — see museum comment above
-            terms: { size: 100, field: 'ondisplay.value.keyword' }
+            terms: { size: 100, field: 'ondisplay.value.keyword', exclude: '.*;.*' }
           }
         }
       },


### PR DESCRIPTION
## Summary

- Extends the `exclude: '.*;.*'` fix from PR #2033 (maker, place) to all remaining human-readable `terms` aggregations
- Affected facets: `object_type`, `collection`, `subgroup`, `user`, `archive`, `occupation`, `place_born`, `material`, `museum`, `gallery`
- Mimsy catalogue records preserve semicolon-separated multi-value strings (e.g. `"commercial road vehicle components; steam road vehicle components; boilers; drawings"`) as a single literal entry alongside properly resolved individual reference entries — causing composite strings to surface as facet buckets
- The `exclude: '.*;.*'` pattern drops any bucket value containing a semicolon; no re-index required; affected records remain fully discoverable via their individual resolved facet values

## Root cause

Same as PR #2033. The Mimsy indexing pipeline correctly creates separate reference entries for each resolved value but also preserves the raw concatenated catalogue string. All free-text human-readable `terms` aggregations are susceptible to this; this PR applies the fix consistently across all of them.

Left without `exclude`: `category` (controlled vocabulary), `organisation` (`@datatype.actual` enum), `mphc` (`@admin.uid`), `image_license` (rights code), `has_image` (`@admin.source`).

## Test plan

- [x] Navigate to `/search/objects` and confirm the Object type facet shows only individual values (e.g. "photographic print", "photograph") with no semicolon-joined composites
- [x] Verified via JSON API that zero facet buckets across all affected aggregations contain a semicolon
- [x] Confirmed valid individual values still appear correctly in all facets