### PR TITLE
Fix SPA decode and make keyword filters case-insensitive

### DIFF
--- a/lib/facets/create-filters.js
+++ b/lib/facets/create-filters.js
@@ -11,11 +11,7 @@ module.exports = function (queryParams, filterType) {
   const categories = queryParams.filter.objects.categories;
   if (categories) {
     categories.forEach((e) => {
-      filters.push({
-        terms: {
-          'category.name.keyword': [e, e.toLowerCase(), dashToSpace(e)]
-        }
-      });
+      filters.push(caseInsensitiveTermFilter('category.name.keyword', e));
     });
   }
 
@@ -71,11 +67,7 @@ module.exports = function (queryParams, filterType) {
   const objectType = queryParams.filter.objects.object_type;
   if (objectType) {
     objectType.forEach((e) => {
-      filters.push({
-        terms: {
-          'name.value.keyword': [e.toLowerCase(), dashToSpace(e.toLowerCase())]
-        }
-      });
+      filters.push(caseInsensitiveTermFilter('name.value.keyword', e));
     });
   }
 
@@ -113,9 +105,7 @@ module.exports = function (queryParams, filterType) {
   const occupation = queryParams.filter.people.occupation;
   if (occupation) {
     occupation.forEach((e) => {
-      filters.push({
-        terms: { 'occupation.value.keyword': [e, dashToSpace(e)] }
-      });
+      filters.push(caseInsensitiveTermFilter('occupation.value.keyword', e));
     });
   }
 
@@ -205,9 +195,7 @@ module.exports = function (queryParams, filterType) {
   const material = queryParams.filter.objects.material;
   if (material) {
     material.forEach((e) => {
-      filters.push({
-        terms: { 'material.value.keyword': [e, dashToSpace(e)] }
-      });
+      filters.push(caseInsensitiveTermFilter('material.value.keyword', e));
     });
   }
 
@@ -284,16 +272,27 @@ module.exports = function (queryParams, filterType) {
   return { bool: { filter: filters } };
 };
 
-/**
- * Builds an Elasticsearch OR filter that matches a location value against both
- * the old ES schema field (location.name.value.lower) and the new schema field
- * (facility.name.value.lower). This dual-field approach covers records indexed
- * before and after the schema migration without requiring a full re-index.
- *
- * @param {string} location - The location name to filter on
- * @param {Function} dashToSpace - Helper that converts hyphens to spaces
- * @returns {Object} Elasticsearch bool.should filter clause
- */
+// Case-sensitive keyword fields (no .lower normalizer) break when the URL case
+// doesn't match the ES-stored case — e.g. "Make-up artist" vs "make-up artist",
+// or categories like "Photographic Collections (railway)" vs "(Railway)". Using
+// `term` with `case_insensitive: true` (ES 7.10+) lets ES compare case-insensitively.
+// `terms` (plural) does not support `case_insensitive` in 7.17, so we wrap one
+// `term` per candidate value in a bool.should. Two candidates cover the dash/space
+// round-trip (e.g. "Rolls-Royce" vs "Rolls Royce" in stored data).
+function caseInsensitiveTermFilter (field, value) {
+  const candidates = [value];
+  const spaced = dashToSpace(value);
+  if (spaced !== value) candidates.push(spaced);
+  return {
+    bool: {
+      should: candidates.map((v) => ({
+        term: { [field]: { value: v, case_insensitive: true } }
+      })),
+      minimum_should_match: 1
+    }
+  };
+}
+
 function buildLocationFilter (location, dashToSpace) {
   const value = location.toLowerCase();
   const valueWithSpaces = dashToSpace(value);

--- a/routes/route-helpers/parse-params.js
+++ b/routes/route-helpers/parse-params.js
@@ -60,9 +60,17 @@ module.exports = function (urlParams) {
     } else if (exclude.indexOf(cat) === -1) {
       categories[cat] = utils.uppercaseFirstChar(categories[cat]);
     } else {
-      // Excluded filters: decode but do not title-case (ES terms are stored lowercase)
-      const applyDecode = v =>
-        typeof v === 'string' ? decodeURIComponent(dashToSpace(v)) : v;
+      // Excluded filters: decode but do not title-case (ES terms are stored lowercase).
+      // Apply decodeURIComponent twice to cover both the server path (Hapi pre-decodes
+      // %25→%, so %252D → %2D → -) and the SPA client path (no pre-decode, so the raw
+      // %252D needs two passes to reach -). The second pass is a no-op server-side.
+      const applyDecode = v => {
+        if (typeof v !== 'string') return v;
+        let s = dashToSpace(v);
+        try { s = decodeURIComponent(s); } catch (e) { /* malformed, keep as-is */ }
+        try { s = decodeURIComponent(s); } catch (e) { /* malformed, keep as-is */ }
+        return s;
+      };
       categories[cat] = Array.isArray(categories[cat])
         ? categories[cat].map(applyDecode)
         : applyDecode(categories[cat]);

--- a/test/facets/create-filter-object.test.js
+++ b/test/facets/create-filter-object.test.js
@@ -117,6 +117,72 @@ test(file + 'The filter people array do not include a term filter of a wrong dat
   t.end();
 });
 
+test(file + 'Category filter is case-insensitive via term + case_insensitive (not a plain terms query)', (t) => {
+  // category.name.keyword has no lowercase normalizer, so a plain `terms` query
+  // was case-sensitive and relied on our title-case heuristic matching the exact ES
+  // value. The bool.should / term / case_insensitive form removes that dependency —
+  // e.g. "Photographic Collections (railway)" (from the URL) will match the ES
+  // value "Photographic Collections (Railway)" regardless of the parenthesised word's case.
+  const query = { 'filter[categories]': 'Photographic Collections (railway)' };
+  const queryParams = createQueryParams('html', { query, params: { type: 'objects' } });
+  const filters = createFilters(queryParams, 'object');
+
+  const categoryFilter = filters.bool.filter.find(
+    (f) => f.bool && f.bool.should && f.bool.should[0] && f.bool.should[0].term && f.bool.should[0].term['category.name.keyword']
+  );
+  t.ok(categoryFilter, 'category filter is a bool.should of term queries');
+  t.ok(
+    categoryFilter.bool.should.every((c) => c.term['category.name.keyword'].case_insensitive === true),
+    'every term candidate has case_insensitive: true'
+  );
+  t.ok(
+    categoryFilter.bool.should.some((c) => c.term['category.name.keyword'].value === 'Photographic Collections (railway)'),
+    'original value is a candidate'
+  );
+  t.notOk(
+    filters.bool.filter.some((f) => f.terms && f.terms['category.name.keyword']),
+    'no legacy terms query for category.name.keyword remains'
+  );
+  t.end();
+});
+
+test(file + 'Occupation, material and object_type keyword filters use case_insensitive term queries', (t) => {
+  // occupation.value.keyword, material.value.keyword and name.value.keyword (for object_type)
+  // are case-sensitive keyword fields in ES with no .lower normalizer. A plain `terms`
+  // query would require the URL/user case to exactly match the stored case — e.g.
+  // "Make-up artist" vs "make-up artist", "Copper alloy" vs "copper alloy". Using
+  // term + case_insensitive: true wrapped in bool.should removes this dependency.
+  const cases = [
+    { filter: 'occupation', queryType: 'people', value: 'Make-up Artist', field: 'occupation.value.keyword' },
+    { filter: 'material', queryType: 'objects', value: 'Copper Alloy', field: 'material.value.keyword' },
+    { filter: 'object_type', queryType: 'objects', value: 'Film Poster', field: 'name.value.keyword' }
+  ];
+
+  cases.forEach(({ filter, queryType, value, field }) => {
+    const query = { ['filter[' + filter + ']']: value };
+    const queryParams = createQueryParams('html', { query, params: { type: queryType } });
+    const filters = createFilters(queryParams, queryType === 'people' ? 'agent' : 'object');
+
+    const match = filters.bool.filter.find(
+      (f) => f.bool && f.bool.should && f.bool.should[0] && f.bool.should[0].term && f.bool.should[0].term[field]
+    );
+    t.ok(match, filter + ': filter uses bool.should of term queries');
+    t.ok(
+      match.bool.should.every((c) => c.term[field].case_insensitive === true),
+      filter + ': every term candidate has case_insensitive: true'
+    );
+    t.ok(
+      match.bool.should.some((c) => c.term[field].value === value),
+      filter + ': original value is a candidate'
+    );
+    t.notOk(
+      filters.bool.filter.some((f) => f.terms && f.terms[field]),
+      filter + ': no legacy terms query for ' + field + ' remains'
+    );
+  });
+  t.end();
+});
+
 test(file + 'The filter people array do not include a term filter of a wrong date format - fiter by create-filter', (t) => {
   const query = queryString.parse('q=ada&filter%5Bdate%5Bfrom%5D%5D=wrongDate&page%5Bsize%5D=50');
   const queryParams = createQueryParams('html', { query, params: { type: 'objects' } });

--- a/test/parse-params.test.js
+++ b/test/parse-params.test.js
@@ -269,6 +269,28 @@ test('filter values with commas decoded correctly (no backslash escaping)', func
   t.end();
 });
 
+test('SPA client path: excluded filter values with raw %252D decode via two decodeURIComponent passes', function (t) {
+  // On the SPA (page.js) route the browser does not pre-decode the URL, so the raw
+  // %252D reaches parseParams and must be decoded twice to become a literal hyphen.
+  // This test mirrors a user clicking an occupation filter link without a full page load.
+  t.deepEqual(
+    parseParameters({ filters: 'people/occupation/make%252dup-artist' }),
+    { params: { type: 'people' }, categories: { occupation: 'make-up artist' } },
+    'occupation with %252D decodes correctly on the SPA path'
+  );
+  t.deepEqual(
+    parseParameters({ filters: 'objects/object_type/black%252dand%252dwhite-print' }),
+    { params: { type: 'objects' }, categories: { object_type: 'black-and-white print' } },
+    'object_type with multiple %252D decodes correctly on the SPA path'
+  );
+  t.deepEqual(
+    parseParameters({ filters: 'objects/material/stainless%252dsteel+brushed-aluminium' }),
+    { params: { type: 'objects' }, categories: { material: ['stainless-steel', 'brushed aluminium'] } },
+    'multi-value material filter with %252D decoded correctly on the SPA path'
+  );
+  t.end();
+});
+
 test('categories with single-dash still title-cased correctly', function (t) {
   t.deepEqual(
     parseParameters({ filters: 'objects/categories/art' }),


### PR DESCRIPTION
## Summary
- **Bug A** — `/search/people/occupation/make%252dup-artist` returned no results when reached via SPA click, worked on direct load. The SPA path sends raw `%252D` to parse-params (no Hapi pre-decode), so the single-pass `decodeURIComponent` in the excluded-filter branch left a literal `%2d`. Match the two-pass decode used in `utils.upperChar`.
- **Bug B** — `/search/categories/photographic-collections-(railway)` returned 0 results because `category.name.keyword` has no lowercase normalizer and the URL case `"(railway)"` did not match the ES value `"(Railway)"`. Switch from `terms` to `bool.should` of `term` queries with `case_insensitive: true`.
- Extend the same fix to `occupation.value.keyword`, `material.value.keyword` and `name.value.keyword` (object_type) — all confirmed broken via live ES (`"Make-up Artist"` → 0 people vs `"make-up artist"` → 2; `"Copper Alloy"` → 1 object vs `"copper alloy"` → 142).
- Extract `caseInsensitiveTermFilter` helper in `create-filters.js` to remove duplication across the 4 fixed filters.

## Why it wasn't caught for years
Before [the URL-encoding overhaul](https://github.com/TheScienceMuseum/collectionsonline/commit/5505e7fd) (Mar 2026), `-` in URLs meant space — hyphenated filter values like `make-up artist` could not round-trip through the URL, so the ES case-sensitivity issue never got exercised for them. Non-hyphenated values happened to match ES-stored lowercase, masking the issue. The overhaul fixed the URL layer (`%252D` = literal hyphen), which finally let hyphenated values reach the ES query layer — where case-sensitivity was still waiting.

`.lower`-suffix fields (archive, maker, collection, places, user, birthPlace, subgroup, museum/gallery) are case-folded at index time and unaffected. Organisations (`@datatype.actual`) and mphc (UIDs) are lowercase-only. Imgtag isn't user-facing in default facets.

## Test plan
- [x] `tape` tests pass (71/71 in `parse-params.test.js` + `create-filter-object.test.js`)
- [x] Live verified: `/search/people/occupation/make-up-artist` → 2 results (was 0 via "Make-up Artist" casing)
- [x] Live verified: `/search/people/occupation/typefounding-machinery-and-typeface-design` → 2 results (cp41309, cp97038)
- [x] Live verified: `/search/categories/photographic-collections-(railway)` → 2452 objects
- [x] Material filter: all casings of "Copper Alloy" return 145 objects (was 142/1/0 pre-fix)