### PR TITLE
Exclude SPH child parts from /people related items

### DIFF
--- a/lib/get-related-items.js
+++ b/lib/get-related-items.js
@@ -21,9 +21,14 @@ module.exports = async (elastic, id, count) => {
                 }
               }
             ],
-            must_not: {
-              term: { '@datatype.base': 'agent' }
-            },
+            must_not: [
+              { term: { '@datatype.base': 'agent' } },
+              // SPH child records (parts) don't have their own public page —
+              // /objects/{partId} redirects to the parent. Showing them in
+              // "Related Objects" produces broken-feeling navigation. Match
+              // the exclusion already used by lib/get-similar-objects.js.
+              { term: { 'grouping.@link.type': 'SPH' } }
+            ],
             minimum_should_match: 1
           }
         },


### PR DESCRIPTION
## Summary

The "Related Objects" and "Related Documents" panels on `/people/{id}` are populated by [lib/get-related-items.js](https://github.com/TheScienceMuseum/collectionsonline/blob/master/lib/get-related-items.js), which until now only excluded agents (`@datatype.base: agent`) from the result set. SPH child records (parts of a larger object) leaked in.

Parts don't have their own public catalogue page — visiting `/objects/{partId}` redirects to the parent — so they produce broken-feeling navigation when surfaced in a relations panel. The parallel pipeline for object pages ([lib/get-similar-objects.js:11](https://github.com/TheScienceMuseum/collectionsonline/blob/master/lib/get-similar-objects.js#L11)) already excludes them via `must_not: { term: { 'grouping.@link.type': 'SPH' } }`. This PR adds the same clause to `get-related-items.js`.

## Test plan

- [x] Before fix: George Stephenson's people page (`/people/cp3870`) had 3 of 24 related items as SPH child parts.
- [x] After fix: 0 SPH children in the panel — verified on cp3870, ap38 (Robert Stephenson, AdLib), cp36993 (Charles Babbage). Total related counts unchanged where the person has enough non-child relations (24/24/8 respectively).
- [x] No server errors after restart.
- [ ] Spot-check a few people pages on the live site after deploy.