### PR TITLE
Sort related-items panel thumbnails to match own-record page

### DIFF
--- a/lib/sort-related-items.js
+++ b/lib/sort-related-items.js
@@ -2,6 +2,7 @@ const config = require('../config');
 const TypeMapping = require('./type-mapping');
 const getNestedProperty = require('./nested-property');
 const getPrimaryValue = require('./get-primary-value');
+const sortImages = require('./helpers/jsonapi-response/sort-images');
 const slug = require('slugg');
 
 module.exports = (related, id) => {
@@ -18,10 +19,16 @@ module.exports = (related, id) => {
       el._source.summary.title && slug(el._source.summary.title).toLowerCase();
     slugValue = slugValue ? '/' + slugValue : '';
     if (sortedRelated[group]) {
-      const figure = getNestedProperty(
-        el,
-        '_source.multimedia.0.@processed.large_thumbnail.location'
-      );
+      // Match the sort order the related record's own page uses
+      // (lib/jsonapi-response.js → sortImages: position asc, upload_sort
+      // desc). Without this the panel thumbnail can differ from what users
+      // see after clicking through. Filter entries without @processed
+      // because sortImages dereferences it and would otherwise throw.
+      const multimedia = Array.isArray(el._source.multimedia)
+        ? el._source.multimedia.filter(m => m && m['@processed'])
+        : [];
+      const sorted = multimedia.length ? sortImages(multimedia) : [];
+      const figure = sorted[0]?.['@processed']?.large_thumbnail?.location || null;
       const summaryTitle = el._source.summary.title;
       const description = getPrimaryValue(el._source.description);
       const title = getPrimaryValue(el._source.title);


### PR DESCRIPTION
## Summary

The "Related Objects" / "Related Documents" / "Related Children" panels on `/people`, `/objects` and `/documents` pages were reading `_source.multimedia[0]` raw from each related Elasticsearch hit. The record's own page sorts multimedia via `sortImages` (position asc, upload_sort desc — see `lib/jsonapi-response.js:52`), so the panel could show a different image to the one the user lands on after clicking through.

Routes the related-items pipeline ([lib/sort-related-items.js](https://github.com/TheScienceMuseum/collectionsonline/blob/fix/related-items-thumbnail-sort/lib/sort-related-items.js)) through the same `sortImages` helper. Same approach as [#2159](https://github.com/TheScienceMuseum/collectionsonline/pull/2159) (barcode preview thumbnail).

## Test plan

- [x] On `/people/cp3870` (George Stephenson, 24 related items with figures), each panel thumbnail now matches the first sorted image returned by the related record's own `/api/{type}/{id}` response.
- [x] On `/objects/co8084201`, the related-objects panel renders without errors; the only related-object that has any multimedia displays its first sorted image (others fall back to the figcaption placeholder as before).
- [x] Records with no multimedia no longer crash the route — sorted-empty path returns a null `figure`, the template renders the existing placeholder card (icon + description).
- [ ] Sanity check on the live site after deploy: spot-check a few rich people/object pages.