### PR TITLE
Fix Topics tab count always showing 0 on every other tab

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -74,11 +74,21 @@ module.exports = async (elastic, queryParams) => {
       function_score: {
         query: {
           bool: {
+            // Include all four types in the search space so per-type
+            // aggregations (the Topics tab count, in particular) see a
+            // complete document set. Tab-specific hit exclusion happens
+            // at post_filter time via createFiltersAll /
+            // createFilters(...) for each type; this filter only scopes
+            // the search space itself.
+            // Prior to this, the search space here excluded 'group'
+            // unless queryParams.type === 'group', which had the
+            // intended effect on hits but the unintended side-effect
+            // of making the Topics tab count permanently 0 on every
+            // other tab (the categories aggregation operates inside
+            // this filter).
             filter: {
               terms: {
-                '@datatype.base': queryParams.type === 'group'
-                  ? ['agent', 'archive', 'object', 'group']
-                  : ['agent', 'archive', 'object']
+                '@datatype.base': ['agent', 'archive', 'object', 'group']
               }
             },
             // Require at least one should clause to match. Without this, documents that
@@ -350,11 +360,14 @@ module.exports = async (elastic, queryParams) => {
     };
   }
 
-  const baseTypes = queryParams.type === 'group'
-    ? ['agent', 'archive', 'object', 'group']
-    : ['agent', 'archive', 'object'];
+  // filtersType wraps the categories aggregation in
+  // `aggs-total-categories.js` — it's the outer filter applied to
+  // total_categories. Include all four types so each per-type
+  // sub-aggregation can count its documents. Hit exclusion per tab
+  // remains controlled by post_filter (createFiltersAll for "all",
+  // createFilters(_, type) for specific tabs).
   const filtersType = [
-    { terms: { '@datatype.base': baseTypes } }
+    { terms: { '@datatype.base': ['agent', 'archive', 'object', 'group'] } }
   ];
 
   const filtersPeople = createFilters(queryParams, 'agent');


### PR DESCRIPTION
## Summary
The Topics tab in the search nav (`templates/partials/global/search-nav.html` lines 28-34, rendered conditionally on `!inProduction`) shows `meta.count.type.group` next to its label. On every tab *other* than Topics itself, this count was always **0** — even though there are group records in the index (5 right now: 1983-7572 Parts, Sound and Vision Galleries, Hawking Building Freestanding Grid, plus two TEST records).

## Root cause
Commit `c75e59e4` ("fix: exclude mgroup records from non-Topics search tabs and clean up organisation filter") added a type-conditional exclusion of `@datatype.base: group` to the top-level `bool.filter` of the ES search query. That filter scopes **both** the returned hits *and* the categories aggregation. The intended effect — keeping groups out of All / People / Objects / Documents hit lists — worked. The unintended side-effect — making the categories aggregation operate over a document set with groups already excluded — meant `total_categories.group.group_total.value` was always 0 when the user wasn't already on the Topics tab.

The same conditional was duplicated at `lib/search.js:363-365` for `filtersType`, which wraps `aggregationTotalCategories` in `aggs-total-categories.js`. Same problem in the aggregation wrapper.

## Fix
Include all four types unconditionally in the search-space filter and the aggregation wrapper. Hit exclusion per tab is already done at post_filter time:

- `/search/all` uses `createFiltersAll` → `selectedFiltersCategories` defaults to `['agent', 'object', 'archive']` (no group) when no group-specific filters are present
- `/search/people`, `/search/objects`, `/search/documents` use `createFilters(_, type)` which restricts hits to that type
- `/search/group` uses `createFilters(_, 'group')` which restricts hits to group

So the post_filter pipeline already does the correct per-tab hit filtering. The top-level `bool.filter` doesn't need to enforce it a second time — and was doing harm by also scoping the aggregation.

## What changes for users
- Topics tab count now shows the actual count (5) on every tab, so the tab is discoverable.
- All / People / Objects / Documents hit lists: unchanged (groups still excluded from hits via `createFiltersAll`).
- Topics tab itself: unchanged.

## Test plan
- [x] Direct ES aggregation query under the new filter scope returns 5 groups (matches `terms: '@datatype.base': 'group'` count of 5 in the index).
- [x] Full unit suite passes when applied alongside the pending multimedia-shape fix (PR #2148). The two fixes are independent — this PR's change doesn't depend on #2148, and #2148 doesn't depend on this. Master's existing 2 pre-existing test failures (`search-group-filters`, `search-params` "Should accept the param groups") are caused by #2148's bug, not this PR's; they go away when #2148 lands.
- [x] Semistandard lint clean.
- [ ] Smoke check on dev: visit `/search?q=` and confirm the Topics tab shows "5" instead of "0".