### PR TITLE
Revert #2152: restore IIIF SPA route + api.html

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -12,6 +12,7 @@ require('./routes/person')(page);
 require('./routes/group')(page);
 require('./routes/document')(page);
 require('./routes/museums')(page);
+require('./routes/iiif')(page);
 require('./routes/embed')(page);
 
 // Anniversary widget analytics tracking

--- a/client/routes/iiif.js
+++ b/client/routes/iiif.js
@@ -1,0 +1,30 @@
+const Snackbar = require('snackbarlightjs');
+const Templates = require('../templates');
+const getData = require('../lib/get-data.js');
+
+module.exports = function (page) {
+  page('/iiif/:type/:id', load, render);
+
+  function load (ctx, next) {
+    const opts = {
+      headers: { Accept: 'application/vnd.api+json' }
+    };
+    const type = ctx.params.type;
+    const id = ctx.params.id;
+    const url = '/iiif/' + type + '/' + id;
+    getData(url, opts, function (err, json) {
+      if (err) {
+        console.error(err);
+        Snackbar.create('Error getting data from the server');
+        return;
+      }
+      ctx.json = JSON.stringify(json, null, 2);
+      next();
+    });
+  }
+
+  function render (ctx, next) {
+    const pageEl = document.getElementById('main-page');
+    pageEl.innerHTML = Templates.api({ api: ctx.json });
+  }
+};

--- a/client/templates.js
+++ b/client/templates.js
@@ -589,6 +589,9 @@ module.exports = {
   'search-main': Handlebars.compile(
     Fs.readFileSync('./templates/partials/global/search-main.html', 'utf8')
   ),
+  api: Handlebars.compile(
+    Fs.readFileSync('./templates/pages/api.html', 'utf8')
+  ),
   articles: Handlebars.compile(
     Fs.readFileSync(
       './templates/partials/records/record-related-articles.html',

--- a/templates/pages/api.html
+++ b/templates/pages/api.html
@@ -1,0 +1,7 @@
+<div id="main-page">
+  <div class="results-api">
+    <pre>
+      {{api}}
+    </pre>
+  </div>
+</div>

--- a/templates/partials/records/panel-cite.html
+++ b/templates/partials/records/panel-cite.html
@@ -41,7 +41,7 @@
   </a></p>
 
   <p>Download <a href="http://iiif.io"><img src="/assets/img/global/IIIF-logo-colored-text.svg" width="16" height="16"
-        alt="IIIF"></a> manifest <a href="{{links.iiif}}" rel="nofollow" download="{{uid}}-iiif-manifest.json">IIIF</a></p>
+        alt="IIIF"></a> manifest <a href="{{links.iiif}}" rel="nofollow">IIIF</a></p>
 
   <small>
     Our records are constantly being enhanced and improved, but please note that we cannot guarantee the accuracy of any


### PR DESCRIPTION
## Summary

Reverts #2152.

The CloudFront `/api/*` rule (Accept-forwarding) had already fixed the original `SyntaxError` end-to-end. #2152 (and #2151) were app-layer fixes for the same problem that, in retrospect, added unnecessary code surface and changed user-facing behaviour we'd rather keep:

- #2152 turned the "Download IIIF manifest" link into a file download via the `download` attribute, instead of letting the SPA render it inline in a `<pre>` (the previous in-browser viewing experience).
- It also deleted `templates/pages/api.html` and `Templates.api`, which are needed once #2151 is also reverted (next PR).

This revert restores the IIIF SPA route, the IIIF link's original markup, and the shared `Templates.api` / `api.html` view used by the SPA.

## Order of operations

This PR should land first, then PR #(TBD) reverts #2151. Reverting in this order keeps `master` in a consistent state at each step:

1. **This PR** — restore `Templates.api`, `api.html`, IIIF SPA route. After merge: master matches the post-#2151 state (i.e. `/api/...` still always-JSON, but IIIF behaves as it always did).
2. **Next PR** — revert #2151 → restore Accept-negotiation on `/api/{type}/{id}` and the JSON SPA route. After merge: master is identical to the pre-#2151 state, GTM tracking on `/api/...` is back, and the CloudFront rule continues to prevent the original `SyntaxError`.

## Test plan

- [x] `tape test/routes.test.js` — 91 tests pass (back to pre-#2152 count).
- [x] `npm run test:lint` — clean.
- [ ] On staging: visit a record page → "Download IIIF manifest IIIF" link clicks into the SPA-rendered `<pre>` view (no file download).
- [ ] On staging: load `/iiif/objects/X` directly → browser displays JSON natively.

## Why revert instead of forward-fix

The CloudFront rule is the actual fix for the underlying bug. App changes here were chasing a symptom, and each attempted refinement traded one behaviour we wanted (GTM tracking, in-browser IIIF viewing) for a different one. Reverting is the smallest, clearest path back to a working baseline.