### PR TITLE
Fix &amp; showing as literal text in Wikidata image captions

### DIFF
--- a/lib/wikidataQueries.js
+++ b/lib/wikidataQueries.js
@@ -126,6 +126,23 @@ async function batchFetchEntities (qCodes) {
     .map(r => r.value));
 }
 
+// Decodes the common HTML entities that arrive in Commons ImageDescription/Artist
+// HTML. Applied after tag stripping so Handlebars doesn't double-escape the `&`
+// in values like `&amp;` (which would render as the literal text `&amp;`).
+function decodeHtmlEntities (str) {
+  if (typeof str !== 'string') return str;
+  const named = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: '\u00A0' };
+  return str.replace(/&(#x[0-9a-f]+|#\d+|[a-z]+);/gi, (match, code) => {
+    if (code[0] === '#') {
+      const num = (code[1] === 'x' || code[1] === 'X')
+        ? parseInt(code.slice(2), 16)
+        : parseInt(code.slice(1), 10);
+      return Number.isFinite(num) ? String.fromCodePoint(num) : match;
+    }
+    return named[code.toLowerCase()] || match;
+  });
+}
+
 // Fetches image metadata from the Wikimedia Commons extmetadata API.
 // Returns { caption, license, licenseUrl, artist, commonsUrl } or null on failure.
 // Never throws — any network error or missing data returns null so the caller degrades gracefully.
@@ -160,7 +177,7 @@ async function fetchImageMetadata (filename) {
       description.length <= 100 &&
       !/&[lg]t;|&#\d+;|https?:\/\//i.test(description);
     const caption = descriptionUsable
-      ? description
+      ? decodeHtmlEntities(description)
       : (page.pageid ? await fetchCommonsCaption(page.pageid, { signal, headers }) : null);
     const license = meta.LicenseShortName && meta.LicenseShortName.value
       ? meta.LicenseShortName.value
@@ -169,7 +186,7 @@ async function fetchImageMetadata (filename) {
       ? meta.LicenseUrl.value
       : null;
     const artist = meta.Artist && meta.Artist.value
-      ? meta.Artist.value.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim() || null
+      ? decodeHtmlEntities(meta.Artist.value.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim()) || null
       : null;
     return {
       caption,


### PR DESCRIPTION
## Summary
- Wikimedia Commons returns `ImageDescription` / `Artist` as HTML. The existing code stripped tags but left named entities (e.g. `&amp;`, `&quot;`) intact, so Handlebars then escaped the `&` on output — rendering `&amp;` as literal text in the Wikidata image caption.
- Example: caption on [/people/cp34933](https://collection.sciencemuseumgroup.org.uk/people/cp34933) showed `Brown &amp; Sharpe Complex, Providence, Rhode Island`.
- Adds a small `decodeHtmlEntities()` helper in `lib/wikidataQueries.js` and applies it to `caption` and `artist` after tag stripping so the caption contains the intended plain-text character before Handlebars renders it.

## Test plan
- [ ] Load a person/company page whose Wikidata image caption contains `&` (e.g. `/people/cp34933`) and confirm the caption renders `Brown & Sharpe Complex, Providence, Rhode Island` rather than `Brown &amp; Sharpe ...`.
- [ ] Confirm captions without entities are unchanged.
- [ ] Sanity check captions containing `"` / `'` / numeric entities also render correctly.