### PR TITLE
Fix /group/* SPA fetch SyntaxError + add HTTP cache validators

### DIFF
--- a/lib/jsonapi-response.js
+++ b/lib/jsonapi-response.js
@@ -107,6 +107,11 @@ module.exports = (data, config, relatedItems, relatedAIItems, childRecordsList) 
     inProduction
   };
 
+  const processed = data._source['@admin'] && data._source['@admin'].processed;
+  if (processed) {
+    response.meta = { lastModified: new Date(processed).toISOString() };
+  }
+
   stripInternalNotes(response.data);
   stripInternalNotes(response.included);
   return response;

--- a/routes/api.js
+++ b/routes/api.js
@@ -4,18 +4,15 @@ const TypeMapping = require('../lib/type-mapping');
 const beautify = require('json-beautify');
 const contentType = require('./route-helpers/content-type.js');
 const cacheHeaders = require('./route-helpers/cache-control');
+const addCacheValidators = require('./route-helpers/cache-validators.js');
 const getChildRecords = require('../lib/get-child-records.js');
 
-// NOTE: This route negotiates response shape via the Accept header
-// (HTML wrapper for browsers — which fires GTM pageview tracking — vs
-// JSON for `Accept: application/vnd.api+json` clients). This relies on
-// CloudFront's `/api/*` behaviour forwarding the Accept header to
-// origin (origin request policy: Managed-AllViewer or equivalent).
-// Without that, CloudFront strips Accept, every request looks like a
-// browser hit, and the client SPA route's JSON fetch receives HTML —
-// causing `JSON.parse('<...')` to throw `SyntaxError: Unrecognized
-// token '<'` on the "Download catalogue entry as JSON" link.
-// See PRs #2151 / #2153 / #2154 for history.
+// Negotiates response shape via the Accept header (HTML wrapper for browsers
+// — which fires GTM pageview tracking — vs JSON for `Accept:
+// application/vnd.api+json` clients). The `/api/*` CloudFront behaviour uses
+// the `OriginControlled-QueryStrings-Accept-CO` cache policy and
+// `Managed-AllViewer` origin request policy, so Accept is both forwarded to
+// origin AND included in the cache key.
 module.exports = (elastic, config) => ({
   method: 'GET',
   path: '/api/{type}/{id}/{slug?}',
@@ -43,22 +40,24 @@ module.exports = (elastic, config) => ({
           console.warn(`[api/${request.params.id}] child records failed: ${err}`);
         }
 
-        const apiData = beautify(
-          buildJSONResponse(
-            result.body,
-            config,
-            null,
-            null,
-            childRecords
-          ), null, 2, 80
+        const jsonData = buildJSONResponse(
+          result.body,
+          config,
+          null,
+          null,
+          childRecords
         );
+        const apiData = beautify(jsonData, null, 2, 80);
+        const lastModified = jsonData.meta && jsonData.meta.lastModified;
 
         if (responseType === 'json') {
-          return h
+          const response = h
             .response(apiData)
             .header('content-type', 'application/vnd.api+json');
+          return addCacheValidators(response, { variant: 'api-json', payload: apiData, lastModified });
         } else {
-          return h.view('api', { api: apiData });
+          const view = h.view('api', { api: apiData });
+          return addCacheValidators(view, { variant: 'api-html', payload: apiData, lastModified });
         }
       } catch (err) {
         if (err.statusCode === 404) {

--- a/routes/iiif.js
+++ b/routes/iiif.js
@@ -5,6 +5,7 @@ const Handlebars = require('handlebars');
 const fs = require('fs');
 const path = require('path');
 const cacheHeaders = require('./route-helpers/cache-control');
+const addCacheValidators = require('./route-helpers/cache-validators.js');
 const jsonEscape = require('../lib/helpers/json-escape');
 const { promisify } = require('util');
 const setTimeoutPromise = promisify(setTimeout);
@@ -60,7 +61,10 @@ module.exports = (elastic, config) => ({
           });
         }
 
-        return h.response(iiifTemplate(iiifData)).header('content-type', 'application/json');
+        const manifest = iiifTemplate(iiifData);
+        const lastModified = result.body._source['@admin'] && result.body._source['@admin'].processed;
+        const response = h.response(manifest).header('content-type', 'application/json');
+        return addCacheValidators(response, { variant: 'iiif', payload: manifest, lastModified });
       } catch (err) {
         request.log({
           tags: ['iiif', 'error'],

--- a/routes/route-helpers/cache-validators.js
+++ b/routes/route-helpers/cache-validators.js
@@ -1,0 +1,27 @@
+const crypto = require('crypto');
+
+// Adds Vary: Accept, ETag (weak), and Last-Modified to a Hapi response.
+// `variant` should differ between HTML and JSON renders of the same record so
+// the two never share an ETag. `payload` is hashed for the ETag; pass either
+// the serialised body string or the underlying data object. `lastModified` is
+// optional and accepts anything `new Date()` understands (ms since epoch, ISO
+// string, Date instance).
+//
+// Hapi's `.etag()` returns 304 automatically when `If-None-Match` matches.
+module.exports = function (response, { variant, payload, lastModified }) {
+  const hash = crypto.createHash('sha1');
+  hash.update(variant + ':');
+  hash.update(typeof payload === 'string' ? payload : JSON.stringify(payload));
+  const etag = hash.digest('hex');
+
+  response.vary('Accept').etag(etag, { weak: true });
+
+  if (lastModified) {
+    const date = lastModified instanceof Date ? lastModified : new Date(lastModified);
+    if (!isNaN(date.getTime())) {
+      response.header('last-modified', date.toUTCString());
+    }
+  }
+
+  return response;
+};

--- a/routes/route-helpers/content-type.js
+++ b/routes/route-helpers/content-type.js
@@ -5,6 +5,16 @@ module.exports = function (request) {
   const jsonAcceptHeaders = ['application/vnd.api+json', 'application/json'];
   const htmlAcceptHeaders = ['text/html', '*/*'];
 
+  // The client SPA appends `?ajax=true` to every resource fetch. Treat it as
+  // an explicit JSON signal so we don't depend on CloudFront forwarding the
+  // Accept header to origin — without that, `/group/*`, `/objects/*` etc.
+  // cache the HTML response and serve it to SPA JSON fetches, causing
+  // `JSON.parse('<...')` to throw "Unrecognized token '<'". The query string
+  // also gives CloudFront a distinct cache key from the bare URL.
+  if (request.query && request.query.ajax === 'true') {
+    return 'json';
+  }
+
   if (request.headers.accept) {
     const accept = request.headers.accept;
     const jsonContent = typesInHeaders(accept, jsonAcceptHeaders);

--- a/routes/route-helpers/response.js
+++ b/routes/route-helpers/response.js
@@ -1,15 +1,20 @@
 const JSONToHTML = require('../../lib/transforms/json-to-html-data.js');
+const addCacheValidators = require('./cache-validators.js');
 
 module.exports = function (h, data, type, responseType) {
+  const lastModified = data && data.meta && data.meta.lastModified;
+
   if (responseType === 'html') {
     const pageData = {
       page: type
     };
     const HTMLData = JSONToHTML(data);
-    return h.view(type, Object.assign(HTMLData, pageData));
+    const view = h.view(type, Object.assign(HTMLData, pageData));
+    return addCacheValidators(view, { variant: 'html', payload: data, lastModified });
   }
 
   if (responseType === 'json') {
-    return h.response(data).header('content-type', 'application/vnd.api+json');
+    const response = h.response(data).header('content-type', 'application/vnd.api+json');
+    return addCacheValidators(response, { variant: 'json', payload: data, lastModified });
   }
 };

--- a/test/content-negotiation.test.js
+++ b/test/content-negotiation.test.js
@@ -78,6 +78,50 @@ testWithServer(file + 'Return json if both json and html header are defined at t
   t.end();
 });
 
+testWithServer(file + 'Return json when ?ajax=true even if Accept header is missing or HTML', {}, async (t, ctx) => {
+  t.plan(2);
+
+  const noAcceptHeader = await ctx.server.inject({
+    method: 'GET',
+    url: '/search?q=test&ajax=true'
+  });
+  t.ok(noAcceptHeader.headers['content-type'].indexOf('application/vnd.api+json') > -1, '?ajax=true with no Accept header should return JSON');
+
+  const htmlAcceptHeader = await ctx.server.inject({
+    method: 'GET',
+    url: '/search?q=test&ajax=true',
+    headers: { Accept: 'text/html' }
+  });
+  t.ok(htmlAcceptHeader.headers['content-type'].indexOf('application/vnd.api+json') > -1, '?ajax=true should override Accept: text/html');
+
+  t.end();
+});
+
+testWithServer(file + 'Resource responses include Vary, ETag, and Last-Modified headers', {}, async (t, ctx) => {
+  t.plan(8);
+
+  const jsonRes = await ctx.server.inject({
+    method: 'GET',
+    url: '/objects/co8245103?ajax=true'
+  });
+  t.equal(jsonRes.statusCode, 200, 'JSON request returns 200');
+  t.ok(/Accept/i.test(jsonRes.headers.vary || ''), 'JSON response has Vary: Accept');
+  t.ok(jsonRes.headers.etag, 'JSON response has ETag');
+  t.ok(jsonRes.headers['last-modified'], 'JSON response has Last-Modified');
+
+  const htmlRes = await ctx.server.inject({
+    method: 'GET',
+    url: '/objects/co8245103',
+    headers: { Accept: 'text/html' }
+  });
+  t.equal(htmlRes.statusCode, 200, 'HTML request returns 200');
+  t.ok(/Accept/i.test(htmlRes.headers.vary || ''), 'HTML response has Vary: Accept');
+  t.ok(htmlRes.headers.etag, 'HTML response has ETag');
+  t.notEqual(htmlRes.headers.etag, jsonRes.headers.etag, 'HTML and JSON ETags differ for the same record');
+
+  t.end();
+});
+
 testWithServer(file + 'Return html if user agent is twitter bot', {}, async (t, ctx) => {
   t.plan(1);
 


### PR DESCRIPTION
## Summary

- **Fixes the production `SyntaxError: Unrecognized token '<'`** when clicking SPA links into `/group/{id}` pages. The Default CloudFront behaviour (`/group/*` fell through to it) had no Origin Request Policy, so `Accept` was stripped before reaching origin and content negotiation always returned HTML. Making `?ajax=true` an explicit JSON signal on the server (the SPA already sends it on every fetch) sidesteps the dependency on Accept-forwarding entirely.
- **Adds `Vary: Accept`, weak `ETag`, and `Last-Modified`** to resource (`group`/`object`/`person`/`archive`), `/api`, and IIIF responses via a new `routes/route-helpers/cache-validators.js`. Hapi's `.etag()` returns `304` automatically when `If-None-Match` matches. `Last-Modified` is sourced from `_source['@admin'].processed` and exposed in the JSON:API top-level `meta.lastModified`.
- **Replaces the stale `/api/*` CloudFront comment** with one that reflects the migration to `OriginControlled-QueryStrings-Accept-CO`.

## Background

This is the same class of CloudFront content-negotiation bug as PRs #2151–#2154, but on `/group/*` rather than `/api/*`. The root cause is structural: relying on `Accept` header forwarding through a CDN is brittle — any path without an explicit Origin Request Policy strips it. Using a query-string signal that's part of the cache key fixes it once for all current and future resource routes.

CloudFront-side changes (separate, infrastructure-only): added a `/group*` behaviour with `Managed-AllViewer` + `OriginControlled-QueryStrings-Accept-CO`, migrated `/objects*`, `/people*`, `/documents*`, `/iiif/*` off legacy `ForwardedValues`, set an Origin Request Policy on the Default behaviour, and moved `/api/*` and `/articles/*` onto the Accept-keyed policy. The code change here would survive a CloudFront misconfiguration; the CloudFront change adds belt-and-braces.

## Test plan

- [x] All 9 content-negotiation tests pass (including 2 new `?ajax=true` cases and 8 new header-presence assertions on `/objects/{id}` HTML + JSON)
- [x] All 107 route + content-negotiation tests pass
- [x] `semistandard` lint clean on all changed files
- [ ] After deploy: verify `https://collection.sciencemuseumgroup.org.uk/group/c83918/hawking-building-freestanding-grid` → click "Hawking Building Grid" under Highlights → SPA navigation completes without JSON parse error
- [ ] After deploy: `curl -i 'https://collection.sciencemuseumgroup.org.uk/objects/co8245103?ajax=true'` shows `Vary: Accept`, `ETag`, `Last-Modified` headers
- [ ] After deploy: spot-check `If-None-Match: <etag>` returns `304`