### PR TITLE
Add meaningful alt text to all homepage images

### DIFF
--- a/config/name-collections.json
+++ b/config/name-collections.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Name collections carousel on the homepage. Featured entries appear first, then random popular collectors fill to `count`. Descriptions auto-populate from description-boxes/collection.json when the `collector` key matches. Collections with no image (neither configured nor found in ES) are dropped.",
+  "_comment": "Name collections carousel on the homepage. Featured entries appear first, then random popular collectors fill to `count`. Descriptions auto-populate from description-boxes/collection.json when the `collector` key matches. Collections with no image (neither configured nor found in ES) are dropped. Optional `alt` overrides the default alt text (collector name) — set this where a configured `figure` depicts something more specific than the collection name.",
 
   "enabled": true,
 
@@ -21,9 +21,9 @@
 
   "featured": [
     { "collector": "BBC Heritage Collection" },
-    { "collector": "Daily Herald Archive", "figure": "/assets/img/home/collections/daily-herald-archive.jpg" },
+    { "collector": "Daily Herald Archive", "figure": "/assets/img/home/collections/daily-herald-archive.jpg", "alt": "Press photograph from the Daily Herald Archive" },
     { "collector": "Monotype Corporation Collection" },
-    { "collector": "Stephen Hawking\u2019s Office", "figure": "/assets/img/home/collections/stephen-hawkings-office.jpg" },
+    { "collector": "Stephen Hawking\u2019s Office", "figure": "/assets/img/home/collections/stephen-hawkings-office.jpg", "alt": "Stephen Hawking\u2019s office with his desk, wheelchair and personal belongings" },
     { "collector": "The Worshipful Company of Clockmakers" }
   ],
 

--- a/fixtures/data.js
+++ b/fixtures/data.js
@@ -10,14 +10,14 @@ module.exports = {
   smg__description:
     'We share our world-leading collection – spanning science, technology, engineering and medicine – with over five million visitors each year.',
   headerImages: [
-    '_D819175-ret.jpg',
-    '1970-0025_0007.jpg',
-    '_D818504.jpg',
-    'textile-sign.jpg',
-    'switches.jpg',
-    '_D817130-Edit2.jpg',
-    '1878-0005_0004_A163_0002.jpg',
-    'cd0634_030_100924_1988_242.jpg'
+    { file: '_D819175-ret.jpg', alt: 'Close-up of intricate brass clockwork mechanism from the collection' },
+    { file: '1970-0025_0007.jpg', alt: 'Vintage scientific instrument from the Science Museum Group collection' },
+    { file: '_D818504.jpg', alt: 'Detail of a historic object from the collection, softly lit against a dark background' },
+    { file: 'textile-sign.jpg', alt: 'Enamel sign from the textile industry collection' },
+    { file: 'switches.jpg', alt: 'Row of industrial electrical switches from the collection' },
+    { file: '_D817130-Edit2.jpg', alt: 'Close-up of a polished metal scientific instrument from the collection' },
+    { file: '1878-0005_0004_A163_0002.jpg', alt: 'Archive photograph from the collection' },
+    { file: 'cd0634_030_100924_1988_242.jpg', alt: 'Historic object from the collection, photographed in studio' }
   ],
   collectionGroup: [
     {
@@ -64,6 +64,7 @@ module.exports = {
       theme: [
         {
           title: 'Medicine',
+          alt: 'Surgical instruments and medical apparatus from the Medicine collection',
           description: 'Explore global medical developments and advances over time',
           figure: '/assets/img/home/collections/medicine.jpg',
           links: [
@@ -91,6 +92,7 @@ module.exports = {
         },
         {
           title: 'Railways',
+          alt: 'Historic steam locomotive from the Railways collection',
           description: 'The development of railways from goods transport to commuter travel',
           figure: '/assets/img/home/collections/railway.jpg',
           links: [
@@ -114,6 +116,7 @@ module.exports = {
         },
         {
           title: 'Art',
+          alt: 'Artwork from the collection depicting scientific and industrial themes',
           description: 'From innovative processes to depicting our connection with science',
           figure: '/assets/img/home/collections/art-theme.jpg',
           links: [
@@ -138,6 +141,7 @@ module.exports = {
         },
         {
           title: 'Industrial Revolution',
+          alt: 'Heavy industrial machinery from the Industrial Revolution collection',
           description: 'The machines and industries that powered the Industrial Revolution',
           figure: '/assets/img/home/collections/industrial-revolution.jpg',
           links: [
@@ -175,6 +179,7 @@ module.exports = {
         {
           type: 'collection',
           title: 'A Brief History of Stuff',
+          alt: 'Artwork for the A Brief History of Stuff podcast',
           figure: '/assets/img/home/collections/brief-history-of-stuff.jpg',
           link: 'https://www.sciencemuseumgroup.org.uk/brief-history-stuff-podcast/'
         },

--- a/lib/anniversary.js
+++ b/lib/anniversary.js
@@ -1,5 +1,6 @@
 const slug = require('slugg');
 const sortImages = require('./helpers/jsonapi-response/sort-images');
+const getImageCaption = require('./helpers/get-image-caption');
 const widgetConfig = require('../config/anniversary-widget.json');
 
 module.exports = async function getAnniversaryData (elastic, config) {
@@ -397,17 +398,20 @@ function transformObjectHit (hit, config, currentYear) {
     subtitle = creationDate;
   }
 
+  const resolvedTitle = title || 'Untitled object';
+
   return {
     id,
     type,
-    title: title || 'Untitled object',
+    title: resolvedTitle,
     link: (config.rootUrl || '') + '/' + type + '/' + id + (titleSlug ? '/' + titleSlug : ''),
     figure: getImage(source, config),
+    alt: getImageCaption(source) || resolvedTitle,
     milestoneLabel,
     subtitle,
     yearsAgo,
     year: creationDate,
-    label: milestoneLabel + ' — ' + (title || 'Untitled object')
+    label: milestoneLabel + ' — ' + resolvedTitle
   };
 }
 
@@ -431,20 +435,22 @@ function transformPersonHit (hit, config, currentYear) {
 
   const occupation = getOccupation(source);
   const figcaption = getBriefBiography(source);
+  const resolvedTitle = title || 'Unknown person';
 
   return {
     id,
     type,
-    title: title || 'Unknown person',
+    title: resolvedTitle,
     link: (config.rootUrl || '') + '/' + type + '/' + id + (titleSlug ? '/' + titleSlug : ''),
     figure: getImage(source, config),
+    alt: getImageCaption(source) || resolvedTitle,
     figcaption,
     milestoneLabel,
     subtitle: occupation,
     yearsAgo,
     birthYear,
     entityType: entityType || 'person',
-    label: milestoneLabel + ' — ' + (title || 'Unknown person')
+    label: milestoneLabel + ' — ' + resolvedTitle
   };
 }
 

--- a/lib/helpers/get-image-caption.js
+++ b/lib/helpers/get-image-caption.js
@@ -1,0 +1,18 @@
+const sortImages = require('./jsonapi-response/sort-images');
+
+// Returns the primary image caption string from an ES record _source, or
+// null if no caption is present. Mirrors the caption extraction used when
+// building record-page images in lib/transforms/json-to-html-data.js so
+// homepage cards carry the same caption text as the record page.
+module.exports = function getImageCaption (source) {
+  if (!source || !source.multimedia) return null;
+
+  const multimedia = Array.isArray(source.multimedia) ? source.multimedia : [source.multimedia];
+  if (multimedia.length === 0) return null;
+
+  const first = sortImages(multimedia)[0];
+  if (!first || !Array.isArray(first.title)) return null;
+
+  const caption = first.title.find(t => t && t.type === 'caption');
+  return (caption && caption.value) || null;
+};

--- a/lib/name-collections.js
+++ b/lib/name-collections.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const sortImages = require('./helpers/jsonapi-response/sort-images');
+const getImageCaption = require('./helpers/get-image-caption');
 const encodeFilterValue = require('./helpers/encode-filter-value');
 const widgetConfig = require('../config/name-collections.json');
 const collectionDescriptions = require('../description-boxes/collection.json');
@@ -102,10 +103,15 @@ async function resolveEntry (entry, elastic, config) {
   // Prefer configured figure, but only if the file actually exists on disk.
   // Otherwise fall back to the most-viewed object image for that collector.
   let figure = null;
+  let dynamicCaption = null;
   if (entry.figure && assetExists(entry.figure)) {
     figure = entry.figure;
   } else {
-    figure = await fetchCollectorImage(name, elastic, config);
+    const fetched = await fetchCollectorImage(name, elastic, config);
+    if (fetched) {
+      figure = fetched.figure;
+      dynamicCaption = fetched.caption;
+    }
   }
 
   if (!figure) return null;
@@ -114,6 +120,7 @@ async function resolveEntry (entry, elastic, config) {
     title: name,
     description,
     figure,
+    alt: entry.alt || dynamicCaption || name,
     link
   };
 }
@@ -181,7 +188,10 @@ async function fetchCollectorImage (collectorName, elastic, config) {
     const hits = (result.body && result.body.hits && result.body.hits.hits) || [];
     if (hits.length === 0) return null;
 
-    return getImage(hits[0]._source || {}, config);
+    const source = hits[0]._source || {};
+    const figure = getImage(source, config);
+    if (!figure) return null;
+    return { figure, caption: getImageCaption(source) };
   } catch (err) {
     return null;
   }

--- a/templates/pages/home.html
+++ b/templates/pages/home.html
@@ -4,14 +4,14 @@
   <main id="main-content">
     <section class="section --spacious home-banner">
       <div class="banner-slides">
-        <img src="/assets/img//home/feature/1600/{{headerImages.[0]}}"
-          srcset="/assets/img/home/feature/800/{{headerImages.[0]}} 800w, /assets/img/home/feature/1600/{{headerImages.[0]}} 1600w"
-          alt="" />
+        <img src="/assets/img//home/feature/1600/{{headerImages.[0].file}}"
+          srcset="/assets/img/home/feature/800/{{headerImages.[0].file}} 800w, /assets/img/home/feature/1600/{{headerImages.[0].file}} 1600w"
+          alt="{{headerImages.[0].alt}}" />
         <template>
           {{#each (reverse headerImages) }}
-          <img src="/assets/img/home/feature/1600/{{this}}"
-            srcset="/assets/img/home/feature/800/{{this}} 800w, /assets/img/home/feature/1600/{{this}} 1600w"
-            alt="" />
+          <img src="/assets/img/home/feature/1600/{{this.file}}"
+            srcset="/assets/img/home/feature/800/{{this.file}} 800w, /assets/img/home/feature/1600/{{this.file}} 1600w"
+            alt="{{this.alt}}" />
           {{/each}}
           <button aria-label="Pause background animation">{{> global/icon i="pause" size="32"}}</button>
         </template>
@@ -80,7 +80,7 @@
           <a href="{{this.link}}" aria-label="{{this.title}}">
             <article class="resultcard resultcard--collection">
               <figure class="resultcard__figure">
-                <img src="{{this.figure}}" alt="" />
+                <img src="{{this.figure}}" alt="{{this.alt}}" />
               </figure>
               <div class="resultcard__info">
                 <h3 class="resultcard__title">{{this.title}}</h3>
@@ -103,7 +103,7 @@
 
         <article class="resultcard resultcard--collection">
           <figure class="resultcard__figure">
-            <img src="{{ this.figure }}" alt="" />
+            <img src="{{ this.figure }}" alt="{{#if this.alt}}{{ this.alt }}{{else}}{{ this.title }}{{/if}}" />
           </figure>
           <div class="resultcard__info">
             <h3 class="resultcard__title">{{ this.title }}</h3>
@@ -160,7 +160,7 @@
           <a href="{{ this.link }}" aria-label="{{ this.title }}">
             <article class="resultcard resultcard--dark {{#if type}}resultcard--{{ this.type }}{{/if}}">
               <figure class="resultcard__figure">
-                <img src="{{ this.figure }}" alt="" />
+                <img src="{{ this.figure }}" alt="{{#if this.alt}}{{ this.alt }}{{else}}{{ this.title }}{{/if}}" />
               </figure>
               <div class="resultcard__info">
                 <h3 class="resultcard__title">{{ this.title }}</h3>

--- a/templates/partials/home/anniversary-card.html
+++ b/templates/partials/home/anniversary-card.html
@@ -5,7 +5,7 @@
   <article class="resultcard resultcard--{{this.type}}">
     <figure class="resultcard__figure">
       {{#if this.figure}}
-        <img src="{{this.figure}}" alt="" loading="lazy" />
+        <img src="{{this.figure}}" alt="{{this.alt}}" loading="lazy" />
       {{else}}
         <figcaption role="presentation">
           {{> global/icon i=this.type }}


### PR DESCRIPTION
## Summary

Every `<img>` on the homepage previously rendered with `alt=""`, which fails WCAG 1.1.1 for record cards that convey meaningful content through the image. This change gives every homepage image appropriate alt text, computed in one place per data source.

**One pattern, three shapes of data** — each card exposes a single `alt` string from the data layer; templates just render `alt="{{this.alt}}"`.

- **Dynamic (ES-backed) cards** — anniversary cards and the name-collections carousel use the image's caption (`multimedia[0].title[type=caption].value`), falling back to the record title. This mirrors the pattern already used for record-page images in `lib/transforms/json-to-html-data.js`. A small shared helper (`lib/helpers/get-image-caption.js`) avoids duplicating the extraction.
- **Static fixture tiles** — collection themes, highlights carousel, and featured name-collections default to the card title. An optional `alt` field can be added to any entry in `fixtures/data.js` / `config/name-collections.json` where the title is a weak description of the image. Authored overrides added for Medicine/Railways/Art/Industrial Revolution themes, the "A Brief History of Stuff" podcast tile, and the Daily Herald / Stephen Hawking's Office featured collections.
- **Banner hero images** — restructured from plain filenames to `{ file, alt }` objects, with a descriptive alt authored per image.

Result: all 50 `<img>` elements under `#main-content` on the homepage now have non-empty alt text.

## Test plan

- [x] `npm run test:lint` — passes
- [x] `npm run test:unit:tape` — 829/830 (same as baseline; the one failure, `document figcaption is correct` in `search-results-to-templates.test.js`, is pre-existing and unrelated)
- [x] Dev server + DOM inspection — every `<img>` under `#main-content` has a non-empty `alt`
- [x] ES caption fallback confirmed on the named-collections carousel (e.g. `alt="Discatron portable record player, 1966-1968"` sourced from ES)
- [x] Title fallback confirmed on static tiles without an explicit alt (e.g. Astronomy, Time measurement)
- [x] Authored alt confirmed on the banner, theme tiles, overrides, and anniversary cards