### PR TITLE
Snap It intro: broader, more personal example list

### DIFF
--- a/templates/pages/scan.html
+++ b/templates/pages/scan.html
@@ -7,7 +7,7 @@
       <header class="scan__intro">
         <h1>Snap It</h1>
         <p>
-          Take a photo of something around you and we’ll show you what our collection has that looks similar. Try it on a watch on your wrist, a kettle, or a vintage poster. You might be surprised by what’s in our collection.
+          Take a photo of something around you and we’ll show you what our collection has that looks similar. Try it on a household item, the watch on your wrist, the wheel of a bicycle or your favourite coffee mug. You might be surprised by what’s in our collection.
         </p>
       </header>
 


### PR DESCRIPTION
## Summary

One-line copy tweak in `templates/pages/scan.html`. The Snap It intro's second sentence was

> Try it on a watch on your wrist, a kettle, or a vintage poster.

Now reads

> Try it on a household item, the watch on your wrist, the wheel of a bicycle or your favourite coffee mug.

## Why

- **'A household item'** up front signals the feature isn't limited to specific kinds of objects — invites the visitor to try anything around them.
- **Possessives** ('the watch on your wrist', 'your favourite coffee mug') make the prompt feel like a direct invitation rather than a generic instruction.
- **'The wheel of a bicycle'** is an unexpected example that hints at the collection's breadth beyond science instruments (and we do hold quite a few bicycles in the collection).
- **'Coffee mug'** lands the playful framing — pedestrian, ubiquitous, the kind of thing visitors actually carry around.

## Test plan

- [ ] Visit `/scan` (Snap It page) on desktop and mobile, server-rendered, confirm the new copy reads naturally and doesn't wrap awkwardly
- [ ] SPA-navigate to `/scan` from another page — confirm the same intro renders (it's a server template re-rendered via `Templates.scan` on the client; same source string)

## Risk

Trivial. One sentence of body copy.