### PR TITLE
Revert #2151: restore Accept-negotiated /api/{type}/{id} + JSON SPA route

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -12,6 +12,7 @@ require('./routes/person')(page);
 require('./routes/group')(page);
 require('./routes/document')(page);
 require('./routes/museums')(page);
+require('./routes/api')(page);
 require('./routes/iiif')(page);
 require('./routes/embed')(page);
 

--- a/client/routes/api.js
+++ b/client/routes/api.js
@@ -1,0 +1,30 @@
+const Snackbar = require('snackbarlightjs');
+const Templates = require('../templates');
+const getData = require('../lib/get-data.js');
+
+module.exports = function (page) {
+  page('/api/:type/:id', load, render);
+
+  function load (ctx, next) {
+    const opts = {
+      headers: { Accept: 'application/vnd.api+json' }
+    };
+    const type = ctx.params.type;
+    const id = ctx.params.id;
+    const url = '/api/' + type + '/' + id + '?ajax=true';
+    getData(url, opts, function (err, json) {
+      if (err) {
+        console.error(err);
+        Snackbar.create('Error getting data from the server');
+        return;
+      }
+      ctx.json = JSON.stringify(json, null, 2);
+      next();
+    });
+  }
+
+  function render (ctx, next) {
+    const pageEl = document.getElementById('main-page');
+    pageEl.innerHTML = Templates.api({ api: ctx.json });
+  }
+};

--- a/routes/api.js
+++ b/routes/api.js
@@ -6,6 +6,16 @@ const contentType = require('./route-helpers/content-type.js');
 const cacheHeaders = require('./route-helpers/cache-control');
 const getChildRecords = require('../lib/get-child-records.js');
 
+// NOTE: This route negotiates response shape via the Accept header
+// (HTML wrapper for browsers — which fires GTM pageview tracking — vs
+// JSON for `Accept: application/vnd.api+json` clients). This relies on
+// CloudFront's `/api/*` behaviour forwarding the Accept header to
+// origin (origin request policy: Managed-AllViewer or equivalent).
+// Without that, CloudFront strips Accept, every request looks like a
+// browser hit, and the client SPA route's JSON fetch receives HTML —
+// causing `JSON.parse('<...')` to throw `SyntaxError: Unrecognized
+// token '<'` on the "Download catalogue entry as JSON" link.
+// See PRs #2151 / #2153 / #2154 for history.
 module.exports = (elastic, config) => ({
   method: 'GET',
   path: '/api/{type}/{id}/{slug?}',

--- a/routes/api.js
+++ b/routes/api.js
@@ -2,6 +2,7 @@ const Boom = require('@hapi/boom');
 const buildJSONResponse = require('../lib/jsonapi-response');
 const TypeMapping = require('../lib/type-mapping');
 const beautify = require('json-beautify');
+const contentType = require('./route-helpers/content-type.js');
 const cacheHeaders = require('./route-helpers/cache-control');
 const getChildRecords = require('../lib/get-child-records.js');
 
@@ -17,6 +18,7 @@ module.exports = (elastic, config) => ({
           id: TypeMapping.toInternal(request.params.id)
         });
 
+        const responseType = contentType(request);
         const { grouping } = result.body._source['@datatype'];
 
         let childRecords = [];
@@ -41,9 +43,13 @@ module.exports = (elastic, config) => ({
           ), null, 2, 80
         );
 
-        return h
-          .response(apiData)
-          .header('content-type', 'application/vnd.api+json');
+        if (responseType === 'json') {
+          return h
+            .response(apiData)
+            .header('content-type', 'application/vnd.api+json');
+        } else {
+          return h.view('api', { api: apiData });
+        }
       } catch (err) {
         if (err.statusCode === 404) {
           return Boom.notFound();

--- a/templates/partials/records/panel-cite.html
+++ b/templates/partials/records/panel-cite.html
@@ -32,7 +32,7 @@
 
   <h2>Download</h2>
 
-  <p>Download catalogue entry as <a href="{{links.api}}" rel="nofollow" download="{{uid}}.json"><abbr
+  <p>Download catalogue entry as <a href="{{links.api}}" rel="nofollow"><abbr
         title="Javascript Object Notation">json</abbr></a></p>
 
   <!--<p>View <a href="http://iiif.io"><img src="/assets/img/global/IIIF-logo-colored-text.svg" width="16" height="16" style="padding-bottom:4px" alt="IIIF"></a> manifest <a href="http://universalviewer.io/uv.html?manifest={{links.iiif}}" rel="nofollow">in IIIF viewer</a></p>-->

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -726,8 +726,8 @@ testWithServer(
   }
 );
 
-testWithServer('Specific api endpoint always returns JSON', {}, async (t, ctx) => {
-  t.plan(3);
+testWithServer('Specific api endpoint, html response', {}, async (t, ctx) => {
+  t.plan(2);
 
   const htmlRequest = {
     method: 'GET',
@@ -737,9 +737,7 @@ testWithServer('Specific api endpoint always returns JSON', {}, async (t, ctx) =
 
   const res = await ctx.server.inject(htmlRequest);
   t.ok(res.statusCode, 200, 'status is 200');
-  t.ok(res.headers['content-type'].indexOf('application/vnd.api+json') > -1, 'json response regardless of Accept');
-  const result = JSON.parse(res.payload);
-  t.ok(result.data, 'payload parses as JSON');
+  t.ok(res.headers['content-type'].indexOf('text/html') > -1, 'html response');
   await ctx.server.stop();
   t.end();
 });


### PR DESCRIPTION
## Summary

Reverts #2151. **Stacked on top of #2153** (which reverts #2152) — merge that first, then change this PR's base to `master`.

The original `SyntaxError: Unrecognized token '<'` on the "Download catalogue entry as JSON" link was caused by CloudFront not forwarding the `Accept` header to origin, so the SPA's `fetch(...,{Accept:'application/vnd.api+json'})` got the cached HTML response back and `JSON.parse('<…')` threw. **A CloudFront behaviour was added for `/api/*` that forwards `Accept`, and that alone fixes the bug end-to-end** — the SPA receives JSON, parses it, renders into `<pre>`, no popup.

#2151 was an app-layer fix for the same symptom: it made `/api/{type}/{id}` always return JSON and dropped the SPA route. That worked, but as a side effect it silently removed the GTM pageview tracking that fires on direct browser hits to those URLs — and those pageviews feed broad-user-engagement KPIs. A subsequent attempt to layer GTM tracking back on (via a separate `.json` download URL) didn't actually solve it, because `Content-Disposition: attachment` responses never render the layout.

So: revert back to the pre-#2151 state. Combined with the CloudFront rule, the bug stays fixed and GTM tracking is preserved.

## What this revert restores

- `routes/api.js` — Accept-based content negotiation (HTML wrapper via `h.view('api', …)` for browsers; JSON for `Accept: application/vnd.api+json` clients).
- `client/main.js` — re-adds `require('./routes/api')(page);`.
- `client/routes/api.js` — restored (SPA route that fetches and renders JSON into the `<pre>` view).
- `templates/partials/records/panel-cite.html` — JSON link reverts to `href="{{links.api}}"` with no `download` attribute.
- `test/routes.test.js` — restores the original "Specific api endpoint, html response" test.

## Test plan

- [x] `tape test/routes.test.js` — 90 tests pass (pre-#2151 baseline, one less than master because the reverted test had 2 assertions instead of 3).
- [x] `npm run test:lint` — clean.
- [ ] On staging (with the CloudFront `/api/*` rule in place): click "Download catalogue entry as JSON" → SPA renders the JSON inline in `<pre>`, no `SyntaxError`.
- [ ] On staging: load `/api/objects/X` directly → HTML wrapper renders, GTM container loads, pageview fires in GA real-time view.
- [ ] On staging GA: `/api/...` URLs continue showing in Pages report after a few hours.

## Critical dependency

**The CloudFront `/api/*` behaviour (Accept-forwarding) must stay in place** for this revert to be safe. If that rule is ever removed, the original `SyntaxError` returns. Worth a code comment somewhere? Open question — happy to add one if you want.