### PR TITLE
Snap It intro: shorten so capture button stays visible on mobile

### DIFF
--- a/templates/pages/scan.html
+++ b/templates/pages/scan.html
@@ -7,7 +7,7 @@
       <header class="scan__intro">
         <h1>Snap It</h1>
         <p>
-          Take a photo of something around you and we’ll show you what our collection has that looks similar. Try it on a household item, the watch on your wrist, the wheel of a bicycle or your favourite coffee mug. You might be surprised by what’s in our collection.
+          Take a photo of something around you and we’ll show you what our collection has that looks similar. Try it on a household item or the watch on your wrist. You might be surprised by what’s in our collection.
         </p>
       </header>
 


### PR DESCRIPTION
## Summary
- Trim the example list from four objects ("household item, the watch on your wrist, the wheel of a bicycle or your favourite coffee mug") to two ("a household item or the watch on your wrist") so the primary "Take a photo" button sits inside the visible viewport on phones without needing a small scroll up.

## Test plan
- [ ] Load `/scan` on a phone in portrait — confirm the "Take a photo" button is fully visible without scrolling.
- [ ] Desktop / tablet — confirm the shorter paragraph still reads naturally.