### PR TITLE
Add WAF challenge SDK and bound date filter inputs

### DIFF
--- a/schemas/filter.js
+++ b/schemas/filter.js
@@ -2,8 +2,8 @@ const Joi = require('joi');
 
 const sharedSchema = {
   // All
-  'filter[date[from]]': Joi.number().allow('', null).integer().min(0),
-  'filter[date[to]]': Joi.number().allow('', null).integer().min(0),
+  'filter[date[from]]': Joi.number().allow('', null).integer().min(0).max(2200),
+  'filter[date[to]]': Joi.number().allow('', null).integer().min(0).max(2200),
   // Objects
   'filter[on_display]': Joi.boolean().truthy('true').falsy('false'),
   'filter[has_image]': Joi.string(),
@@ -11,8 +11,8 @@ const sharedSchema = {
   'filter[rotational]': Joi.string(),
   'filter[mphc]': Joi.string(),
   // People
-  'filter[birth[date]]': Joi.number().allow('', null).integer().min(0),
-  'filter[death[date]]': Joi.number().allow('', null).integer().min(0)
+  'filter[birth[date]]': Joi.number().allow('', null).integer().min(0).max(2200),
+  'filter[death[date]]': Joi.number().allow('', null).integer().min(0).max(2200)
   // Documents
 };
 

--- a/templates/layouts/default.html
+++ b/templates/layouts/default.html
@@ -2,6 +2,7 @@
 <html class="no-js" lang="en">
 
 <head>
+  <script src="https://9e27d934dcc0.edge.sdk.awswaf.com/9e27d934dcc0/68da2414f017/challenge.js" defer></script>
   <!-- Data layer-->
   <script>
     window.dataLayer = window.dataLayer || []


### PR DESCRIPTION
## Summary

- Load the AWS WAF Application Integration `challenge.js` SDK from `templates/layouts/default.html` so every browser navigation runs the silent proof-of-work challenge and acquires an `aws-waf-token` cookie. This lets Bot Control TARGETED rules (`TGT_VolumetricIpTokenAbsent`, `TGT_TokenReuseIp`, etc.) tell real users apart from the residential-proxy bot traffic that has been driving ES timeouts in prod.
- Tighten Joi validation in `schemas/filter.js`: add `.max(2200)` to `filter[date[from]]`, `filter[date[to]]`, `filter[birth[date]]`, `filter[death[date]]`. Absurd year values are now rejected at the edge with a 400 instead of reaching Elasticsearch.

## Why now

After deployment to AWS EBS, prod was seeing 40–71% 5xx rates driven by residential-proxy bots hammering paginated date-range browse queries (e.g. `type=all&filter[date[from]]=1861&filter[date[to]]=1890&page[number]=7`). WAF Bot Control TARGETED + ML has been configured in the console; its TARGETED rules only work once most legitimate requests present a WAF token, which is what this SDK script enables.

The date bounds are a cheap defence-in-depth: they cost nothing, and reject a query shape that currently makes its way down to ES.

## Test plan

- [ ] Deploy to EBS and confirm `aws-waf-token` cookie is set on first page load (DevTools → Application → Cookies).
- [ ] Confirm WAF logs show `TGT_*` rules evaluating real users with tokens (`labels: awswaf:managed:aws:bot-control:token:accepted`).
- [ ] Hit `/search?filter[date[from]]=99999` and confirm a 400 response from Joi (previous behaviour: accepted and forwarded to ES).
- [ ] Hit `/search?filter[date[from]]=1861&filter[date[to]]=1890` and confirm normal results render (unchanged behaviour for in-range values).
- [ ] Monitor `web.stdout.log` for 30 minutes post-deploy — expect the `Error: Search service unavailable` rate from paginated browse to drop.