### PR TITLE
Strip internal cataloguer notes from JSON API responses

### DIFF
--- a/fixtures/attributes.js
+++ b/fixtures/attributes.js
@@ -9,7 +9,6 @@ module.exports = [
   'description',
   'identifier',
   'name',
-  'note',
   'reference_links',
   'summary',
   'title',

--- a/lib/helpers/strip-internal-notes.js
+++ b/lib/helpers/strip-internal-notes.js
@@ -1,0 +1,26 @@
+// Strip `note` fields from JSON API output to prevent internal cataloguer
+// notes (often containing staff names, e.g. "Changed from … by LUCY_ELLIS")
+// from leaking out of Mimsy / AdLib via the API.
+//
+// Two parent keys are preserved as carve-outs because their `note` subfield
+// is legitimate public content:
+//   - access.note      → rendered as the "Access" row on archive pages
+//   - measurements.note → catalogue context for object dimensions
+const NOTE_ALLOWED_PARENTS = new Set(['access', 'measurements']);
+
+function stripInternalNotes (value, parentKey) {
+  if (Array.isArray(value)) {
+    for (const item of value) stripInternalNotes(item, parentKey);
+    return;
+  }
+  if (!value || typeof value !== 'object') return;
+  for (const key of Object.keys(value)) {
+    if (key === 'note' && !NOTE_ALLOWED_PARENTS.has(parentKey)) {
+      delete value[key];
+      continue;
+    }
+    stripInternalNotes(value[key], key);
+  }
+}
+
+module.exports = stripInternalNotes;

--- a/lib/jsonapi-response.js
+++ b/lib/jsonapi-response.js
@@ -7,6 +7,7 @@ const displayLegalStatus = require('./display-legal-status');
 const slug = require('slugg');
 const sortImages = require('./helpers/jsonapi-response/sort-images.js');
 const restrictedMaterials = require('../fixtures/restricted-materials-record.js');
+const stripInternalNotes = require('./helpers/strip-internal-notes.js');
 // const { CloudFrontKeyValueStore } = require('aws-sdk');
 
 module.exports = (data, config, relatedItems, relatedAIItems, childRecordsList) => {
@@ -20,21 +21,6 @@ module.exports = (data, config, relatedItems, relatedAIItems, childRecordsList) 
   }
 
   const attributes = getAttributes(data._source);
-
-  // TODO: Remove this block once attribution notes have been removed from the Elasticsearch index itself.
-  // Strips `attribution.note` from creation maker/place items to prevent internal cataloguer
-  // notes (e.g. "project cataloguer") from leaking into the public JSON API response.
-  if (attributes.creation) {
-    ['maker', 'place'].forEach((key) => {
-      if (Array.isArray(attributes.creation[key])) {
-        attributes.creation[key].forEach((item) => {
-          if (item['@link'] && item['@link'].attribution) {
-            delete item['@link'].attribution.note;
-          }
-        });
-      }
-    });
-  }
 
   const filteredEnhancements = filterAndExtractChildEnhancements(children);
   const hasChildEnhancements = !!filteredEnhancements;
@@ -103,7 +89,7 @@ module.exports = (data, config, relatedItems, relatedAIItems, childRecordsList) 
   const ___comment =
     '### WARNING ### - <enhancement> tags are experimental, please do not aggregate';
 
-  return {
+  const response = {
     data: {
       ___comment,
       type,
@@ -120,6 +106,10 @@ module.exports = (data, config, relatedItems, relatedAIItems, childRecordsList) 
     included,
     inProduction
   };
+
+  stripInternalNotes(response.data);
+  stripInternalNotes(response.included);
+  return response;
 };
 
 function filterRestrictedMaterials (attributes) {

--- a/lib/transforms/json-to-html-data.js
+++ b/lib/transforms/json-to-html-data.js
@@ -360,7 +360,6 @@ function getDetails (resource, links) {
   const legal = getLegal(resource.data);
   const arrangement = getArrangement(resource.data);
   const transcriptions = getTranscriptions(resource.data);
-  const notes = getNotes(resource.data);
   const objectType = getObjectType(resource.data, links);
   const taxonomy = getTaxonomy(resource, links);
   const subject = getSubject(resource.data, links);
@@ -380,7 +379,7 @@ function getDetails (resource, links) {
     objectType,
     taxonomy
   ]
-    .concat(legal, notes)
+    .concat(legal)
     .filter((el) => el);
 }
 
@@ -708,20 +707,6 @@ function getTranscriptions (data) {
       transcriptions.push(el.value.replace(/\r\n|\n|\r/gm, '<br />'));
     });
     return { key: 'Transcription', value: transcriptions.join('<hr />') };
-  } else {
-    return null;
-  }
-}
-
-function getNotes (data) {
-  const notes = [];
-  if (data.attributes.note && data.type !== 'people') {
-    data.attributes.note.forEach((el) => {
-      if (el.type) {
-        notes.push({ key: el.type, value: el.value });
-      }
-    });
-    return notes;
   } else {
     return null;
   }

--- a/lib/transforms/search-results-to-jsonapi.js
+++ b/lib/transforms/search-results-to-jsonapi.js
@@ -8,6 +8,7 @@ const paramify = require('../helpers/paramify.js');
 const querify = require('../helpers/querify.js');
 const slug = require('slugg');
 const sortImages = require('../helpers/jsonapi-response/sort-images.js');
+const stripInternalNotes = require('../helpers/strip-internal-notes.js');
 
 module.exports = (queryParams, results, config, mphcParent) => {
   results = results || {};
@@ -20,6 +21,8 @@ module.exports = (queryParams, results, config, mphcParent) => {
   const links = createLinks(queryParams, results, rootUrl);
   const meta = createMeta(queryParams, results);
   const inProduction = config && config.NODE_ENV === 'production';
+  stripInternalNotes(data);
+  stripInternalNotes(included);
   return { data, included, links, meta, inProduction, mphcParent };
 };
 
@@ -76,7 +79,6 @@ const createResource = {
       'multimedia',
       'mphc',
       'name',
-      'note',
       'numbers',
       // 'options',
       'reference_links',
@@ -135,7 +137,6 @@ const createResource = {
       'lifecycle',
       'name',
       'nationality',
-      'note',
       'occupation',
       'reference_links',
       'summary',
@@ -178,7 +179,6 @@ const createResource = {
       'measurements',
       'multimedia',
       'name',
-      'note',
       'reference_links',
       'summary',
       'title',
@@ -246,7 +246,6 @@ const createResource = {
       'child',
       'mphc',
       'name',
-      'note',
       'numbers',
       // 'options',
       'reference_links',


### PR DESCRIPTION
## Summary
- Several nested `note` fields (e.g. `attributes.identifier[].note`, `attributes.date[].note`) were passing through the public JSON API carrying internal cataloguer audit-log strings of the form *"Changed from \<old id\> to \<new id\> on \<date\> by \<CATALOGUER\>"*. The previous defensive block only stripped `creation.maker[].@link.attribution.note`, missing every other nested location.
- New helper `lib/helpers/strip-internal-notes.js` recursively deletes every `note` key from the response, with carve-outs for the two legitimately-public uses we identified:
  - `access.note` — rendered as the "Access" row on archive record pages
  - `measurements.note` — catalogue context for dimensions
- Wired into both `lib/jsonapi-response.js` (single-record API + HTML page data) and `lib/transforms/search-results-to-jsonapi.js` (search results / included resources). The old localised `attribution.note` block is removed, since the recursive walker covers that case too.
- Belt-and-braces: also dropped `'note'` from the top-level attribute whitelists in `fixtures/attributes.js` and the per-record-type lists in `search-results-to-jsonapi.js`, and removed the now-dead `getNotes` helper in `json-to-html-data.js` (it was already inert for typeless audit notes).

## Test plan
- [x] All 82 `jsonapi-response-builder-*.test.js` assertions pass
- [x] Verified against four real API responses (objects/co8618973, co26704, co8364603, co8413731): every `identifier.note` / `date.note` audit entry is stripped; all 11 `measurements.note` entries on co8413731 are preserved
- [ ] Spot-check `/api/objects/co8618973` on a deployed preview to confirm the cataloguer-named `note` no longer appears in the response
- [ ] Spot-check an archive record with `access.note` to confirm the "Access" row still renders on the HTML page

Closes the leak originally surfaced on `/api/objects/co8618973`.