### PR TITLE
Suppress repeat lookups for not-found barcodes on /barcode

### DIFF
--- a/client/barcode.js
+++ b/client/barcode.js
@@ -109,13 +109,21 @@ function main () {
         openSheet(res.body);
       } else if (res.status === 404) {
         ui.showToast(mount, 'Barcode ' + text + ' not found in the catalogue.', { variant: 'warn' });
+        // Suppress this specific barcode for 30s so we don't refire the
+        // lookup (and re-toast) every 2s while the user is still pointing
+        // at the same wrapper. Other barcodes still scan instantly.
+        scanner.suppress(text, 30000);
         scanner.resume();
       } else {
         ui.showToast(mount, 'Lookup failed. Please try again.', { variant: 'error' });
+        // Server-side error — short suppression so the user doesn't see a
+        // wall of error toasts, but recovers if it was a transient blip.
+        scanner.suppress(text, 5000);
         scanner.resume();
       }
     }).catch(function () {
       ui.showToast(mount, 'Network error. Please try again.', { variant: 'error' });
+      scanner.suppress(text, 5000);
       scanner.resume();
     });
   }

--- a/client/lib/barcode/scanner.js
+++ b/client/lib/barcode/scanner.js
@@ -57,6 +57,11 @@ function createScanner () {
   let tickCount = 0;
   let lastDecoded = null;
   let lastDecodedAt = 0;
+  // Suppression list: text → expiresAt (epoch ms). Used by the entry point
+  // to silence repeat lookups for a barcode that just 404'd, since the
+  // user is likely still pointing the camera at the same code. Without
+  // this we'd refire the lookup every 2s and re-toast indefinitely.
+  const suppressed = new Map();
   let debugEl = null;
   let lastHitDeg = null;
 
@@ -171,11 +176,29 @@ function createScanner () {
   function handleHit (text, deg, onResult) {
     const now = Date.now();
     if (text === lastDecoded && now - lastDecodedAt < DEDUPE_WINDOW_MS) return;
+
+    // Caller asked us to suppress this barcode (typically after a 404
+    // lookup). Pretend we didn't see it; suppression entry self-expires.
+    const expiry = suppressed.get(text);
+    if (expiry !== undefined) {
+      if (expiry > now) return;
+      suppressed.delete(text);
+    }
+
     lastDecoded = text;
     lastDecodedAt = now;
     // eslint-disable-next-line no-console
     console.log('[barcode] decoded at', deg + '°:', text);
     onResult(text);
+  }
+
+  // Mark `text` as suppressed for `ttlMs` so the scan loop ignores it
+  // even if the camera continues to resolve it. Used by the entry point
+  // when a barcode is genuinely not in the catalogue, to avoid hammering
+  // the lookup endpoint and re-toasting on every frame.
+  function suppress (text, ttlMs) {
+    if (!text) return;
+    suppressed.set(text, Date.now() + (ttlMs || 30000));
   }
 
   // ---- debug overlay (only when ?debug=1) -------------------------------
@@ -223,6 +246,7 @@ function createScanner () {
   function stop () {
     stopped = true;
     paused = true;
+    suppressed.clear();
     if (timer) { clearTimeout(timer); timer = null; }
     if (stream) {
       stream.getTracks().forEach(function (t) {
@@ -280,7 +304,7 @@ function createScanner () {
     return p.then(function () { return true; }).catch(function () { return false; });
   }
 
-  return { start, pause, resume, stop, setTorch, torchSupported, isStreamAlive, poke };
+  return { start, pause, resume, stop, setTorch, torchSupported, isStreamAlive, poke, suppress };
 }
 
 module.exports = { createScanner };


### PR DESCRIPTION
## Summary

When the camera saw a barcode that wasn't in the catalogue (snack wrapper, random EAN, etc.), the toast popped up roughly every 2 seconds for as long as the user kept the camera pointed at it — and we were hammering the `/barcode/<value>` lookup endpoint at the same rate.

## Root cause

After a 404 the entry point called `scanner.resume()`, which resets the scanner's dedupe state (`lastDecoded → null`). The next camera frame decoded the same barcode, fired the lookup again, and re-toasted. Loop.

## Fix

Adds a per-barcode suppression list to the scanner module. The entry point now calls `scanner.suppress(text, ttlMs)` on lookup failure:

| Outcome | TTL |
|---|---|
| 404 — definitively not in the catalogue | 30 s |
| 5xx / network error — possibly transient | 5 s |

While a barcode is suppressed, decodes for that exact value are silently dropped — so no toast, no lookup. Other barcodes scan instantly: the user can keep moving from item to item with no friction. Suppression entries self-expire on access; the map is cleared on `scanner.stop()`.

## Test plan

- [x] `npm run test:lint` clean
- [x] Code review: suppress() expiry / cleanup paths, dedupe still applies independently
- [ ] Smoke test: scan a non-catalogue barcode → exactly one "not found" toast → keep camera on it → no further toasts and no further lookup requests in DevTools network tab. Move camera to a valid barcode → still scans normally.