### PR TITLE
Fix IIIF manifest JSON.parse failures on raw control characters

### DIFF
--- a/lib/helpers/json-escape.js
+++ b/lib/helpers/json-escape.js
@@ -1,0 +1,13 @@
+const Handlebars = require('handlebars');
+
+// Escapes a value for safe interpolation inside a JSON string literal.
+// JSON.stringify handles ", \, and control chars (0x00-0x1F) per RFC 8259;
+// slicing off the surrounding quotes leaves the bare escaped contents.
+// Returns a SafeString so Handlebars does not HTML-escape the result.
+module.exports = function jsonEscape (value) {
+  if (value === null || value === undefined) {
+    return new Handlebars.SafeString('');
+  }
+  const stringified = JSON.stringify(String(value));
+  return new Handlebars.SafeString(stringified.slice(1, -1));
+};

--- a/routes/iiif.js
+++ b/routes/iiif.js
@@ -5,8 +5,12 @@ const Handlebars = require('handlebars');
 const fs = require('fs');
 const path = require('path');
 const cacheHeaders = require('./route-helpers/cache-control');
+const jsonEscape = require('../lib/helpers/json-escape');
 const { promisify } = require('util');
 const setTimeoutPromise = promisify(setTimeout);
+
+// Required so raw newlines/tabs in CIIM fields don't break JSON.parse on the manifest.
+Handlebars.registerHelper('jsonEscape', jsonEscape);
 
 // Pre-load the IIIF manifest template once at startup rather than on every request
 const iiifTemplate = Handlebars.compile(

--- a/templates/iiif/iiifmanifest.json
+++ b/templates/iiif/iiifmanifest.json
@@ -1,58 +1,58 @@
 {
     "@context": "http://iiif.io/api/presentation/2/context.json",
-    "@id": "{{self}}/manifest",
+    "@id": "{{jsonEscape self}}/manifest",
     "@type": "sc:Manifest",
-    "label": "{{data.attributes.summary.title}}",
-    "description": "{{data.attributes.description.0.value}}",
+    "label": "{{jsonEscape data.attributes.summary.title}}",
+    "description": "{{jsonEscape data.attributes.description.0.value}}",
     "attribution": "Science Museum Group",
     "logo": "http://collection.sciencemuseum.org.uk/assets/img/global/smg-logo.svg",
     "metadata": [
-        {"label": "Identifier", "value": "{{data.attributes.identifier.0.value}}"}
-        {{#each data.attributes.lifecycle.creation}}    
-            {{#if date}},{{/if}}   
+        {"label": "Identifier", "value": "{{jsonEscape data.attributes.identifier.0.value}}"}
+        {{#each data.attributes.lifecycle.creation}}
+            {{#if date}},{{/if}}
             {{#each date}}
-                {"label": "Date made", "value": "{{value}}"}
+                {"label": "Date made", "value": "{{jsonEscape value}}"}
                 {{#unless @last}},{{/unless}}
             {{/each}}
-            {{#if places}},{{/if}}   
+            {{#if places}},{{/if}}
             {{#each places}}
-                {"label": "Place made", "value": "{{summary_title}}"}
+                {"label": "Place made", "value": "{{jsonEscape summary_title}}"}
                 {{#unless @last}},{{/unless}}
             {{/each}}
             {{#unless @last}},{{/unless}}
-        {{/each}}   
+        {{/each}}
     ],
 
     "thumbnail": {
-        "@id": "{{media.0.large_thumbnail.location}}"
+        "@id": "{{jsonEscape media.0.large_thumbnail.location}}"
     },
 
     "sequences": [
         {
-            "@id": "{{data.links.self}}/sequence/normal",
+            "@id": "{{jsonEscape data.links.self}}/sequence/normal",
             "@type": "sc:Sequence",
 
             "canvases": [
                 {{#each media}}
                 {
-                    "@id": "{{../self}}/canvas/{{@index}}",
+                    "@id": "{{jsonEscape ../self}}/canvas/{{@index}}",
                     "@type": "sc:Canvas",
-                    "label": "{{data.attributes.summary.title}}",
+                    "label": "{{jsonEscape data.attributes.summary.title}}",
                     "height": {{large.measurements.dimensions.0.value}},
-                    "width": {{large.measurements.dimensions.1.value}},  
+                    "width": {{large.measurements.dimensions.1.value}},
                     "images": [
                         {
-                            "@id": "{{zoom.location}}",
+                            "@id": "{{jsonEscape zoom.location}}",
                             "@type": "oa:Annotation",
                             "motivation": "sc:painting",
-                            "on": "{{../self}}/canvas/{{@index}}",
+                            "on": "{{jsonEscape ../self}}/canvas/{{@index}}",
                             "resource":{
-                                "@id": "{{zoom.location}}/full/max/0/default.jpg",
+                                "@id": "{{jsonEscape zoom.location}}/full/max/0/default.jpg",
                                 "@type": "dctypes:Image",
                                 "format": "image/jpeg",
-                                "label": "{{source.title.0.value}}",
+                                "label": "{{jsonEscape source.title.0.value}}",
                                 "service": {
-                                    "@id": "{{zoom.location}}",
+                                    "@id": "{{jsonEscape zoom.location}}",
                                     "@context": "http://iiif.io/api/image/2/context.json",
                                     "profile": "http://iiif.io/api/image/2/level1.json"
                                 },

--- a/test/iiif-manifest.test.js
+++ b/test/iiif-manifest.test.js
@@ -1,0 +1,111 @@
+const test = require('tape');
+const fs = require('fs');
+const path = require('path');
+const Handlebars = require('handlebars');
+const jsonEscape = require('../lib/helpers/json-escape');
+
+const dir = __dirname.split('/')[__dirname.split('/').length - 1];
+const file = dir + __filename.replace(__dirname, '') + ' > ';
+
+Handlebars.registerHelper('jsonEscape', jsonEscape);
+
+const templateSource = fs.readFileSync(
+  path.join(__dirname, '/../templates/iiif/iiifmanifest.json'),
+  'utf8'
+);
+const iiifTemplate = Handlebars.compile(templateSource);
+
+function buildContext (overrides) {
+  const base = {
+    self: 'http://example.com/iiif/objects/co8085283',
+    data: {
+      attributes: {
+        summary: { title: 'A title' },
+        description: [{ value: 'A description' }],
+        identifier: [{ value: 'INV-1' }],
+        lifecycle: { creation: [] }
+      },
+      links: { self: 'http://example.com/objects/co8085283' }
+    },
+    media: [
+      {
+        large_thumbnail: { location: 'http://example.com/thumb.jpg' },
+        zoom: { location: 'http://example.com/iiif/img1' },
+        large: { measurements: { dimensions: [{ value: 480 }, { value: 640 }] } },
+        source: { title: [{ value: 'Image label' }] }
+      }
+    ]
+  };
+  return Object.assign(base, overrides || {});
+}
+
+test(file + 'jsonEscape helper escapes control characters', (t) => {
+  t.equal(jsonEscape('line1\nline2').toString(), 'line1\\nline2', 'newline escaped');
+  t.equal(jsonEscape('tab\there').toString(), 'tab\\there', 'tab escaped');
+  t.equal(jsonEscape('quote"inside').toString(), 'quote\\"inside', 'double-quote escaped');
+  t.equal(jsonEscape('back\\slash').toString(), 'back\\\\slash', 'backslash escaped');
+  t.equal(jsonEscape('bellhere').toString(), 'bell\\u0007here', 'unicode control escaped');
+  t.equal(jsonEscape(null).toString(), '', 'null becomes empty string');
+  t.equal(jsonEscape(undefined).toString(), '', 'undefined becomes empty string');
+  t.end();
+});
+
+test(file + 'rendered manifest is valid JSON when title contains a newline', (t) => {
+  const ctx = buildContext();
+  ctx.data.attributes.summary.title = 'Stephenson Rocket\nReplica';
+  const rendered = iiifTemplate(ctx);
+  const parsed = JSON.parse(rendered);
+  t.equal(parsed.label, 'Stephenson Rocket\nReplica', 'newline preserved in parsed value');
+  t.end();
+});
+
+test(file + 'rendered manifest is valid JSON when description contains tabs and newlines', (t) => {
+  const ctx = buildContext();
+  ctx.data.attributes.description[0].value =
+    'Multi-line\ndescription\twith\ttabs\nand returns\r\nhere.';
+  const rendered = iiifTemplate(ctx);
+  const parsed = JSON.parse(rendered);
+  t.equal(
+    parsed.description,
+    'Multi-line\ndescription\twith\ttabs\nand returns\r\nhere.',
+    'control characters survive round-trip'
+  );
+  t.end();
+});
+
+test(file + 'rendered manifest is valid JSON when a string contains a literal double quote', (t) => {
+  const ctx = buildContext();
+  ctx.data.attributes.summary.title = 'The "Rocket" locomotive';
+  const rendered = iiifTemplate(ctx);
+  const parsed = JSON.parse(rendered);
+  t.equal(parsed.label, 'The "Rocket" locomotive', 'embedded quotes preserved');
+  t.end();
+});
+
+test(file + 'rendered manifest is valid JSON for the place-made and date-made fields', (t) => {
+  const ctx = buildContext();
+  ctx.data.attributes.lifecycle.creation = [
+    {
+      date: [{ value: '1829\tcirca' }],
+      places: [{ summary_title: 'Newcastle\nupon\nTyne' }]
+    }
+  ];
+  const rendered = iiifTemplate(ctx);
+  const parsed = JSON.parse(rendered);
+  const dateEntry = parsed.metadata.find((m) => m.label === 'Date made');
+  const placeEntry = parsed.metadata.find((m) => m.label === 'Place made');
+  t.equal(dateEntry.value, '1829\tcirca', 'tab in date value preserved');
+  t.equal(placeEntry.value, 'Newcastle\nupon\nTyne', 'newlines in place name preserved');
+  t.end();
+});
+
+test(file + 'rendered manifest is valid JSON when image label has control chars', (t) => {
+  const ctx = buildContext();
+  ctx.media[0].source.title[0].value = 'Front view\nof the engine';
+  const rendered = iiifTemplate(ctx);
+  const parsed = JSON.parse(rendered);
+  const canvas = parsed.sequences[0].canvases[0];
+  const imageLabel = canvas.images[0].resource.label;
+  t.equal(imageLabel, 'Front view\nof the engine', 'newline preserved in image label');
+  t.end();
+});


### PR DESCRIPTION
## Summary
- `routes/iiif.js` renders the manifest by interpolating CIIM fields (label, description, identifier, dates, places, image label) into a Handlebars JSON template. Some records (e.g. `/iiif/objects/co8085283`) have raw newlines/tabs in those fields, which Handlebars' default `{{var}}` HTML-escapes but does *not* escape for JSON string contexts — so the control chars land verbatim inside string literals and `JSON.parse` of the response fails (`Bad control character in string literal in JSON at position ~302`).
- Adds a small `jsonEscape` Handlebars helper (`lib/helpers/json-escape.js`) that uses `JSON.stringify(value).slice(1, -1)` to escape `"`, `\`, and control chars `U+0000`–`U+001F` per RFC 8259, and returns a `Handlebars.SafeString` so the result isn't HTML-escaped on top.
- Wraps every string-context interpolation in `templates/iiif/iiifmanifest.json` with `{{jsonEscape ...}}`. Numeric fields (`large.measurements.dimensions.*.value`, `@index`) are left bare since they render into numeric positions.

## Test plan
- [x] Unit + template tests in `test/iiif-manifest.test.js` — 13 assertions covering the helper directly (newlines, tabs, double quotes, backslash, `U+0007`, null/undefined) and a full template round-trip through `JSON.parse` for title, description, dates, place names, embedded `"`, and image labels containing control characters.
- [x] `npx semistandard` clean on all changed files.
- [ ] Manual: hit `/iiif/objects/co8085283` against a running instance and confirm `curl ... | jq .` succeeds.
- [ ] Manual: spot-check a record without any control chars (e.g. `co8094437`) to confirm output is byte-identical aside from the few whitespace tweaks the template received.

## Notes
- Not blocking the IIIF download-link cleanup work — touches a different surface (server-side manifest rendering, not the client download flow).
- Branched off the new `master` tip (`9296323b`, post-reverts of #2151/#2152).
