### PR TITLE
Add Monotype Corporation Collection description box

### DIFF
--- a/description-boxes/collection.json
+++ b/description-boxes/collection.json
@@ -27,5 +27,13 @@
   "The Worshipful Company of Clockmakers": {
     "title": "The Worshipful Company of Clockmakers",
     "description":"The Worshipful Company of Clockmakers - founded in London by Royal Charter in 1631 - began assembling its collection of clocks, watches and extraordinary objects in 1814, and continues to do so to the present day. This collection forms the basis of the Clockmakers' Museum and includes works by many of the greatest names in horology."
+  },
+  "Monotype Corporation Collection": {
+    "title": "Monotype Corporation Collection",
+    "description":"The Monotype Corporation made the printed word far easier to produce by mechanising the process of casting and composing metal type for printing. The Monotype Collection contains business records, specialised machinery, and the patterns, punches and matrices needed to make type.",
+    "related-articles": [{
+      "title": "The Monotype Collection: A Brief History",
+      "link": "https://www.sciencemuseum.org.uk/monotype-collection"
+    }]
   }
 }


### PR DESCRIPTION
## Summary
- Adds a new "Monotype Corporation Collection" entry to `description-boxes/collection.json` with title, description, and a related article link to the Science Museum article.

## Test plan
- [x] Browse to a Monotype collection page and verify the description box renders with the new copy and related article link