### PR TITLE
Fix 503 on /search/group when a child record lacks a processed thumbnail

### DIFF
--- a/lib/transforms/search-results-to-jsonapi.js
+++ b/lib/transforms/search-results-to-jsonapi.js
@@ -266,17 +266,72 @@ const createResource = {
           attrs[key][0]['@processed'].large_thumbnail.location =
             mediaPath + sortedImages[0]['@processed'].large_thumbnail.location;
         }
-        // Adds image host to child records
-        if (key === 'child' && hit._source.child) {
-          Array.isArray(
-            hit._source.child.forEach((child) => {
-              if (child.multimedia) {
-                child.multimedia['@processed'].large_thumbnail.location =
-                  mediaPath +
-                  child.multimedia?.['@processed'].large_thumbnail.location;
-              }
-            })
-          );
+        // Adds image host to child records. Children come from related
+        // collection items on a group record; not all of them have a
+        // processed thumbnail (archive documents without images,
+        // multimedia mid-processing, etc.) so we guard each step of the
+        // path before mutating. Earlier code used a half-applied
+        // optional chain on the RHS only, which still crashed because
+        // the LHS evaluates `child.multimedia['@processed'].large_thumbnail`
+        // before the assignment — for any child missing @processed it
+        // threw "Cannot read properties of undefined (reading
+        // 'large_thumbnail')" and surfaced as a misleading 503 from
+        // the search route. The outer Array.isArray(...forEach()) was
+        // dead — forEach returns undefined, Array.isArray(undefined)
+        // is just discarded.
+        // Prepend mediaPath to child-record thumbnail locations on
+        // group results. Within a single group hit, `child.multimedia`
+        // varies *per child*. The common shape is a single fully-
+        // resolved multimedia object with `@processed.large_thumbnail.
+        // location`. The previous implementation assumed every child
+        // with a `multimedia` field matched that shape and mutated
+        // the deep path directly. In real ES data some children carry
+        // a different shape that crashed the deep mutation: an array
+        // of `@entity: "reference"` stubs with only `@admin`/`uuid`
+        // and no `@processed` block. Investigation showed these stubs
+        // are stale denormalised references — for example the group
+        // `c81835.child[4]` (object `co8056866`) carried 37 such
+        // stubs pointing at media-XXX records, but the standalone
+        // `co8056866` record has no multimedia at all and the media
+        // records the stubs point at don't exist in ES either. Same
+        // for `c81734.child[6/8]` (objects co8868118, co8838270).
+        // The group document's denormalised `child` snapshot retained
+        // references that have since been removed from both the
+        // source objects and the media index. There's nothing to
+        // resolve them to. The stubs should be ignored, not rendered.
+        //
+        // The previous code's deep-path mutation threw "Cannot read
+        // properties of undefined (reading 'large_thumbnail')" on
+        // the stub-array shape, which the search route surfaced as
+        // a misleading 503 from `/search/group`. The half-applied
+        // optional chain on the RHS didn't help — the LHS evaluated
+        // first. The outer `Array.isArray(forEach(...))` wrapper was
+        // dead — forEach returns undefined and the wrapper was a
+        // no-op.
+        //
+        // The multimedia-shape duality (single object vs array) is
+        // documented-by-convention elsewhere: `lib/helpers/get-image-
+        // caption.js`, `lib/name-collections.js`, `lib/anniversary.js`
+        // all normalise with `Array.isArray(m) ? m : [m]`. This
+        // transform was the only place not following that convention.
+        //
+        // Fix: normalise to an array, iterate, and prepend mediaPath
+        // only on entries that actually carry the full processed-
+        // thumbnail path. Stub/orphan references are left untouched —
+        // nothing to render. (If CIIM ever stops emitting these stale
+        // snapshots, this code keeps working unchanged.)
+        if (key === 'child' && Array.isArray(hit._source.child)) {
+          hit._source.child.forEach((child) => {
+            if (!child || !child.multimedia) return;
+            const entries = Array.isArray(child.multimedia) ? child.multimedia : [child.multimedia];
+            entries.forEach((entry) => {
+              const loc = entry &&
+                entry['@processed'] &&
+                entry['@processed'].large_thumbnail &&
+                entry['@processed'].large_thumbnail.location;
+              if (loc) entry['@processed'].large_thumbnail.location = mediaPath + loc;
+            });
+          });
         }
       }
       return attrs;


### PR DESCRIPTION
## Summary
`/search/group` returned a misleading **503 *Search service unavailable*** when a result group contained at least one child record whose `multimedia` field was in the array-of-reference-stubs shape. Investigation showed those stubs are **stale denormalised references** in the group document's `child[]` snapshot — not legitimate deferred-resolution pointers.

## Two code paths, only one affected
For clarity, the two routes that show "group data" use different data sources, and only one is affected by this bug:

| Route | Source | Affected? |
|---|---|---|
| `/group/{id}` (a.k.a. `/api/group/{id}`) | `lib/get-child-records.js` does a fresh ES search for records whose `grouping.@admin.uid` = the group's uid, returning current standalone object records | **No** — bypasses the denormalised snapshot |
| `/search/group?...` (the search-results listing) | `lib/transforms/search-results-to-jsonapi.js` reads each group hit's denormalised `child[]` field from the group document itself | **Yes** — this is where the crash happened |

The `/group/{id}` page already shows reality because it does a live join against current data. The bug only ever affected the search-results listing page.

## What I observed
Direct ES lookups confirmed the stub shape on `/search/group` doesn't reflect reality on the source records or the media index:

```
c81835.child[4]  (co8056866 "histological slides"):
  group document's snapshot — 37 reference stubs to media-XXX records
  standalone co8056866       — multimedia field absent (no images)
  media-17937 etc.           — no such records exist in ES

c81734.child[6]  (co8868118 "alchometer used to produce sanitiser"):
  group document's snapshot — 6 reference stubs
  standalone co8868118       — multimedia field absent

c81734.child[8]  (co8838270 "#CareHomeAlbumCovers 2021 calendar"):
  group document's snapshot — 5 reference stubs
  standalone co8838270       — multimedia field absent
```

The group documents' denormalised `child[]` arrays retained references that have since been removed from both the source object records and the media index. There's nothing for our code to render or resolve to — these stubs should be ignored. This stale-snapshot phenomenon is a CIIM data-hygiene issue (group documents not being re-indexed when member objects' media references change); raising it upstream would be the proper long-term fix. This PR just stops the crash that the previous code did on encountering the shape.

The fixture (`test/fixtures/elastic-responses/example-get-response-group.json`) captured only the resolved-shape children of `c81734`, which is why fixture-driven tests passed; real ES exposes the mixed shapes and triggers the crash.

## What was broken
The previous transform tried to mutate `child.multimedia['@processed'].large_thumbnail.location` directly, assuming the single-object-with-processed shape unconditionally. When a child had the stale stub-array shape, the LHS evaluated the deep path first, threw `Cannot read properties of undefined (reading 'large_thumbnail')`, and the search route surfaced the TypeError as a misleading 503.

The half-applied optional chain on the RHS didn't help (LHS evaluated first). The outer `Array.isArray(...forEach(...))` wrapper was dead code — `forEach` returns undefined; the wrapper was a no-op.

The multimedia-shape duality (single object vs array) is documented-by-convention elsewhere in the codebase — `lib/helpers/get-image-caption.js`, `lib/name-collections.js`, `lib/anniversary.js` all normalise with `Array.isArray(m) ? m : [m]`. This transform was the only place not following that convention.

## Fix
- Normalise `child.multimedia` to an array, matching the existing codebase convention.
- Iterate entries; prepend `mediaPath` only on entries that carry the full `@processed.large_thumbnail.location` path. Stale-reference stubs are left untouched — nothing to render.
- Replace the dead `Array.isArray(forEach(...))` wrapper with a proper `Array.isArray(hit._source.child)` outer guard.

## Test plan
- [x] `test/search-group-filters.test.js > Should accept params in filter[PARAMS_NAME] format for group type` — was failing with 503, now 200.
- [x] `test/search-params.test.js > Should accept the param groups` — was failing with 503, now 200.
- [x] Full unit suite passes (1150/1150).
- [x] Semistandard lint clean.
- [ ] Smoke-check `/search/group` on staging to confirm rendered HTML page works end-to-end with the real ES dataset.

## Follow-up (out of scope)
CIIM stale-snapshot issue — group documents' `child` arrays retain media references that have been removed from source object/media records. Should be raised upstream so groups get re-indexed when their member objects' media change. Until then, the defensive fix in this PR ensures we never crash on the stale shape; we just don't render thumbnails that don't exist.