### PR TITLE
Tighten /scan result headings

### DIFF
--- a/client/lib/visual-search/controller.js
+++ b/client/lib/visual-search/controller.js
@@ -191,7 +191,7 @@ function createController (mountEl) {
     const top = data.results[0];
     const rest = data.results.slice(1, 7);
     const restMarkup = rest.length
-      ? '<h2 class="scan__results-subheading">Other possibilities</h2>' +
+      ? '<h2 class="scan__results-subheading">Things that look similar</h2>' +
         '<div class="scan__results-grid">' +
           rest.map(renderResultCard).join('') +
         '</div>'
@@ -200,7 +200,7 @@ function createController (mountEl) {
       '<div class="scan__results scan__results--high">' +
         renderCapturedPhoto(capture) +
         renderDebugBadge(data) +
-        '<h2 class="scan__results-heading">Looks like this from our collection</h2>' +
+        '<h2 class="scan__results-heading">Looks like this</h2>' +
         '<div class="scan__results-hero">' +
           renderResultCard(top) +
         '</div>' +


### PR DESCRIPTION
## Summary

Two small copy tweaks to the Snap It results page, both in `client/lib/visual-search/controller.js`:

- **High-confidence heading** `Looks like this from our collection` → `Looks like this`. Saves the wrap onto a second line on phone portrait viewports. The "from our collection" context is implicit — the page is `/scan`, the H1 is "Snap It", and the cards link to /objects/co… records.

- **High-confidence sub-heading** (the cards shown below the hero card when we're confident enough to lead with one) `Other possibilities` → `Things that look similar`. Reuses the exact phrase from the medium-confidence tier heading, so the same cards always carry the same label regardless of which tier the results land in. Removes a redundant phrase from the lexicon.

## Test plan

- [ ] On a phone, scan something that produces a high-confidence result (e.g. screen-photo a catalogue object). Heading reads "Looks like this" on one line; sub-heading below the hero card reads "Things that look similar".
- [ ] On the same scan, GTM `VisualSearch` event with `ga_event.action = 'search-complete'` still fires as before. No analytics changes here, just text.

## Risk

Trivial — two `innerHTML` template strings. No behaviour change.