### PR TITLE
Drop "(Beta)" from Interesting Articles heading

### DIFF
--- a/templates/partials/records/record-ai-related-articles.html
+++ b/templates/partials/records/record-ai-related-articles.html
@@ -1,6 +1,6 @@
 
 <div class="panel panel__text">
-  <h2>Interesting Articles (Beta)</h2>
+  <h2>Interesting Articles</h2>
   {{#if aiRelated.articles.oands}}
   <div class="museum-articles">
     <h3>Objects and Stories</h3><p>

--- a/templates/partials/records/record-ai-related-records.html
+++ b/templates/partials/records/record-ai-related-records.html
@@ -1,5 +1,5 @@
 <!-- <div class="panel panel__text">
-  <h2>Related Records (Beta)</h2>
+  <h2>Related Records</h2>
   <div class="museum-articles">
     <h3>Objects</h3>
     <ul class="related-article">


### PR DESCRIPTION
## Summary
- Remove the "(Beta)" suffix from the "Interesting Articles" `<h2>` in the AI related articles panel on object pages.

## Test plan
- [ ] Visit an object page where `aiRelated.hasArticles` is true and confirm the panel heading reads "Interesting Articles" with no "(Beta)" suffix.