### PR TITLE
refactor: simplify wiki image caption with structured-data fallback

### DIFF
--- a/lib/wikidataQueries.js
+++ b/lib/wikidataQueries.js
@@ -136,10 +136,8 @@ async function fetchImageMetadata (filename) {
     '&prop=imageinfo&iiprop=extmetadata&format=json&origin=*';
   try {
     const signal = AbortSignal.timeout(10000);
-    const response = await fetch(url, {
-      signal,
-      headers: { 'User-Agent': 'CollectionsOnline/1.0 (https://collection.sciencemuseumgroup.org.uk; web.team@sciencemuseum.ac.uk)' }
-    });
+    const headers = { 'User-Agent': 'CollectionsOnline/1.0 (https://collection.sciencemuseumgroup.org.uk; web.team@sciencemuseum.ac.uk)' };
+    const response = await fetch(url, { signal, headers });
     if (!response.ok) {
       console.error(`Commons API returned ${response.status} for ${filename}`);
       return null;
@@ -149,51 +147,18 @@ async function fetchImageMetadata (filename) {
     const page = pages ? Object.values(pages)[0] : null;
     const meta = page && page.imageinfo && page.imageinfo[0] && page.imageinfo[0].extmetadata;
     if (!meta) return null;
-    // Build a clean, display-safe caption from the Commons ImageDescription field.
-    // The raw value often contains HTML markup, HTML entities, or structured
-    // archival metadata (Source:, Identifier:, Digitization Sponsor:, etc.) that
-    // is not intended for end-user display.
-    //
-    // Rules applied in order:
-    //   1. Strip actual HTML tags (<...>).
-    //   2. Suppress entirely if HTML entities remain (e.g. &lt; &gt;) — these
-    //      indicate the field contained escaped markup that survived tag-stripping
-    //      and would render as literal &lt; / &gt; characters.
-    //   3. Suppress entirely if a URL is present (http:// or https://) — captions
-    //      containing links are metadata records, not descriptive text.
-    //   4. Normalise whitespace, then truncate near 100 characters. To avoid
-    //      cutting mid-word the truncation extends to the next word boundary,
-    //      up to 20 extra characters, before appending an ellipsis.
-    //
-    // truncateCaption: cut at ~100 chars, but finish the current word (up to +20
-    // chars) so we never split a word mid-syllable.
-    function truncateCaption (text) {
-      if (text.length <= 100) return text;
-      // Find the first space at or after position 100 (within a 20-char grace window).
-      const boundary = text.indexOf(' ', 100);
-      const cutAt = (boundary !== -1 && boundary <= 120) ? boundary : 100;
-      return text.slice(0, cutAt).trimEnd() + '\u2026';
-    }
-    let caption = meta.ImageDescription && meta.ImageDescription.value
+    // Caption selection: prefer the Description (ImageDescription) when it is
+    // short and plain text; otherwise fall back to the structured-data Caption
+    // (the human-curated "Captions" field in the Commons UI).
+    const description = meta.ImageDescription && meta.ImageDescription.value
       ? meta.ImageDescription.value.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim()
       : null;
-    if (caption) {
-      if (/&[lg]t;|&#\d+;/i.test(caption) || /https?:\/\//i.test(caption)) {
-        caption = null;
-      } else {
-        caption = truncateCaption(caption);
-      }
-    }
-    // If ImageDescription was absent or suppressed, fall back to ObjectName.
-    // ObjectName is a short, clean title assigned by the uploader (e.g. "Portrait
-    // of Thomas Nelson") and is almost always suitable for display without further
-    // filtering. Apply the same word-boundary truncation for consistency.
-    if (!caption && meta.ObjectName && meta.ObjectName.value) {
-      const objectName = meta.ObjectName.value.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim();
-      if (objectName) {
-        caption = truncateCaption(objectName);
-      }
-    }
+    const descriptionUsable = description &&
+      description.length <= 100 &&
+      !/&[lg]t;|&#\d+;|https?:\/\//i.test(description);
+    const caption = descriptionUsable
+      ? description
+      : (page.pageid ? await fetchCommonsCaption(page.pageid, { signal, headers }) : null);
     const license = meta.LicenseShortName && meta.LicenseShortName.value
       ? meta.LicenseShortName.value
       : null;
@@ -214,6 +179,24 @@ async function fetchImageMetadata (filename) {
     };
   } catch (err) {
     console.error('Failed to fetch Commons image metadata:', err.message);
+    return null;
+  }
+}
+
+// Fetches the structured-data Caption for a Wikimedia Commons file.
+// These are the short, human-curated labels visible in the Commons UI
+// under "Captions", stored as Wikibase labels on the M-entity (M + page ID).
+// Returns the English caption string, or null on failure.
+async function fetchCommonsCaption (pageId, fetchOpts) {
+  try {
+    const url = 'https://commons.wikimedia.org/w/api.php?action=wbgetentities' +
+      '&ids=M' + pageId + '&props=labels&languages=en&format=json&origin=*';
+    const response = await fetch(url, fetchOpts);
+    if (!response.ok) return null;
+    const json = await response.json();
+    const entity = json && json.entities && json.entities['M' + pageId];
+    return (entity && entity.labels && entity.labels.en && entity.labels.en.value) || null;
+  } catch (err) {
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- Replaces the truncation-based caption logic (truncateCaption + ObjectName fallback) with a simpler two-source strategy
- Uses the Commons **Description** (ImageDescription) when it is short (≤100 chars) and plain text
- Falls back to the **structured-data Caption** from the Commons `wbgetentities` API — the human-curated "Captions" field visible in the Commons UI
- Net reduction: 47 lines removed, 30 added

## Test plan
- [x] Verified Steve Jobs (`/people/cp50119`) — Description is short and clean, used directly
- [x] Verified Thomas Nelson (`/people/cp127995`) — Description contains non-text content, gracefully falls back (no structured caption available, shows license only)
- [x] Linting passes
- [x] Unit tests: 764/766 pass (2 pre-existing failures on master, unrelated)