### PR TITLE
fix: 'On display' panel hidden on production — read ondisplay, not facility @hierarchy

### DIFF
--- a/lib/facets/create-filters.js
+++ b/lib/facets/create-filters.js
@@ -239,8 +239,6 @@ module.exports = function (queryParams, filterType) {
 
   // locations
   // Gallery filter takes precedence over museum filter.
-  // Both location.name (old ES schema) and facility.name (new ES schema) are queried
-  // with OR so that records indexed under either schema are matched.
   const museums = queryParams.filter.objects.museum || [];
   const galleries = queryParams.filter.objects.gallery || [];
   const locations = galleries.length > 0 ? galleries : museums;
@@ -293,23 +291,24 @@ function caseInsensitiveTermFilter (field, value) {
   };
 }
 
+// Filters museum/gallery clicks against `facility.name.value.lower`.
+// NOTE: facets aggregate on `ondisplay.value.keyword` (see lib/facets/aggs-all.js)
+// while filtering happens against `facility.name.value.lower` here. The two fields
+// are 1:1 in ciim today (every record with one has the other; same museum/gallery
+// values), so this divergence isn't user-visible — but it's worth knowing if the
+// data team ever changes how `facility` and `ondisplay` are populated.
+//
+// We can't trivially flip the filter to `ondisplay.value` because that field has
+// no `.lower` subfield in the ciim mapping, and `getDisplayLocation` (which is now
+// the consumer of `ondisplay`) reads it via the JSON-API attributes, not via this
+// filter path. A future cleanup could move both onto `ondisplay` using
+// `term` + `case_insensitive: true` (see caseInsensitiveTermFilter above).
 function buildLocationFilter (location, dashToSpace) {
   const value = location.toLowerCase();
   const valueWithSpaces = dashToSpace(value);
   return {
-    bool: {
-      should: [
-        {
-          terms: {
-            'location.name.value.lower': [value, valueWithSpaces]
-          }
-        },
-        {
-          terms: {
-            'facility.name.value.lower': [value, valueWithSpaces]
-          }
-        }
-      ]
+    terms: {
+      'facility.name.value.lower': [value, valueWithSpaces]
     }
   };
 }

--- a/lib/transforms/get-values.js
+++ b/lib/transforms/get-values.js
@@ -52,54 +52,37 @@ module.exports = {
   //   return display.museum ? display : null;
   // },
 
+  // Reads on-display museum/gallery from `attributes.ondisplay`, the only field
+  // that's reliably populated and consistently shaped across both the legacy
+  // `test` ES index and the production `ciim` index. The previous implementation
+  // walked `facility[0]['@hierarchy']` looking for `@datatype: 'site'/'permanent gallery'`
+  // entries — those tags exist on `test` but not on `ciim` (where @hierarchy is a
+  // nested array of bare {summary,@admin} objects), so the panel was hidden for
+  // every on-display object on production.
   getDisplayLocation (data) {
+    const ondisplay = getNestedProperty(data, 'attributes.ondisplay');
+    if (!Array.isArray(ondisplay)) return null;
+
     const display = {};
     const filters = [];
 
-    // old model
-    const locations = getNestedProperty(data, 'attributes.location.0.name');
-    if (locations) {
-      locations.forEach((loc) => {
-        if (loc.type === 'gallery' || loc.type === 'museum') {
-          // console.log(loc);
-          let displayValue = loc.value;
-          if (displayValue === 'National Media Museum') {
-            displayValue = 'National Science and Media Museum';
-          }
-          if (displayValue === 'Museum of Science and Industry') {
-            displayValue = 'Science and Industry Museum';
-          }
-          display[loc.type] = displayValue;
-          filters.push(loc.type + '/' + encodeURIComponent(loc.value));
-        }
-      });
-      display.link = '/search/' + this.formatLink(filters.join('/'));
-    }
+    ondisplay.forEach((loc) => {
+      if (!loc || (loc.type !== 'gallery' && loc.type !== 'museum')) return;
+      let displayValue = loc.value;
+      if (displayValue === 'National Media Museum') {
+        displayValue = 'National Science and Media Museum';
+      }
+      if (displayValue === 'Museum of Science and Industry') {
+        displayValue = 'Science and Industry Museum';
+      }
+      display[loc.type] = displayValue;
+      filters.push(loc.type + '/' + encodeURIComponent(loc.value));
+    });
 
-    // new model
-    if (
-      data.attributes.facility &&
-      data.attributes.facility[0] &&
-      data.attributes.facility[0]['@hierarchy']
-    ) {
-      data.attributes.facility[0]['@hierarchy'].forEach((f) => {
-        if (
-          f['@datatype'] === 'permanent gallery' ||
-          f['@datatype'] === 'open store' ||
-          f['@datatype'] === 'temporary exhibition'
-        ) {
-          display.gallery = f.name[0].value;
-          filters.push('gallery/' + encodeURIComponent(f.name[0].value));
-        }
-        if (f['@datatype'] === 'site') {
-          display.museum = f.name[0].value;
-          filters.push('museum/' + encodeURIComponent(f.name[0].value));
-        }
-      });
-      display.link = '/search/' + this.formatLink(filters.join('/'));
-    }
+    if (!display.museum) return null;
 
-    return display.museum ? display : null;
+    display.link = '/search/' + this.formatLink(filters.join('/'));
+    return display;
   },
 
   // Collects on-display locations from the parent record and all direct child records.

--- a/test/transforms/get-display-location.test.js
+++ b/test/transforms/get-display-location.test.js
@@ -1,0 +1,127 @@
+const test = require('tape');
+const getValues = require('../../lib/transforms/get-values');
+const dir = __dirname.split('/')[__dirname.split('/').length - 1];
+const file = dir + __filename.replace(__dirname, '') + ' > ';
+
+// ---------------------------------------------------------------------------
+// getDisplayLocation() / getDisplayLocations() unit tests
+//
+// Reproduces the production `ciim` ES index shape that previously broke the
+// "On display" panel for ~22k object records: facility[0]['@hierarchy'] is a
+// nested array of bare {summary, @admin} objects with no @datatype tags, so
+// the legacy facility-walking implementation could never set display.museum.
+//
+// The current implementation reads `attributes.ondisplay`, which has a stable
+// flat [{type,value}] shape across both indexes.
+// ---------------------------------------------------------------------------
+
+// Mirrors a real ciim record (co499537 — Vickers Vimy biplane in Flight Gallery).
+function ciimShapedRecord () {
+  return {
+    attributes: {
+      ondisplay: [
+        { type: 'name', value: 'Science Museum, Flight Gallery', primary: true },
+        { type: 'gallery', value: 'Flight Gallery' },
+        { type: 'museum', value: 'Science Museum' }
+      ],
+      facility: [{
+        summary: { title: 'FS01' },
+        name: [
+          { type: 'name', value: 'Science Museum, Flight Gallery', primary: true },
+          { type: 'gallery', value: 'Flight Gallery' },
+          { type: 'museum', value: 'Science Museum' }
+        ],
+        // ciim shape: nested array of objects with only summary.title +
+        // @admin — no @datatype, no top-level name array.
+        '@hierarchy': [[
+          { summary: { title: 'Science Museum' }, '@admin': { id: 'facility-103' } },
+          { summary: { title: 'Third Floor' }, '@admin': { id: 'facility-168778' } },
+          { summary: { title: 'Flight Gallery' }, '@admin': { id: 'facility-170168' } },
+          { summary: { title: 'FS01' }, '@admin': { id: 'facility-170197' } }
+        ]],
+        '@entity': 'reference',
+        primary: true
+      }]
+    }
+  };
+}
+
+test(file + 'getDisplayLocation: ciim-shaped record returns museum + gallery + link', (t) => {
+  t.plan(4);
+  const result = getValues.getDisplayLocation(ciimShapedRecord());
+  t.equal(result.museum, 'Science Museum', 'museum populated from ondisplay');
+  t.equal(result.gallery, 'Flight Gallery', 'gallery populated from ondisplay');
+  t.equal(
+    result.link,
+    '/search/gallery/flight-gallery/museum/science-museum',
+    'link includes both gallery and museum filters'
+  );
+  t.notOk(
+    result.museum.includes('FS01') || result.gallery.includes('Third Floor'),
+    'no leakage from facility hierarchy levels'
+  );
+});
+
+test(file + 'getDisplayLocation: museum-name remap applied (National Media Museum)', (t) => {
+  t.plan(1);
+  const data = {
+    attributes: {
+      ondisplay: [
+        { type: 'gallery', value: 'Wonderlab' },
+        { type: 'museum', value: 'National Media Museum' }
+      ]
+    }
+  };
+  t.equal(
+    getValues.getDisplayLocation(data).museum,
+    'National Science and Media Museum',
+    'legacy museum name renamed for display'
+  );
+});
+
+test(file + 'getDisplayLocation: missing ondisplay returns null', (t) => {
+  t.plan(2);
+  t.equal(getValues.getDisplayLocation({ attributes: {} }), null, 'no ondisplay → null');
+  t.equal(
+    getValues.getDisplayLocation({ attributes: { ondisplay: [] } }),
+    null,
+    'empty ondisplay → null'
+  );
+});
+
+test(file + 'getDisplayLocation: ondisplay without museum entry returns null', (t) => {
+  t.plan(1);
+  // gallery alone shouldn't render a panel — display.museum is the gate
+  const data = { attributes: { ondisplay: [{ type: 'gallery', value: 'Foo' }] } };
+  t.equal(getValues.getDisplayLocation(data), null, 'no museum entry → null');
+});
+
+test(file + 'getDisplayLocations: aggregates parent + children, dedupes', (t) => {
+  t.plan(2);
+  // SPH/MPH parent with no ondisplay of its own (e.g. co30141), children carry it
+  const railwayChild = {
+    data: {
+      attributes: {
+        ondisplay: [
+          { type: 'gallery', value: 'Station Hall' },
+          { type: 'museum', value: 'National Railway Museum' }
+        ]
+      }
+    }
+  };
+  const data = {
+    attributes: {},
+    children: [
+      { data: ciimShapedRecord() },
+      { data: ciimShapedRecord() },
+      railwayChild
+    ]
+  };
+  const result = getValues.getDisplayLocations(data);
+  t.equal(result.length, 2, 'two distinct museum/gallery pairs after dedupe');
+  t.deepEqual(
+    result.map(l => `${l.museum} / ${l.gallery}`).sort(),
+    ['National Railway Museum / Station Hall', 'Science Museum / Flight Gallery'],
+    'correct museum/gallery pairs'
+  );
+});


### PR DESCRIPTION
## Summary

The "On display" sidebar panel is hidden for ~22k object records on production. Two examples flagged: [co499537](https://collection.sciencemuseumgroup.org.uk/objects/co499537/alcock-and-browns-vickers-vimy-biplane) and [co224464](https://collection.sciencemuseumgroup.org.uk/objects/co224464/railway-collecting-dog-laddie). Same root cause for the whole set.

### Why it broke

`getDisplayLocation()` walks `attributes.facility[0]['@hierarchy']` looking for entries tagged `@datatype: 'site'` (museum) and `@datatype: 'permanent gallery' / 'open store' / 'temporary exhibition'` (gallery).

- **Local `test` ES index**: `@hierarchy` is a flat array with `@datatype` tags — the walk works.
- **Production `ciim` ES index**: `@hierarchy` is a **nested array of arrays** with only `summary.title` + `@admin` on inner items, **no `@datatype` tags anywhere**. The walk matches nothing, `display.museum` never gets set, function returns `null`, `{{#if displayLocation}}` is false, panel hidden.

Local dev pointed at `test` (`.corc` override), so the bug was invisible during development.

### Fix

Read from `attributes.ondisplay` instead. Confirmed via direct ES queries against `ciim`:

| Field | Object records |
|---|---|
| Has `facility` | 22,059 |
| Has `ondisplay` | 22,059 |
| Has both | 22,059 (1:1) |
| Has neither | — |
| Has legacy `location` | 0 |

Every `ondisplay` array in `ciim` contains `museum`, `gallery`, AND `name` type entries. Switching `getDisplayLocation` to read this field is correct on both indexes and loses zero records.

End-to-end traced against live `ciim`:
- `co499537` → `Science Museum / Flight Gallery` ✅
- `co224464` → `National Railway Museum / Station Hall` ✅
- `co30141` (MPH parent, aggregates from children) → `Science Museum / Flight Gallery` ✅

### Also tidied

- Dropped the legacy `attributes.location.0.name` branch from `getDisplayLocation` (0 records use it).
- Dropped the dead `location.name.value.lower` OR clause from `buildLocationFilter` in [lib/facets/create-filters.js](https://github.com/TheScienceMuseum/collectionsonline/blob/master/lib/facets/create-filters.js).
- Added a note explaining that `facility.name.value.lower` is still the filter target while facets aggregate on `ondisplay.value.keyword` — pointer for a future cleanup that aligns both onto `ondisplay` (would need `term` + `case_insensitive: true` since `ondisplay.value` has no `.lower` subfield).

### Worth flagging to the data team

The `@hierarchy` shape change in `ciim` lost the `@datatype` tags ('site', 'permanent gallery', 'floor', 'free standing', etc.). The hierarchy positions are still ordered Museum → Floor → Gallery → Cabinet, but with no type tags they can't be reliably used for hierarchical breadcrumbs. Worth restoring those tags if we want to build that feature.

### Local dev

Recommend pointing your `.corc` `elasticIndex` at `ciim` (the default) instead of `test` to catch this class of index-shape bug locally going forward.

## Test plan

- [x] `npm run test:unit:tape` — full suite passes (888/890; the 2 failing pre-exist on master, unrelated to this change — search-results-to-jsonapi `large_thumbnail` undefined, multimedia issue)
- [x] New `test/transforms/get-display-location.test.js` — 10/10 pass, including a fixture mirroring the `ciim` `@hierarchy` shape to lock in the regression
- [x] End-to-end traced against live `ciim` for `co499537`, `co224464`, `co30141`
- [x] Verified `buildLocationFilter` no longer emits `location.name.value.lower`; behaviour unchanged for `facility.name.value.lower` (598 records match "Station Hall" on both old and new code)
- [ ] Spot-check a few on-display object pages locally with `.corc` pointing at `ciim`