### PR TITLE
Reduce ES aggregation load to prevent prod browse-page timeouts

### DIFF
--- a/lib/facets/aggs-all.js
+++ b/lib/facets/aggs-all.js
@@ -136,9 +136,9 @@ module.exports = function (queryParams, isFreeText) {
         filter: filterQuery,
         aggs: {
           archive_filters: {
-            // size: 100 — fonds (archive collections) are more numerous than categories;
-            // 100 ensures all active fonds appear as filter options
-            terms: { size: 100, field: 'fonds.summary.title.keyword', exclude: '.*;.*' }
+            // size: 30 — covers the active fonds; higher sizes caused the
+            // archive terms agg to dominate ES CPU on wide-population queries.
+            terms: { size: 30, field: 'fonds.summary.title.keyword', exclude: '.*;.*' }
           }
         }
       },
@@ -194,10 +194,10 @@ module.exports = function (queryParams, isFreeText) {
         filter: filterQuery,
         aggs: {
           museum_filters: {
-            // size: 100 — museum/gallery values are numerous; 100 ensures all locations appear.
+            // size: 30 — covers every SMG museum/gallery comfortably.
             // Both museum and gallery aggregations query the same ondisplay.value.keyword field;
             // the UI layer separates them into museum-level vs gallery-level display.
-            terms: { size: 100, field: 'ondisplay.value.keyword', exclude: '.*;.*' }
+            terms: { size: 30, field: 'ondisplay.value.keyword', exclude: '.*;.*' }
           }
         }
       },
@@ -205,8 +205,8 @@ module.exports = function (queryParams, isFreeText) {
         filter: filterQuery,
         aggs: {
           gallery_filters: {
-            // size: 100 — see museum comment above
-            terms: { size: 100, field: 'ondisplay.value.keyword', exclude: '.*;.*' }
+            // size: 30 — see museum comment above
+            terms: { size: 30, field: 'ondisplay.value.keyword', exclude: '.*;.*' }
           }
         }
       },

--- a/lib/search.js
+++ b/lib/search.js
@@ -302,7 +302,10 @@ module.exports = async (elastic, queryParams) => {
     index: config.elasticIndex,
     from: pageNumber * pageSize,
     body,
-    timeout: '5s'
+    // Soft cap — ES returns timed_out:true with partial results rather than
+    // erroring. Paired with a per-request client requestTimeout below so the
+    // HTTP transport gives ES enough headroom to self-abort first.
+    timeout: '15s'
   };
   if (!queryParams.q) {
     searchOpts.body.query.function_score.query = { match_all: {} };
@@ -392,7 +395,7 @@ module.exports = async (elastic, queryParams) => {
   );
 
   try {
-    return await elastic.search(searchOpts);
+    return await elastic.search(searchOpts, { requestTimeout: 20000 });
   } catch (error) {
     let errorType = 'es_error';
     if (error.name === 'TimeoutError') {


### PR DESCRIPTION
## Summary
After AWS EBS deployment, prod logs showed `Error: Search service unavailable` on deep-pagination browse queries (no `q`, date filter, `page[number]` 7–8). Root cause: facet aggregations run against the full filtered dataset with no sampler for browse queries, and three terms aggs sized at 100 dominate ES CPU. The 10s HTTP client timeout fires before ES finishes.

- **`lib/facets/aggs-all.js`** — cap `archive` (fonds), `museum`, `gallery` terms aggs at `size: 30` (was `100`). 30 still covers every active fonds and every SMG museum/gallery comfortably.
- **`lib/search.js`** — raise body `timeout` `5s` → `15s` (soft cap, ES returns partial results) and pass `{ requestTimeout: 20000 }` per search so the HTTP client gives ES headroom to self-abort before giving up. Matches the per-route timeout pattern already used in `routes/barcode.js`, `routes/collections.js`, etc.

No changes to scoring, filter shape, or aggregation structure.

## Test plan
- [ ] Local: `http://localhost:8000/search?type=all&filter[date[from]]=1861&filter[date[to]]=1890&page[number]=7` returns under 2s with results.
- [ ] Same URL `page[number]=1` — aggregations still present in JSON response.
- [ ] `npm test` passes.
- [ ] Post-deploy: monitor `/var/log/web.stdout.log` for 30 min; expect zero `Error: Search service unavailable` from paginated browse.
