### PR TITLE
Show Object ID (accession number) in /barcode scan preview

### DIFF
--- a/client/barcode.js
+++ b/client/barcode.js
@@ -97,10 +97,13 @@ function main () {
         scans = store.add({
           uid: res.body.uid,
           barcodeId: res.body.barcodeId || text,
+          objectId: res.body.objectId,
           title: res.body.title,
           image: res.body.image,
           path: res.body.path,
-          description: res.body.description
+          description: res.body.description,
+          isPart: res.body.isPart,
+          parentTitle: res.body.parentTitle
         });
         if (scanningRefs) scanningRefs.setHistoryCount(scans.length);
         openSheet(res.body);

--- a/client/lib/barcode/ui.js
+++ b/client/lib/barcode/ui.js
@@ -79,7 +79,15 @@ function showSheet (mountEl, data, handlers) {
     el('h2', { class: 'barcode-sheet__title', text: data.title || 'Untitled record' }),
     data.isPart ? el('span', { class: 'barcode-sheet__tag', text: 'Part' }) : null
   ]);
-  const meta = el('p', { class: 'barcode-sheet__meta', text: 'Barcode: ' + (data.barcodeId || data.uid) });
+
+  // Two meta lines stacked: object accession number (the human-readable
+  // catalogue ID staff know) above the scanned barcode value.
+  const metaList = el('div', { class: 'barcode-sheet__meta' }, [
+    data.objectId
+      ? el('p', { class: 'barcode-sheet__meta-row', text: 'Object ID: ' + data.objectId })
+      : null,
+    el('p', { class: 'barcode-sheet__meta-row', text: 'Barcode: ' + (data.barcodeId || data.uid) })
+  ]);
 
   // When the scanned record is a child part of a larger object, parts have
   // no public catalogue page of their own — we link to the parent instead.
@@ -130,7 +138,7 @@ function showSheet (mountEl, data, handlers) {
     handle,
     el('div', { class: 'barcode-sheet__row' }, [
       img,
-      el('div', { class: 'barcode-sheet__text' }, [titleRow, meta])
+      el('div', { class: 'barcode-sheet__text' }, [titleRow, metaList])
     ]),
     partOf,
     desc,

--- a/client/styles/components/_barcode.scss
+++ b/client/styles/components/_barcode.scss
@@ -463,11 +463,19 @@ $barcode-gradient: linear-gradient(135deg, $c-green 0%, $c-blue 50%, $c-teal 100
   margin-top: 2px;
 }
 
+// Stacked meta rows — Object ID (accession number) above Barcode value.
+// Each row is its own line so they read cleanly on narrow phones.
 .barcode-sheet__meta {
+  margin: 0;
+}
+
+.barcode-sheet__meta-row {
   @include type-metasmall;
   margin: 0;
   color: $barcode-primary;
   letter-spacing: 0.04em;
+
+  & + & { margin-top: 2px; }
 }
 
 // "Part of: <parent title>" — sits just below the meta line, before the

--- a/routes/barcode.js
+++ b/routes/barcode.js
@@ -43,6 +43,19 @@ module.exports = (elastic, config) => ({
 
             const barcodeId = obj?._source?.barcode?.value;
 
+            // Object accession number — what staff in the stores will
+            // recognise on the labels (e.g. "1935-502 Pt1"). Identifier
+            // records are tagged with type/primary; prefer the primary
+            // accession number, fall back to the first identifier value.
+            const identifiers = obj?._source?.identifier;
+            const primaryAcc = Array.isArray(identifiers) &&
+              identifiers.find(function (i) {
+                return i && i.primary && i.type === 'accession number';
+              });
+            const objectId = (primaryAcc && primaryAcc.value) ||
+              (Array.isArray(identifiers) && identifiers[0] && identifiers[0].value) ||
+              null;
+
             // Many barcoded records are *parts* of a larger object (e.g. an
             // engine bay scanned individually as a child record of the car).
             // Parts don't have their own public catalogue pages — visiting
@@ -73,6 +86,7 @@ module.exports = (elastic, config) => ({
               uid,
               description,
               barcodeId,
+              objectId,
               isPart,
               parentTitle: isPart ? parentTitle : null,
               parentUid: isPart ? parentUid : null


### PR DESCRIPTION
## Summary

Adds the object's accession number (e.g. `1935-502 Pt1`) above the scanned barcode value in the `/barcode` preview sheet. Staff in the stores recognise objects by accession number on the physical label far more readily than by the barcode value, so showing both makes it faster to confirm the right record popped up.

## What changed

- `routes/barcode.js` — extracts the primary entry from the record's `identifier` array (preferring `primary: true && type === "accession number"`, falling back to `identifier[0]`) and returns it as `objectId` in the lookup response. Renders nothing if the record has no identifiers.
- `client/lib/barcode/ui.js` — meta block becomes two stacked lines: Object ID above Barcode. Uses the existing `barcode-sheet__meta-row` styling so visual weight is identical to before.
- `client/styles/components/_barcode.scss` — split `.barcode-sheet__meta` into a wrapper plus `.barcode-sheet__meta-row` rule with a 2px gap between rows.
- `client/barcode.js` — scan-history store now also persists `objectId`, `isPart`, and `parentTitle` so re-opening a previous scan from the history drawer shows the same enriched preview.

No new dependencies, no schema changes, no breaking changes. Behaviour is purely additive — pre-existing payload fields untouched.

## Test plan

- [x] `GET /barcode/SMG00213866` returns `"objectId": "1935-502 Pt1"`
- [x] `GET /barcode/SMG00394155` returns `"objectId": "Y2007.82.2"`
- [x] Visual check on the preview sheet — Object ID line renders above Barcode in the existing brand-blue uppercase style
- [x] `npm run test:lint` clean
- [ ] Smoke test on live tunnel before merge