### PR TITLE
Add /snap vanity redirect to /scan

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -35,6 +35,7 @@ module.exports = (elastic, config) => [
   require('./wiki')(elastic, config),
   ...(config.visualSearchEnabled
     ? [
+        require('./redirects').snap(),
         require('./scan').page(elastic, config),
         require('./scan').search(elastic, config),
         require('./scan').health(elastic, config)

--- a/routes/redirects.js
+++ b/routes/redirects.js
@@ -34,5 +34,17 @@ module.exports = {
         return h.redirect(config.rootUrl + '/search/collection/daily-herald-archive').permanent();
       }
     };
+  },
+  snap () {
+    // Vanity URL for sharing (press releases, emails) — /snap reads
+    // better than /scan. Temporary redirect so the pointer can change
+    // without browsers caching it forever.
+    return {
+      method: 'GET',
+      path: '/snap',
+      handler: function (request, h) {
+        return h.redirect('/scan');
+      }
+    };
   }
 };

--- a/routes/redirects.js
+++ b/routes/redirects.js
@@ -38,12 +38,13 @@ module.exports = {
   snap () {
     // Vanity URL for sharing (press releases, emails) — /snap reads
     // better than /scan. Temporary redirect so the pointer can change
-    // without browsers caching it forever.
+    // without browsers caching it forever. Query strings carry over so
+    // UTM campaign parameters survive the redirect for GA attribution.
     return {
       method: 'GET',
       path: '/snap',
       handler: function (request, h) {
-        return h.redirect('/scan');
+        return h.redirect('/scan' + (request.url.search || ''));
       }
     };
   }


### PR DESCRIPTION
## Summary
- `/snap` now 302-redirects to `/scan`, giving us a nicer-looking URL for press releases and emails.
- One real page remains: `/scan` keeps the GTM pagename, client route, and template — `/snap` is just a pointer, added via the existing `routes/redirects.js` pattern.
- Registered inside the `visualSearchEnabled` block, so when the feature flag is off `/snap` 404s instead of redirecting to a dead page.
- Temporary (302) rather than permanent, so browsers don't cache the pointer forever if we ever repoint it.

## Test plan
- [x] `server.inject` GET `/snap` → `302` with `location: /scan`
- [x] `semistandard` clean on both changed files
- [ ] After deploy: visit `https://collection.sciencemuseumgroup.org.uk/snap` and confirm it lands on Snap It