### PR TITLE
Fix barcode preview thumbnail sort + missing-image fallback

### DIFF
--- a/routes/barcode.js
+++ b/routes/barcode.js
@@ -1,5 +1,25 @@
 const slug = require('slugg');
 const Boom = require('@hapi/boom');
+const sortImages = require('../lib/helpers/jsonapi-response/sort-images');
+
+// Pick the first usable derivative for a preview thumbnail. Falls back through
+// sizes because some records' first image has only a subset of derivatives.
+// Returns null if nothing usable was found.
+function firstImageLocation (source) {
+  const raw = Array.isArray(source?.multimedia)
+    ? source.multimedia.filter(m => m && m['@processed'])
+    : [];
+  if (!raw.length) return null;
+  const sorted = sortImages(raw);
+  const p = sorted[0]?.['@processed'];
+  return (
+    p?.medium?.location ||
+    p?.large_thumbnail?.location ||
+    p?.large?.location ||
+    p?.small_thumbnail?.location ||
+    null
+  );
+}
 
 module.exports = (elastic, config) => ({
   method: 'GET',
@@ -32,9 +52,10 @@ module.exports = (elastic, config) => ({
 
             const title = obj?._source?.summary?.title;
 
-            const image =
-              config.mediaPath +
-              obj?._source?.multimedia?.[0]?.['@processed']?.medium?.location;
+            // Match the sort order the object page uses (lib/jsonapi-response.js
+            // → sortImages: position asc, upload_sort desc) so the preview
+            // thumbnail aligns with what the user sees on /objects/{id}.
+            let imageLocation = firstImageLocation(obj?._source);
 
             const uid = obj?._id;
             slugValue = slugValue ? '/' + slugValue : '';
@@ -78,6 +99,25 @@ module.exports = (elastic, config) => ({
             } else {
               path = '/objects/' + obj?._id + slugValue;
             }
+
+            // Parts often have no multimedia of their own (e.g. SMG00420385,
+            // a lens cap). Since the sheet's "View record" links to the parent
+            // anyway, fall back to the parent's first sorted image so the
+            // preview matches what the user will see after clicking through.
+            if (!imageLocation && isPart && parentUid) {
+              try {
+                const parentRes = await elastic.get(
+                  { index: config.elasticIndex, id: parentUid },
+                  { requestTimeout: 5000 }
+                );
+                imageLocation = firstImageLocation(parentRes?.body?._source);
+              } catch (e) {
+                // Swallow — a missing/unreachable parent shouldn't break the
+                // primary scan response. The UI handles a null image.
+              }
+            }
+
+            const image = imageLocation ? config.mediaPath + imageLocation : null;
 
             return h.response({
               path,


### PR DESCRIPTION
## Summary

Two small fixes to the barcode scanner preview thumbnail (`/barcode/{uid}` JSON response):

- **Sort order matched to object page.** The route used the raw `multimedia[0]`; the object page sorts via `sortImages` (position asc, upload_sort desc). For records where the first ES entry was a barcode-label scan rather than the primary object photo, the preview thumbnail and the page the user landed on showed different images. Routes the barcode response through the same `sortImages` helper.
- **Missing-derivative + part-with-no-images fallback.** Previously, when the first image lacked a `medium` derivative the route emitted `<mediaPath>undefined` (a broken `<img>`), and when a part record had no multimedia of its own the same broken URL appeared. The route now:
  1. Falls through `medium → large_thumbnail → large → small_thumbnail` on the chosen image.
  2. If the scanned record is a part with no usable image of its own, fetches the parent and uses its first sorted image — matching what users see after clicking "View record".
  3. If neither yields anything, returns `image: null`. The client UI already renders a placeholder div in that case.

## Test plan

- [x] `/barcode/SMG00213866` returns the parent car's primary photo (`medium_1935_0502_0001__0001_.jpg`) — matches `/api/objects/co26369` first sorted image.
- [x] `/barcode/SMG00354291` returns the lens's first sorted image (`medium_1999_5149_0002__0001_.jpg`).
- [x] `/barcode/SMG00420385` (lens cap, no own multimedia) falls back to the parent projector's first image (`medium_1999_5149__0001_.jpg`).
- [x] Unknown barcode still 404s.
- [x] `/barcode` landing page still 200s.
- [ ] Scan one of the affected barcodes in the live scanner app on a phone and confirm the thumbnail in both the result sheet and history drawer.