### PR TITLE
Route AJAX through AWS WAF fetch wrapper with token warmup

### DIFF
--- a/client/lib/get-data.js
+++ b/client/lib/get-data.js
@@ -1,7 +1,18 @@
-const fetch = require('fetch-ponyfill')().fetch;
+const ponyfillFetch = require('fetch-ponyfill')().fetch;
+
+// Use the AWS WAF Application Integration SDK's fetch wrapper when available.
+// It catches 202 Challenge responses from WAF, solves the silent PoW, refreshes
+// the aws-waf-token cookie, and retries the request transparently. Falls back
+// to the ponyfill in test environments where the SDK global isn't present.
+function wafAwareFetch (url, opts) {
+  if (typeof window !== 'undefined' && window.AwsWafIntegration && typeof window.AwsWafIntegration.fetch === 'function') {
+    return window.AwsWafIntegration.fetch(url, opts);
+  }
+  return ponyfillFetch(url, opts);
+}
 
 module.exports = function (url, opts, cb) {
-  fetch(url, opts)
+  wafAwareFetch(url, opts)
     .then(function (res) {
       if (res.ok) {
         return res.json();

--- a/client/main.js
+++ b/client/main.js
@@ -1,6 +1,14 @@
 require('./lib/polyfills.js')();
 const page = require('page');
 
+// Warm up the AWS WAF token cookie before any AJAX fires. The SDK's
+// challenge.js is loaded deferred from the default layout; calling getToken()
+// here asks it to issue/refresh the token immediately so fast first-AJAX
+// interactions (e.g. search-box autocomplete) don't race the SDK init.
+if (typeof window !== 'undefined' && window.AwsWafIntegration && typeof window.AwsWafIntegration.getToken === 'function') {
+  window.AwsWafIntegration.getToken().catch(() => {});
+}
+
 require('./middleware/initial-render')(page);
 
 // Client routes


### PR DESCRIPTION
## Summary

Follow-up to [#2122](https://github.com/TheScienceMuseum/collectionsonline/pull/2122).

- `client/lib/get-data.js` now calls `window.AwsWafIntegration.fetch()` when the WAF SDK global is present. The wrapper handles 202 Challenge responses by solving the silent proof-of-work, refreshing the `aws-waf-token` cookie, and retrying the request transparently. Without this, any Challenge action on an AJAX endpoint silently 403s the user.
- `client/main.js` warms the token up at app init with `AwsWafIntegration.getToken()`, so a fast first AJAX (e.g. search autocomplete) doesn't race the deferred SDK.
- Falls back to `fetch-ponyfill` when the SDK global is absent (unit tests, non-prod).

`client/lib/listeners/internal-header.js` posts cross-origin to Google Apps Script and never touches WAF — left unchanged.

## Why this matters

Right now, `TGT_VolumetricSession → Challenge` and the Medium-tier TokenReuse rules are configured to Challenge but behave as Block for anyone tripping them on an XHR call, because plain `fetch` can't solve a 202 challenge and retry. We saw this in the WAF logs on 2026-04-18 — three BLOCK entries on a single user's AJAX before the override propagated. This PR makes Challenge actually behave as Challenge on AJAX, so those rules can keep their current settings and do real work against residential-proxy bots without punishing real users.

## Test plan

- [ ] Merge and deploy.
- [ ] DevTools → Network filter on an AJAX path (e.g. `/search?...&ajax=true`). Look for a `202` immediately followed by another request to the same URL returning `200`. That sequence = wrapper caught a Challenge, solved it, retried successfully.
- [ ] Confirm `aws-waf-token` cookie is set within the first second of loading any page (warmup working).
- [ ] Search autocomplete, wiki panel, "load more" all still work normally when no Challenge is issued (fallback path).
- [ ] Unit tests pass locally (`get-data.js` is not imported by any test; fallback kicks in under Node anyway).
- [ ] Monitor WAF logs for 24h post-deploy: Challenge-actioned requests on AJAX paths should show a corresponding retry with `awswaf:managed:token:accepted`.

## Follow-ups this unlocks

Once verified in prod, we can safely tighten:
- `TGT_TokenReuseIpMedium` / `CountryMedium` / `AsnMedium` → Block
- `TGT_ML_CoordinatedActivityMedium` → Block

(See the summary in the parent conversation for the full tightening ladder.)