### PR TITLE
Remove AWS WAF Challenge SDK integration

### DIFF
--- a/client/lib/get-data.js
+++ b/client/lib/get-data.js
@@ -1,18 +1,7 @@
-const ponyfillFetch = require('fetch-ponyfill')().fetch;
-
-// Use the AWS WAF Application Integration SDK's fetch wrapper when available.
-// It catches 202 Challenge responses from WAF, solves the silent PoW, refreshes
-// the aws-waf-token cookie, and retries the request transparently. Falls back
-// to the ponyfill in test environments where the SDK global isn't present.
-function wafAwareFetch (url, opts) {
-  if (typeof window !== 'undefined' && window.AwsWafIntegration && typeof window.AwsWafIntegration.fetch === 'function') {
-    return window.AwsWafIntegration.fetch(url, opts);
-  }
-  return ponyfillFetch(url, opts);
-}
+const fetch = require('fetch-ponyfill')().fetch;
 
 module.exports = function (url, opts, cb) {
-  wafAwareFetch(url, opts)
+  fetch(url, opts)
     .then(function (res) {
       if (res.ok) {
         return res.json();

--- a/client/main.js
+++ b/client/main.js
@@ -1,14 +1,6 @@
 require('./lib/polyfills.js')();
 const page = require('page');
 
-// Warm up the AWS WAF token cookie before any AJAX fires. The SDK's
-// challenge.js is loaded deferred from the default layout; calling getToken()
-// here asks it to issue/refresh the token immediately so fast first-AJAX
-// interactions (e.g. search-box autocomplete) don't race the SDK init.
-if (typeof window !== 'undefined' && window.AwsWafIntegration && typeof window.AwsWafIntegration.getToken === 'function') {
-  window.AwsWafIntegration.getToken().catch(() => {});
-}
-
 require('./middleware/initial-render')(page);
 
 // Client routes

--- a/templates/layouts/default.html
+++ b/templates/layouts/default.html
@@ -2,7 +2,6 @@
 <html class="no-js" lang="en">
 
 <head>
-  <script src="https://9e27d934dcc0.edge.sdk.awswaf.com/9e27d934dcc0/68da2414f017/challenge.js" defer></script>
   <!-- Data layer-->
   <script>
     window.dataLayer = window.dataLayer || []


### PR DESCRIPTION
## Summary

Removes the AWS WAF Application Integration SDK wiring that was added to support **Bot Control TARGETED** rules. We've since dropped to the **COMMON** ruleset, which does not evaluate the token-based signals (`TGT_VolumetricIpTokenAbsent`, `TGT_TokenReuseIp`, `TGT_VolumetricSession`, `TGT_TokenReuse*`) that the SDK exists to satisfy — so every user is currently paying for a third-party `challenge.js` script tag and an AJAX wrapper that provide no corresponding protection.

Changes:
- `templates/layouts/default.html` — drop the `awswaf.com/.../challenge.js` script tag from `<head>`
- `client/main.js` — drop the `AwsWafIntegration.getToken()` warmup call
- `client/lib/get-data.js` — replace `wafAwareFetch` wrapper with the plain `fetch-ponyfill` fetch

No npm dependencies were added for the original integration (it was a remote script), so nothing to uninstall. No server-side changes.

## If we need to re-enable TARGETED

Revert this commit. The original integration comes back as a single atomic change.

## Test plan

- [ ] `npm run package` builds the client bundle without errors
- [ ] Site loads in staging with no `awswaf.com` script request in Network panel
- [ ] Search autocomplete, IIIF, wiki, and API AJAX calls still succeed
- [ ] No console errors referencing `AwsWafIntegration`