### PR TITLE
Fix 404 page returning JSON when Accept header is missing

### DIFF
--- a/routes/plugins/error.js
+++ b/routes/plugins/error.js
@@ -1,4 +1,5 @@
 const Boom = require('@hapi/boom');
+const contentType = require('../route-helpers/content-type.js');
 const isDevelopment = (process.env.NODE_ENV || 'development') === 'development';
 
 // Heavily based on the excellent https://github.com/dwyl/hapi-error
@@ -15,12 +16,13 @@ exports.plugin = {
 
       const error = new Boom.Boom(request.response);
       const accept = request.headers.accept || '';
+      const wants = contentType(request);
 
       if (error.output.statusCode >= 500) {
         console.error(error.stack);
       }
 
-      if (accept.indexOf('text/html') === 0) {
+      if (wants === 'html') {
         // Respond with an error template
         if (error.output.statusCode === 401) {
           return h.redirect('/login');


### PR DESCRIPTION
## Summary
- Production `/404` and any non-existent URL was returning `{\"statusCode\":404,\"error\":\"Not Found\",\"message\":\"Not Found\"}` instead of the branded HTML 404 page.
- Root cause: CloudFront was stripping / not forwarding the browser's `Accept` header to the origin. The error plugin's check `accept.indexOf('text/html') === 0` only matched when `text/html` was at the **start** of the header, so requests with missing or `*/*` Accept headers fell through to Hapi's default JSON 404.
- Fix: switch to the existing [routes/route-helpers/content-type.js](routes/route-helpers/content-type.js) helper — which already handles this exact case (and has a comment explicitly referencing CloudFront).

## Test plan
- [x] `npm test` — no new failures from this change (2 pre-existing unrelated failures in `search-results-to-templates.test.js` and `login.test.js`)
- [x] Existing `test/error-plugin.test.js` — all 9 assertions pass
- [x] Local server: `curl` with empty Accept, `*/*`, browser Accept, and `application/vnd.api+json` — all route correctly
- [ ] After deploy, verify `https://collection.sciencemuseumgroup.org.uk/404` returns the HTML 404 page