### PR TITLE
Show title text on imageless related, part and group cards

### DIFF
--- a/client/styles/components/_record.scss
+++ b/client/styles/components/_record.scss
@@ -315,6 +315,58 @@
   .column {
     @include flexcards-item;
   }
+
+  // mobile-only compact list of imageless related items, rendered alongside
+  // the card grid in markup; CSS chooses which to show per breakpoint.
+  &__mobile-list {
+    display: none;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+
+    li {
+      display: flex;
+      gap: 0.5rem;
+      align-items: baseline;
+      padding: 0.5rem 0;
+      border-top: 1px solid rgba(white, 0.15);
+
+      &:last-child {
+        border-bottom: 1px solid rgba(white, 0.15);
+      }
+    }
+
+    a {
+      color: white;
+      text-decoration: underline;
+    }
+
+    .icon {
+      flex-shrink: 0;
+      color: rgba(white, 0.5);
+      align-self: center;
+    }
+  }
+
+  @include media("<small") {
+    // hide imageless related cards (the "see more" tile uses an SVG icon
+    // not an <img>, so we exclude it explicitly)
+    .resultcard--related:not(.resultcard--seemore):not(:has(img)) {
+      display: none;
+    }
+
+    // and surface the text list in their place
+    &__mobile-list:not(:empty) {
+      display: block;
+      margin-top: 1rem;
+    }
+
+    // when every related item is imageless the card grid collapses to nothing
+    // visible — drop its top margin so the list isn't floating in space
+    .o-grid:not(:has(img)) {
+      display: none;
+    }
+  }
 }
 
 .see-more {

--- a/client/styles/components/_resultcard.scss
+++ b/client/styles/components/_resultcard.scss
@@ -216,6 +216,35 @@
     }
   }
 
+  // related and part-of grids stack single-column on mobile so the tile is twice
+  // as wide as the 2-up search-results grid — bump the figcaption to fill it.
+  // Above the small breakpoint the grid kicks in (3-6 cols / auto-fit min-16rem)
+  // and the tile shrinks below search-results size, so scale the figcaption down.
+  &--related,
+  &.mph-records__resultcard,
+  &--group {
+    .resultcard__figure figcaption {
+      font-size: clamp-between(2rem, 3rem);
+
+      @include media(">=small") {
+        font-size: clamp-between(0.875rem, 1.125rem);
+        letter-spacing: 0;
+      }
+    }
+  }
+
+  // Mobile-only: collapse imageless part-cards (MPH/group/SPH) to text-only.
+  // The gradient placeholder exists to keep multi-column grids aligned; on a
+  // single-column layout it just wastes space, so hide the figure entirely
+  // and let the title + creation date sit on their own.
+  @include media("<small") {
+    &.mph-records__resultcard:not(:has(img)) .resultcard__figure,
+    &--group:not(:has(img)) .resultcard__figure,
+    .sph-records__grid &:not(:has(img)) .resultcard__figure {
+      display: none;
+    }
+  }
+
   &--dark {
     @include reversed;
   }

--- a/lib/sort-related-items.js
+++ b/lib/sort-related-items.js
@@ -22,11 +22,17 @@ module.exports = (related, id) => {
         el,
         '_source.multimedia.0.@processed.large_thumbnail.location'
       );
+      const summaryTitle = el._source.summary.title;
+      const description = getPrimaryValue(el._source.description);
+      const title = getPrimaryValue(el._source.title);
       const item = {
         id: TypeMapping.toExternal(el._id),
         type: TypeMapping.toExternal(el._source['@datatype'].base),
         attributes: {
-          summary_title: el._source.summary.title,
+          summary_title: summaryTitle,
+          // longer text used as figcaption when no image is available, mirroring
+          // the search-results card behaviour (description → title → summary_title)
+          figcaption: description || title || summaryTitle,
           level: getNestedProperty(el, '_source.level.value'),
           identifier: getPrimaryValue(el._source.identifier),
           figure: figure ? config.mediaPath + figure : null

--- a/lib/transforms/json-to-html-data.js
+++ b/lib/transforms/json-to-html-data.js
@@ -991,12 +991,18 @@ function getChildRecords (
       );
     }
 
+    const figcaption =
+      description?.primary?.initialDescription?.[0] ||
+      description?.web?.initialDescription?.[0] ||
+      title;
+
     const result = {
       uid,
       record,
       // groupingType,
       description,
       title,
+      figcaption,
       details,
       // details: groupingType === 'SPH' ? details : null,
       images,

--- a/templates/partials/records/record-mgroup-records.html
+++ b/templates/partials/records/record-mgroup-records.html
@@ -10,8 +10,8 @@
         <img src="{{firstImage images 0 'card' }}" class="" alt="{{title}}" />
         {{else}}
         <figcaption role="presentation">
-          {{! > global/icon "object" }}{{!-- Usually we show icon for the record type, but don't have that data. --}}
-          {{ this.title }}{{!-- Usually custom figcaption is supplied --}}
+          {{> global/icon i="objects" }}
+          {{ this.figcaption }}
         </figcaption>
         {{/if }}
       </figure>

--- a/templates/partials/records/record-mph-records.html
+++ b/templates/partials/records/record-mph-records.html
@@ -13,6 +13,11 @@
           {{else}}
           <img src="{{firstImage images 0 'card' }}" class="" alt="{{title}}" />
           {{/if }}
+          {{else}}
+          <figcaption role="presentation">
+            {{> global/icon i="objects" }}
+            {{ figcaption }}
+          </figcaption>
           {{/if }}
 
         </figure>

--- a/templates/partials/records/record-related-documents.html
+++ b/templates/partials/records/record-related-documents.html
@@ -7,7 +7,14 @@
       <a href="{{link}}" aria-label="{{this.attributes.summary_title}}">
         <article class="resultcard resultcard--related {{#if type}}resultcard--{{ this.type }}{{/if}}">
           <figure class="resultcard__figure">
-            {{#if this.attributes.figure}}<img src="{{ this.attributes.figure }}" alt="" /> {{/if}}
+            {{#if this.attributes.figure}}
+            <img src="{{ this.attributes.figure }}" alt="" />
+            {{else}}
+            <figcaption role="presentation">
+              {{> global/icon i=this.type }}
+              {{ this.attributes.figcaption }}
+            </figcaption>
+            {{/if}}
           </figure>
           <div class="resultcard__info">
             <h3 class="resultcard__title">{{this.attributes.summary_title}}</h3>
@@ -30,5 +37,19 @@
 
       {{/seemore}}
     </div>
+
+    {{!-- mobile-only fallback: imageless items render as a compact text list --}}
+    <ul class="record-related__mobile-list">
+      {{#each related.documents}}
+      {{#formatrelated ../related.documents @index this}}
+      {{#unless this.attributes.figure}}
+      <li>
+        {{> global/icon i=this.type }}
+        <a href="{{link}}">{{this.attributes.summary_title}}</a>
+      </li>
+      {{/unless}}
+      {{/formatrelated}}
+      {{/each}}
+    </ul>
   </div>
 </section>

--- a/templates/partials/records/record-related-objects.html
+++ b/templates/partials/records/record-related-objects.html
@@ -7,7 +7,14 @@
       <a href="{{link}}" aria-label="{{this.attributes.summary_title}}">
         <article class="resultcard resultcard--related {{#if type}}resultcard--{{ this.type }}{{/if}}">
           <figure class="resultcard__figure">
-            {{#if this.attributes.figure}}<img src="{{ this.attributes.figure }}" alt="" /> {{/if}}
+            {{#if this.attributes.figure}}
+            <img src="{{ this.attributes.figure }}" alt="" />
+            {{else}}
+            <figcaption role="presentation">
+              {{> global/icon i=this.type }}
+              {{ this.attributes.figcaption }}
+            </figcaption>
+            {{/if}}
           </figure>
           <div class="resultcard__info">
             <h3 class="resultcard__title">{{this.attributes.summary_title}}</h3>
@@ -37,5 +44,21 @@
         {{/seemore}}
         {{/isequal}}
     </div>
+
+    {{!-- mobile-only fallback: imageless items render as a compact text list
+         (CSS hides this list on desktop and hides imageless cards on mobile,
+         so each item appears in exactly one place per breakpoint) --}}
+    <ul class="record-related__mobile-list">
+      {{#each related.objects}}
+      {{#formatrelated ../related.objects @index this}}
+      {{#unless this.attributes.figure}}
+      <li>
+        {{> global/icon i=this.type }}
+        <a href="{{link}}">{{this.attributes.summary_title}}</a>
+      </li>
+      {{/unless}}
+      {{/formatrelated}}
+      {{/each}}
+    </ul>
   </div>
 </section>

--- a/templates/partials/records/record-sph-images.html
+++ b/templates/partials/records/record-sph-images.html
@@ -19,6 +19,9 @@
 {{/if}}
 {{ else }}
 <figure class="resultcard__figure">
-  <figcaption>{{title}}</figcaption>
+  <figcaption role="presentation">
+    {{> global/icon i="objects" }}
+    {{ figcaption }}
+  </figcaption>
 </figure>
 {{/if }}


### PR DESCRIPTION
## Summary

Search-result cards already overlay the title on the gradient placeholder when there's no image, but the related-items, MPH part, group and SPH grids were rendering empty placeholders. This PR brings them in line and adds mobile-specific layout tweaks where the placeholder didn't earn its space.

### Imageless cards now show a figcaption (icon + text)

- Related-objects, related-documents, MPH part, group and SPH cards render the cube icon and descriptive text on the gradient placeholder when no image is available.
- Text follows the search-results fallback chain (`description` → `title` → `summary_title`), precomputed server-side in `sort-related-items.js` and `json-to-html-data.js` so templates stay simple.
- Figcaption font scales down for the smaller related-grid tiles at `>=small` and stays larger on mobile single-column layouts.

### Mobile-only layout tweaks (`<small`, single-column)

- **Part records (MPH/group/SPH):** imageless cards collapse — the figure is hidden so the title + creation date sit on their own.
- **Related items:** section now renders a mobile-only `<ul>` of imageless entries.
  - Mix of with/without images → image cards as cards, imageless entries listed below.
  - All imageless → card grid hides, just the text list shows.
  - Desktop unchanged.

## Test plan

- [ ] Object detail page with imageless related items (e.g. `/objects/co8557600/...`):
  - Mobile: confirm `RELATED OBJECTS` appears as a compact text list.
  - Desktop: confirm grid of placeholder cards with cube icon + description text.
- [ ] MPH parent record (e.g. `/objects/co533313`):
  - Mobile: confirm imageless part cards collapse to title + date; imaged cards keep their image.
  - Desktop: confirm gradient placeholders still render for grid alignment.
- [ ] SPH parent record (e.g. `/objects/co8364603/...`):
  - Mobile: confirm imageless SPH cards collapse cleanly.
  - Desktop: unchanged.
- [ ] Search results page: confirm card rendering is identical to before.