### PR TITLE
Transcription block loads closed with Show/Hide labels

### DIFF
--- a/client/lib/listeners/more-button.js
+++ b/client/lib/listeners/more-button.js
@@ -4,7 +4,7 @@ module.exports = function () {
     el.addEventListener('toggle', function (e) {
       if (e.target && e.target.className === 'c-truncated') {
         const summary = e.target.querySelector('summary');
-        summary.innerHTML = e.target.hasAttribute('open') ? 'Less' : 'More';
+        summary.innerHTML = e.target.hasAttribute('open') ? 'Hide' : 'Show';
       }
     });
   });

--- a/templates/helpers/comma.js
+++ b/templates/helpers/comma.js
@@ -6,11 +6,11 @@ module.exports = (item, parent, and) => {
   // to handle edge case - duplicate entry in Ciim
   const dedupedParent = dedupe(parent);
 
-  if (dedupedParent.length >= 2 && dedupedParent.at(-2).value === item.value) {
+  if (dedupedParent.length >= 2 && dedupedParent[dedupedParent.length - 2].value === item.value) {
     // Display 'and' instead of the last comma if required
 
     return ' and';
-  } else if (dedupedParent.at(-1).value !== item.value) {
+  } else if (dedupedParent[dedupedParent.length - 1].value !== item.value) {
     // console.log('**comma**' + item.value);
     return ',';
   }

--- a/templates/helpers/toggleDetailOpen.js
+++ b/templates/helpers/toggleDetailOpen.js
@@ -1,6 +1,5 @@
 'use strict';
 
 module.exports = function (key, options) {
-  const toggleFor = ['TRANSCRIPTION'];
-  return toggleFor.indexOf(key.toUpperCase()) > -1 && options.data.root.page === 'archive' ? 'open' : null;
+  return null;
 };

--- a/templates/partials/records/record-details.html
+++ b/templates/partials/records/record-details.html
@@ -10,7 +10,7 @@
           <dd>
             {{#if (toggleDetail key)}}
             <details class="c-truncated" {{toggleDetailOpen key}}>
-              <summary>More</summary>
+              <summary>Show</summary>
               <div>
                 {{/if}}
                 {{#taxonomy this}}


### PR DESCRIPTION
## Summary
- Transcription and other toggleable detail blocks on archive pages now load **collapsed** by default instead of expanded
- Toggle labels changed from **More/Less** to **Show/Hide**
- Fixed Node 14 compatibility bug in `comma.js` — replaced `Array.at()` (Node 16.6+) with bracket indexing, which was causing 500 errors on document pages

## Test plan
- [x] Visit an archive document with a transcription (e.g. `/documents/aa110119321`) and verify the transcription block is collapsed
- [x] Click "Show" to expand, verify label changes to "Hide"
- [x] Click "Hide" to collapse, verify label changes back to "Show"
- [x] Verify other toggleable details (System of Arrangement, Copyright, History Note) also work correctly