### PR TITLE
Hot-load name-collections descriptions from disk

### DIFF
--- a/lib/name-collections.js
+++ b/lib/name-collections.js
@@ -4,10 +4,33 @@ const sortImages = require('./helpers/jsonapi-response/sort-images');
 const getImageCaption = require('./helpers/get-image-caption');
 const encodeFilterValue = require('./helpers/encode-filter-value');
 const widgetConfig = require('../config/name-collections.json');
-const collectionDescriptions = require('../description-boxes/collection.json');
 const anniversary = require('./anniversary');
 
 const PUBLIC_DIR = path.join(__dirname, '..', 'public');
+const DESCRIPTIONS_FILE = path.join(__dirname, '..', 'description-boxes', 'collection.json');
+
+// description-boxes/collection.json is loaded with stat-checked freshness rather
+// than `require()`. require() caches the parsed object at process start, so any
+// edit to the file does not take effect until every Node PID on every EB
+// instance is restarted — and EB's "Restart app server(s)" is not always
+// reliable across multiple instances. Stat is microseconds; re-read only fires
+// when the file's mtime changes (i.e. after a fresh deploy).
+let _descriptionsCache = null;
+let _descriptionsMtime = 0;
+
+function loadDescriptions () {
+  try {
+    const stat = fs.statSync(DESCRIPTIONS_FILE);
+    if (!_descriptionsCache || stat.mtimeMs !== _descriptionsMtime) {
+      _descriptionsCache = JSON.parse(fs.readFileSync(DESCRIPTIONS_FILE, 'utf8'));
+      _descriptionsMtime = stat.mtimeMs;
+    }
+    return _descriptionsCache;
+  } catch (err) {
+    console.error('Failed to load collection descriptions:', err.message || err);
+    return _descriptionsCache || {};
+  }
+}
 
 module.exports = async function getNameCollectionsData (elastic, config) {
   if (!widgetConfig.enabled) return null;
@@ -138,7 +161,7 @@ function assetExists (figurePath) {
 const DESCRIPTION_MAX = 200;
 
 function getDescription (collectorName) {
-  const entry = collectionDescriptions[collectorName];
+  const entry = loadDescriptions()[collectorName];
   if (!entry || !entry.description) return '';
 
   const desc = entry.description.trim();


### PR DESCRIPTION
## Problem

`description-boxes/collection.json` was loaded via `require()` at module load:

```js
const collectionDescriptions = require('../description-boxes/collection.json');
```

`require()` parses the JSON once and caches the result in Node's module cache for the lifetime of the process. This means:

1. Edits to `collection.json` only take effect after every Node PID on every EB instance restarts.
2. EB's **Actions → Restart app server(s)** doesn't reliably cycle every PID in multi-instance environments.
3. Worse: any PID *spawned later* (autoscaling, OOM recovery, health-check kill, AMI refresh) reads whatever the disk happens to contain at the exact moment that PID boots. If the volume was briefly stale, that PID stays broken until the next manual restart.

This produced the symptom we kept hitting: descriptions appear immediately after a deploy, then progressively flicker / disappear as the fleet cycles, even though no code or config has changed.

## Fix

Replace the top-level `require` with a stat-checked lazy loader inside `getDescription()`. Every call:

1. `fs.statSync` the JSON file (microseconds — same kind of call `assetExists()` already makes nearby).
2. If `mtime` matches the cached value, return the in-memory parse.
3. Otherwise re-parse from disk and update the cache.

A fresh deploy bumps the file's `mtime`, which transparently invalidates the cache. No restart needed.

## Why now / why this file in particular

`anniversary-widget.json`, the fixture data files, and `name-collections.json` itself all use `require()` and have the same latent issue — but they're rarely edited so nobody's noticed. `description-boxes/collection.json` is the first content config under active iterative editing, so it surfaced the problem.

If we hit this for another file later, we can extract the loader into a helper. For now, scoped to the one file actually causing pain.

## Test plan
- [ ] Local: `node -e "require('./lib/name-collections')._getDescription('BBC Heritage Collection')"` returns the trimmed first sentence
- [ ] Edit `description-boxes/collection.json`, hit `/` again — change visible without restarting the dev server
- [ ] Deploy to EB, confirm descriptions render
- [ ] Wait several days, confirm they continue to render even after instances have cycled