### PR TITLE
Fix Information Age gallery link in homepage fixtures

### DIFF
--- a/fixtures/data.js
+++ b/fixtures/data.js
@@ -224,7 +224,7 @@ module.exports = {
           type: 'collection',
           title: 'Information Age',
           figure: '/assets/img/home/collections/informationage.jpg',
-          link: '/search/gallery/information-age-gallery%3A-web'
+          link: '/search/museum/science-museum/gallery/information-age-gallery'
         },
         {
           type: 'collection',


### PR DESCRIPTION
## Summary
- Updates the Information Age collection link in `fixtures/data.js` from the old URL-encoded colon format (`information-age-gallery%3A-web`) to the correct museum/gallery path format (`/search/museum/science-museum/gallery/information-age-gallery`)

## Test plan
- [x] Verify the Information Age link on the homepage navigates to the correct gallery search results