### PR TITLE
Fix shared Redis cache leaking environment-specific URLs

### DIFF
--- a/lib/cached-wikidata.js
+++ b/lib/cached-wikidata.js
@@ -1,3 +1,78 @@
+// Internal route shapes — used to recognise URLs that point at this app
+// (as opposed to external links like wikidata.org / wikipedia.org / VIAF).
+// Tight on purpose: matches `/people/cp123`, `/objects/co456`, etc., where
+// the prefix is one of our known UID schemes. External URLs, even if they
+// happen to contain `/people/` somewhere in the path, won't match because
+// of the UID prefix requirement.
+const INTERNAL_ROUTE_RE = /^\/(?:people|objects|documents|group)\/(?:cp|ap|co|aa|ag)\w+/i;
+const ABSOLUTE_URL_RE = /^https?:\/\//i;
+
+// Walk a cached value and strip any hostname from URLs that point at us.
+//
+// Why: this cache is shared across staging and production. Older code (or
+// any future regression) embedded `${config.rootUrl}` into URLs at write
+// time, meaning a write from staging would serve staging URLs to
+// production for the 30-day TTL. Read-time normalisation makes the cache
+// environment-agnostic without needing a flush — legacy entries quietly
+// get the hostname stripped on the way out.
+//
+// Conservative: only strips when the URL's path matches one of our
+// internal route shapes. External URLs (wikidata.org, wikipedia.org,
+// gracesguide.co.uk, viaf.org, etc.) pass through untouched.
+//
+// Mutative — modifies the input in place. Cached objects can be large
+// (full Wikidata response with nested arrays) and an immutable deep clone
+// would be wasteful for what is effectively a write-during-deserialisation
+// step.
+//
+// === REMOVAL CRITERIA ===
+//
+// This function is a transitional cleanup, not a long-term part of the
+// caching architecture. The forward fix (3 call sites in wikidataQueries.js
+// and routes/wiki.js now writing relative paths) means new cache entries
+// are correct without it. The normaliser exists only to handle entries
+// written BEFORE the forward fix landed.
+//
+// CACHE_TTL is ~30 days. Once this fix has been deployed to every
+// environment that writes to this Redis cache (staging + production) for
+// at least 30 days, every legacy entry will have expired and been
+// re-written by the new code path. From that point onwards the normaliser
+// is dead code and can be removed.
+//
+// **Safe to remove ~30 days after this PR merges and deploys to all
+// environments that share the cache.** Set a reminder when deploying;
+// ripping it out is one commit of pure deletion (this function, the two
+// call sites in fetchCache / memGet, and the test file
+// `test/cached-wikidata-url-normaliser.test.js`).
+function normaliseInternalUrls (obj) {
+  if (obj == null) return obj;
+  if (typeof obj === 'string') {
+    if (!ABSOLUTE_URL_RE.test(obj)) return obj;
+    try {
+      const u = new URL(obj);
+      if (INTERNAL_ROUTE_RE.test(u.pathname)) {
+        return u.pathname + u.search + u.hash;
+      }
+    } catch (err) {
+      // Unparseable URL string — leave as-is.
+    }
+    return obj;
+  }
+  if (Array.isArray(obj)) {
+    for (let i = 0; i < obj.length; i++) {
+      obj[i] = normaliseInternalUrls(obj[i]);
+    }
+    return obj;
+  }
+  if (typeof obj === 'object') {
+    for (const k of Object.keys(obj)) {
+      obj[k] = normaliseInternalUrls(obj[k]);
+    }
+    return obj;
+  }
+  return obj;
+}
+
 // In-memory fallback used when Redis is unavailable (e.g. local dev).
 // Keyed by Q-code; each entry carries an expiry timestamp so stale data
 // is never returned even if Redis stays down for an extended period.
@@ -19,7 +94,7 @@ function memGet (key) {
     memoryCache.delete(key);
     return null;
   }
-  return entry.data;
+  return normaliseInternalUrls(entry.data);
 }
 
 function memSet (key, data) {
@@ -40,7 +115,7 @@ exports.fetchCache = async function (cache, qCode, clearCache = undefined) {
       await cache.drop({ segment: CACHE_SEGMENT, id: qCode });
       return null;
     }
-    return cached;
+    return normaliseInternalUrls(cached);
   } catch (err) {
     console.debug("Couldn't fetch from wikidata cache:", err.message);
     return null;
@@ -75,3 +150,7 @@ exports.clearMemoryCache = function (qCode) {
 exports.clearAllMemoryCache = function () {
   memoryCache.clear();
 };
+
+// Exported for tests. Production callers go through fetchCache, which
+// applies the normaliser automatically.
+exports._normaliseInternalUrls = normaliseInternalUrls;

--- a/lib/wikidataQueries.js
+++ b/lib/wikidataQueries.js
@@ -377,8 +377,13 @@ module.exports = {
       const related = relatedMap
         ? (relatedMap.get(fieldId) || null)
         : await relatedWikidata(elastic, fieldId);
+      // Store as a RELATIVE path. The Wikidata cache is shared between
+      // staging and production; embedding `config.rootUrl` here would mean
+      // a write from one environment poisons the other for up to 30 days.
+      // Browsers resolve relative hrefs against the page's origin at render
+      // time, which gives the right answer per environment automatically.
       const link = related
-        ? `${config.rootUrl}/people/${related?.[0]?._id}`
+        ? `/people/${related?.[0]?._id}`
         : undefined;
 
       // pulls out position as top level field
@@ -525,9 +530,11 @@ module.exports = {
 
       // if no related record and has wikidata config flag, hide from ui
       const hideFromUi = !related && hasDisplayLinkedFlag;
-      // to build anchor tags to related records
+      // to build anchor tags to related records — stored as a relative path
+      // so the shared Wikidata cache stays environment-agnostic (see the
+      // matching note ~150 lines above on the `link` for occupation context).
       const link = related
-        ? `${config.rootUrl}/people/${related?.[0]?._id}`
+        ? `/people/${related?.[0]?._id}`
         : undefined;
       return {
         ...(link ? { related: link } : {}),

--- a/routes/wiki.js
+++ b/routes/wiki.js
@@ -261,7 +261,11 @@ async function fetchColleagues (employers, currentQCode, elastic, config, subjec
         .map(q => {
           const hit = inCollection.get(q);
           const name = colleagueDisplayName(hit._source) || hit._id;
-          return { name, url: `${config.rootUrl}/people/${hit._id}` };
+          // Relative path — this object is cached in shared Redis (segment
+          // 'wikidata', 30-day TTL). Embedding config.rootUrl here would
+          // poison the cross-environment cache: a write from staging could
+          // serve staging URLs to production for up to a month.
+          return { name, url: `/people/${hit._id}` };
         });
       return colleagues.length > 0 ? { employer: label, colleagues } : null;
     })

--- a/test/cached-wikidata-url-normaliser.test.js
+++ b/test/cached-wikidata-url-normaliser.test.js
@@ -1,0 +1,180 @@
+'use strict';
+
+// Tests for the read-time URL normaliser in cached-wikidata.js.
+// The Wikidata cache is keyed by Q-code and shared between staging and
+// production. Older code embedded `${config.rootUrl}` into URLs at write
+// time, which leaked the writing environment's hostname through the
+// cache. The normaliser strips those hostnames at read time when the path
+// matches one of our internal route shapes — leaving external URLs
+// (Wikidata, Wikipedia, VIAF, etc.) untouched.
+
+const test = require('tape');
+const { _normaliseInternalUrls: norm } = require('../lib/cached-wikidata');
+
+test('normaliser: passes through nullish and primitive non-string values', function (t) {
+  t.equal(norm(null), null);
+  t.equal(norm(undefined), undefined);
+  t.equal(norm(42), 42);
+  t.equal(norm(true), true);
+  t.end();
+});
+
+test('normaliser: leaves already-relative paths unchanged', function (t) {
+  t.equal(norm('/people/cp52967'), '/people/cp52967');
+  t.equal(norm('/objects/co8083260/foo'), '/objects/co8083260/foo');
+  t.equal(norm('/search?q=foo'), '/search?q=foo');
+  t.end();
+});
+
+test('normaliser: strips production hostname from internal-route URLs', function (t) {
+  t.equal(
+    norm('https://collection.sciencemuseumgroup.org.uk/people/cp52967'),
+    '/people/cp52967'
+  );
+  t.equal(
+    norm('http://collection.sciencemuseumgroup.org.uk/objects/co8083260'),
+    '/objects/co8083260'
+  );
+  t.equal(
+    norm('https://collection.sciencemuseumgroup.org.uk/documents/aa110000017'),
+    '/documents/aa110000017'
+  );
+  t.end();
+});
+
+test('normaliser: strips arbitrary hostname (staging, EBS, localhost) from internal URLs', function (t) {
+  t.equal(
+    norm('http://collectionsonline-ai-biogs.eba-9hnswuq5.eu-west-1.elasticbeanstalk.com/people/cp1939'),
+    '/people/cp1939'
+  );
+  t.equal(
+    norm('http://localhost:8000/people/cp52967'),
+    '/people/cp52967'
+  );
+  t.end();
+});
+
+test('normaliser: preserves query string and fragment when stripping', function (t) {
+  t.equal(
+    norm('https://collection.sciencemuseumgroup.org.uk/people/cp52967?foo=1'),
+    '/people/cp52967?foo=1'
+  );
+  t.equal(
+    norm('https://collection.sciencemuseumgroup.org.uk/objects/co8083260#section'),
+    '/objects/co8083260#section'
+  );
+  t.end();
+});
+
+test('normaliser: leaves external URLs untouched', function (t) {
+  // Wikidata / Wikipedia
+  t.equal(
+    norm('https://www.wikidata.org/wiki/Q937'),
+    'https://www.wikidata.org/wiki/Q937'
+  );
+  t.equal(
+    norm('https://en.wikipedia.org/wiki/Albert_Einstein'),
+    'https://en.wikipedia.org/wiki/Albert_Einstein'
+  );
+  // External identifier services
+  t.equal(
+    norm('https://viaf.org/viaf/12345'),
+    'https://viaf.org/viaf/12345'
+  );
+  t.equal(
+    norm('https://www.gracesguide.co.uk/Smith'),
+    'https://www.gracesguide.co.uk/Smith'
+  );
+  // Wikimedia Commons (image hosting for wiki blocks)
+  t.equal(
+    norm('https://commons.wikimedia.org/wiki/File:foo.jpg'),
+    'https://commons.wikimedia.org/wiki/File:foo.jpg'
+  );
+  t.end();
+});
+
+test('normaliser: leaves URLs with non-internal paths alone, even on our hostname', function (t) {
+  // Our hostname BUT the path doesn't match an internal-record shape —
+  // could be a static asset URL or a marketing link. Don't touch.
+  t.equal(
+    norm('https://collection.sciencemuseumgroup.org.uk/about'),
+    'https://collection.sciencemuseumgroup.org.uk/about'
+  );
+  t.equal(
+    norm('https://collection.sciencemuseumgroup.org.uk/assets/img/logo.svg'),
+    'https://collection.sciencemuseumgroup.org.uk/assets/img/logo.svg'
+  );
+  t.end();
+});
+
+test('normaliser: leaves URLs whose path coincidentally contains "/people/" but no UID', function (t) {
+  // Defensive check — INTERNAL_ROUTE_RE requires the prefix is followed
+  // by a known UID scheme (cp/ap/co/aa/ag).
+  t.equal(
+    norm('https://example.com/people/famous-folks'),
+    'https://example.com/people/famous-folks'
+  );
+  t.equal(
+    norm('https://example.com/objects/by-decade'),
+    'https://example.com/objects/by-decade'
+  );
+  t.end();
+});
+
+test('normaliser: walks arrays and strips internal URLs in nested entries', function (t) {
+  const input = [
+    { url: 'https://collection.sciencemuseumgroup.org.uk/people/cp1', name: 'Alice' },
+    { url: 'https://collection.sciencemuseumgroup.org.uk/objects/co2', name: 'Bob' },
+    { url: 'https://en.wikipedia.org/wiki/Bob', name: 'External' }
+  ];
+  const out = norm(input);
+  t.equal(out[0].url, '/people/cp1');
+  t.equal(out[1].url, '/objects/co2');
+  t.equal(out[2].url, 'https://en.wikipedia.org/wiki/Bob', 'external untouched');
+  t.end();
+});
+
+test('normaliser: walks deeply nested objects', function (t) {
+  // Mirrors the actual cached Wikidata response shape — values is an
+  // array of objects, each with potentially internal `url` or `related`
+  // fields plus external `wikidataUrl` / `wikipediaUrl`.
+  const input = {
+    wikidataUrl: 'https://www.wikidata.org/wiki/Q937',
+    wikipediaUrl: 'https://en.wikipedia.org/wiki/Albert_Einstein',
+    values: [
+      {
+        label: 'employer',
+        related: 'http://localhost:8000/people/cp4566',
+        value: 'ETH Zurich'
+      },
+      {
+        label: 'colleagues',
+        list: [
+          { name: 'Alice', url: 'https://collection.sciencemuseumgroup.org.uk/people/cp10' },
+          { name: 'Bob', url: 'https://collection.sciencemuseumgroup.org.uk/people/cp11' }
+        ]
+      }
+    ]
+  };
+  const out = norm(input);
+  // External URLs untouched
+  t.equal(out.wikidataUrl, 'https://www.wikidata.org/wiki/Q937');
+  t.equal(out.wikipediaUrl, 'https://en.wikipedia.org/wiki/Albert_Einstein');
+  // Internal URLs stripped, regardless of which environment wrote them
+  t.equal(out.values[0].related, '/people/cp4566');
+  t.equal(out.values[1].list[0].url, '/people/cp10');
+  t.equal(out.values[1].list[1].url, '/people/cp11');
+  t.end();
+});
+
+test('normaliser: handles unparseable URL strings gracefully', function (t) {
+  // Ensure URL-parse failures don't blow up the cache read path.
+  t.equal(norm('http://'), 'http://');
+  t.equal(norm('http:///bad'), 'http:///bad', 'unparseable left as-is');
+  t.end();
+});
+
+test('normaliser: handles empty string', function (t) {
+  t.equal(norm(''), '');
+  t.end();
+});


### PR DESCRIPTION
## Summary
- The Wikidata cache (Redis segment `wikidata`, 30-day TTL, shared between staging and production) was embedding `${config.rootUrl}` into URLs at write time, meaning a write from one environment could serve wrong-host URLs to the other for up to 30 days.
- **Forward fix**: store relative paths only (`/people/cp123` rather than `<host>/people/cp123`). Browsers resolve relative paths against the page origin at render time, so HTML rendering produces correct per-environment URLs without per-request work. JSON consumers get standard JSON:API relative-link semantics.
- **Backward fix**: a read-time normaliser at `cached-wikidata.js::fetchCache` strips hostnames from any URL whose path matches one of our internal route shapes (`/people/cp…`, `/objects/co…`, `/documents/aa…`, `/group/ag…`). External URLs (Wikidata, Wikipedia, VIAF, gracesguide, Wikimedia Commons, etc.) pass through untouched. Legacy poisoned entries get cleaned up at read time without needing a Redis flush.
- The normaliser is transitional — once both staging and production have been on this code for ≥30 days (the cache TTL), every legacy entry will have expired and been re-written by the new code path, at which point the normaliser becomes dead code and can be removed. Removal criteria documented inline above the function.

## Why
- Three call sites in the wikidata path (`lib/wikidataQueries.js` × 2, `routes/wiki.js` × 1) were concatenating `${config.rootUrl}` into URLs that were then written to a cache shared by all environments. Hostnames have no business in shared infrastructure cache; this leak was an architectural smell that has been in place for as long as the wikidata cache has existed.
- Shipping today closes the leak going forwards and provides a graceful read-time cleanup for any cache entries written under the old code path.

## Test plan
- [ ] CI passes (lint + 34 new unit tests for the normaliser, plus the existing test suite)
- [ ] Manual verification on staging: load a record with a Wikidata block, confirm internal links use relative paths
- [ ] Production deploy: same check, no cross-environment URLs surface

## Files changed
- `lib/cached-wikidata.js` — adds `normaliseInternalUrls` helper, applied at the cache-read boundary
- `lib/wikidataQueries.js` — 2 call sites: write relative paths, not absolute
- `routes/wiki.js` — 1 call site: same change
- `test/cached-wikidata-url-normaliser.test.js` — 34 unit tests covering: nullish input, internal-host stripping (production / staging / localhost hostnames), external-host preservation (Wikidata / Wikipedia / VIAF / gracesguide / Wikimedia Commons), our-hostname-but-non-record-paths preservation (assets, marketing pages), deeply nested walking, query string + fragment preservation, malformed URL graceful handling.