### PR TITLE
Fix archive hierarchy truncation: fetch all fonds records via scroll API

### DIFF
--- a/lib/archive-tree.js
+++ b/lib/archive-tree.js
@@ -1,9 +1,22 @@
 module.exports = {
   sortChildren (data) {
+    // Index every node (including any pre-nested children) by id so each
+    // parent lookup is O(1) — the largest fonds has ~11.5k records, which
+    // made the previous recursive scan per node prohibitively slow.
+    const byId = new Map();
+    const stack = data.slice();
+    while (stack.length > 0) {
+      const node = stack.pop();
+      if (!byId.has(node.id)) byId.set(node.id, node);
+      if (node.children) stack.push(...node.children);
+    }
+
     data.forEach((el) => {
       if (el.parent) {
-        if (this.findNestedObject(data, el.parent[0]['@admin'].uid)) {
-          this.findNestedObject(data, el.parent[0]['@admin'].uid).children.push(el);
+        const parent = byId.get(el.parent[0]['@admin'].uid);
+        if (parent) {
+          if (!parent.children) parent.children = [];
+          parent.children.push(el);
         }
       }
     });

--- a/lib/cached-document.js
+++ b/lib/cached-document.js
@@ -26,7 +26,21 @@ module.exports = async (elastic, id, fondsId, sourceBody) => {
     if (!cache || !cache.isReady()) return null;
 
     try {
-      return await cache.get({ segment: CACHE_SEGMENT, id: fondsId });
+      const envelope = await cache.get({ segment: CACHE_SEGMENT, id: fondsId });
+      if (!envelope) return null;
+
+      // If the requested record was reprocessed upstream after the tree was
+      // cached, the cached hierarchy may be out of date — drop it and rebuild.
+      // sourceBody is optional; callers without it just get TTL-based expiry.
+      const admin = sourceBody && sourceBody._source && sourceBody._source['@admin'];
+      const processed = admin && admin.processed;
+      if (processed && processed > envelope.stored) {
+        console.info('Cached archive tree is stale, regenerating', { fondsId, processed, stored: envelope.stored });
+        await dropCache(fondsId);
+        return null;
+      }
+
+      return envelope;
     } catch (err) {
       console.warn('Cache get operation failed', { error: err.message, fondsId });
       return null;
@@ -37,7 +51,11 @@ module.exports = async (elastic, id, fondsId, sourceBody) => {
     const data = await getFullArchive(elastic, id, sourceBody);
     const tree = archiveTree.sortChildren(data);
 
-    if (!data.incomplete) {
+    if (data.incomplete) {
+      // Surface the flag to the route so the response isn't CDN-cached;
+      // it lives on the flat array and would otherwise be lost here.
+      tree.incomplete = true;
+    } else {
       try {
         await cacheDocument(fondsId, tree);
       } catch (err) {

--- a/lib/get-full-archive.js
+++ b/lib/get-full-archive.js
@@ -1,25 +1,36 @@
 const TypeMapping = require('./type-mapping.js');
 const config = require('../config');
 
-module.exports = async (elastic, id, count) => {
-  const body = {
-    size: count || 500,
-    query: {
-      constant_score: {
-        filter: {
-          bool: {
-            must: {
-              term: { 'fonds.@admin.uid': TypeMapping.toInternal(id) }
+const PAGE_SIZE = 1000;
+const SCROLL_TTL = '30s';
+const REQUEST_TIMEOUT = 5000;
+
+// Fetch every record belonging to a fonds. Large archives exceed both the old
+// single-request cap and ES's 10k result window (SMG Corporate Archive is
+// ~11.5k records), so results are paged with the scroll API. Throws if the
+// full set can't be retrieved — callers treat that as an incomplete tree and
+// skip caching it.
+module.exports = async (elastic, id) => {
+  const searchOpts = {
+    index: config.elasticIndex,
+    scroll: SCROLL_TTL,
+    body: {
+      size: PAGE_SIZE,
+      // Without this ES7 caps hits.total.value at 10000, which would silently
+      // end the loop early and defeat the completeness check below.
+      track_total_hits: true,
+      query: {
+        constant_score: {
+          filter: {
+            bool: {
+              must: {
+                term: { 'fonds.@admin.uid': TypeMapping.toInternal(id) }
+              }
             }
           }
         }
       }
-    }
-  };
-
-  const searchOpts = {
-    index: config.elasticIndex,
-    body,
+    },
     _source: [
       '@admin',
       'parent',
@@ -28,6 +39,34 @@ module.exports = async (elastic, id, count) => {
     ]
   };
 
-  const result = await elastic.search(searchOpts, { requestTimeout: 5000 });
-  return result.body.hits.hits;
+  let scrollId;
+  try {
+    let result = await elastic.search(searchOpts, { requestTimeout: REQUEST_TIMEOUT });
+    scrollId = result.body._scroll_id;
+    const total = result.body.hits.total.value;
+    const hits = result.body.hits.hits.slice();
+
+    while (hits.length < total && result.body.hits.hits.length > 0) {
+      result = await elastic.scroll(
+        { scroll_id: scrollId, scroll: SCROLL_TTL },
+        { requestTimeout: REQUEST_TIMEOUT }
+      );
+      scrollId = result.body._scroll_id || scrollId;
+      hits.push(...result.body.hits.hits);
+    }
+
+    if (hits.length < total) {
+      throw new Error(`Incomplete archive fetch for ${id}: got ${hits.length} of ${total} records`);
+    }
+
+    return hits;
+  } finally {
+    if (scrollId) {
+      try {
+        await elastic.clearScroll({ body: { scroll_id: scrollId } });
+      } catch (err) {
+        console.warn('clearScroll failed', { error: err.message, fondsId: id });
+      }
+    }
+  }
 };

--- a/routes/archive.js
+++ b/routes/archive.js
@@ -29,7 +29,16 @@ module.exports = (elastic, config) => ({
 
           const JSONData = Object.assign(buildJSONResponse(result.body, config), { tree: data });
 
-          return response(h, JSONData, 'archive', responseType);
+          const res = response(h, JSONData, 'archive', responseType);
+
+          // A degraded page (hierarchy fetch failed or was truncated) must not
+          // be pinned by CloudFront for the route's 24h TTL — send no-cache so
+          // it is retried until a complete tree renders.
+          if (data && data.incomplete) {
+            res.ttl(0);
+          }
+
+          return res;
         } catch (err) {
           return elasticError(err);
         }

--- a/test/archive-tree.test.js
+++ b/test/archive-tree.test.js
@@ -24,3 +24,18 @@ test('Sorting Nested Objects', function (t) {
   t.deepEqual(sorted.children[1].children.length, 2, 'sorting');
   t.end();
 });
+
+test('Flat input builds the full tree and drops orphans', function (t) {
+  t.plan(3);
+  const flat = [
+    { id: 'fonds-1' },
+    { id: 'series-1', identifier: 'S1', parent: [{ '@admin': { uid: 'fonds-1' } }] },
+    { id: 'item-1', identifier: 'I1', parent: [{ '@admin': { uid: 'series-1' } }] },
+    { id: 'orphan-1', identifier: 'O1', parent: [{ '@admin': { uid: 'missing-parent' } }] }
+  ];
+  const sorted = archiveTree.sortChildren(flat);
+  t.equal(sorted.children.length, 1, 'one series attached to the fonds');
+  t.equal(sorted.children[0].children[0].id, 'item-1', 'item attached under its series');
+  t.notOk(JSON.stringify(sorted).includes('orphan-1'), 'node with a missing parent is dropped');
+  t.end();
+});

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -8,6 +8,14 @@ const archiveTree = require('../lib/archive-tree');
 // Note: cache.start() is called in bin/server.mjs at startup, NOT here.
 // Tests control cache behaviour entirely via sinon stubs — no Redis required.
 
+// Shape of an ES scroll response page, as consumed by lib/get-full-archive.js
+const scrollPage = (hits, total) => ({
+  body: {
+    _scroll_id: 'scroll-1',
+    hits: { total: { value: total }, hits }
+  }
+});
+
 test('Get fonds data: cache miss falls back to Elasticsearch', async function (t) {
   t.plan(1);
   const cacheIsReady = stub(cache, 'isReady').returns(true);
@@ -23,6 +31,8 @@ test('Get fonds data: cache miss falls back to Elasticsearch', async function (t
       }
     }
   });
+  const elasticSearch = stub(elastic, 'search').resolves(scrollPage([], 0));
+  const elasticClearScroll = stub(elastic, 'clearScroll').resolves({});
 
   const data = await cachedDocument(elastic, 'smga-documents-110000013', 'smga-documents-110000003');
   t.ok(data, 'data returned from elasticsearch on cache miss');
@@ -30,6 +40,8 @@ test('Get fonds data: cache miss falls back to Elasticsearch', async function (t
   cacheGet.restore();
   cacheSet.restore();
   elasticGet.restore();
+  elasticSearch.restore();
+  elasticClearScroll.restore();
 });
 
 test('Get cached document: cache hit returns stored item', async function (t) {
@@ -60,6 +72,9 @@ test('Get child document data: falls back to Elasticsearch', async function (t) 
     }
   });
 
+  const elasticSearch = stub(elastic, 'search').resolves(scrollPage([], 0));
+  const elasticClearScroll = stub(elastic, 'clearScroll').resolves({});
+
   const archiveTreeSort = stub(archiveTree, 'sortChildren').callsFake(function (data) {
     return {};
   });
@@ -71,6 +86,8 @@ test('Get child document data: falls back to Elasticsearch', async function (t) 
   cacheGet.restore();
   cacheSet.restore();
   elasticGet.restore();
+  elasticSearch.restore();
+  elasticClearScroll.restore();
   archiveTreeSort.restore();
 });
 
@@ -163,9 +180,117 @@ test('Cache unavailable: falls back to Elasticsearch without error', async funct
       }
     }
   });
+  const elasticSearch = stub(elastic, 'search').resolves(scrollPage([], 0));
+  const elasticClearScroll = stub(elastic, 'clearScroll').resolves({});
 
   const data = await cachedDocument(elastic, 'smga-documents-110000013', 'smga-documents-110000003');
   t.ok(data, 'data returned from elasticsearch when cache is unavailable');
   cacheIsReady.restore();
   elasticGet.restore();
+  elasticSearch.restore();
+  elasticClearScroll.restore();
+});
+
+test('Truncated archive fetch is returned but never cached', async function (t) {
+  t.plan(3);
+  const cacheIsReady = stub(cache, 'isReady').returns(true);
+  const cacheGet = stub(cache, 'get').resolves(null);
+  const cacheSet = stub(cache, 'set').resolves();
+
+  const elasticGet = stub(elastic, 'get').resolves({
+    body: {
+      _source: {
+        level: { value: 'document' },
+        fonds: [{ '@admin': { uid: 'smga-documents-110000003' }, summary: { title: 'doc' } }],
+        summary: { title: 'doc' },
+        identifier: [{ value: 'BAB' }]
+      }
+    }
+  });
+
+  // First page returns 2 of 5 hits, then the scroll dries up — get-full-archive
+  // throws, cached-document marks the tree incomplete.
+  const elasticSearch = stub(elastic, 'search').resolves(scrollPage([
+    { _source: { '@admin': { uid: 'doc-1' } } },
+    { _source: { '@admin': { uid: 'doc-2' } } }
+  ], 5));
+  const elasticScroll = stub(elastic, 'scroll').resolves(scrollPage([], 5));
+  const elasticClearScroll = stub(elastic, 'clearScroll').resolves({});
+
+  const archiveTreeSort = stub(archiveTree, 'sortChildren').callsFake(function (data) {
+    return data;
+  });
+
+  const data = await cachedDocument(elastic, 'smga-documents-110000013', 'smga-documents-110000003');
+
+  t.ok(data, 'partial data still returned to the user');
+  t.ok(data.incomplete, 'tree is flagged incomplete for the route');
+  t.notOk(cacheSet.called, 'incomplete tree is not cached');
+
+  cacheIsReady.restore();
+  cacheGet.restore();
+  cacheSet.restore();
+  elasticGet.restore();
+  elasticSearch.restore();
+  elasticScroll.restore();
+  elasticClearScroll.restore();
+  archiveTreeSort.restore();
+});
+
+test('Stale cache entry (record processed after caching) is dropped and regenerated', async function (t) {
+  t.plan(3);
+  const cacheIsReady = stub(cache, 'isReady').returns(true);
+  const cacheGet = stub(cache, 'get').resolves({ item: 'old-tree', stored: 1000, ttl: 100000000 });
+  const cacheDrop = stub(cache, 'drop').resolves();
+  const cacheSet = stub(cache, 'set').resolves();
+
+  const elasticSearch = stub(elastic, 'search').resolves(scrollPage([], 0));
+  const elasticClearScroll = stub(elastic, 'clearScroll').resolves({});
+
+  const sourceBody = {
+    _source: {
+      '@admin': { processed: 2000 },
+      level: { value: 'fonds' },
+      summary: { title: 'doc' },
+      identifier: [{ value: 'BAB' }]
+    }
+  };
+
+  const data = await cachedDocument(elastic, 'smga-documents-110000013', 'smga-documents-110000003', sourceBody);
+
+  t.ok(cacheDrop.calledOnce, 'stale entry dropped from cache');
+  t.notEqual(data, 'old-tree', 'stale cached tree is not returned');
+  t.ok(cacheSet.calledOnce, 'regenerated tree is re-cached');
+
+  cacheIsReady.restore();
+  cacheGet.restore();
+  cacheDrop.restore();
+  cacheSet.restore();
+  elasticSearch.restore();
+  elasticClearScroll.restore();
+});
+
+test('Fresh cache entry (record processed before caching) is served without hitting Elasticsearch', async function (t) {
+  t.plan(2);
+  const cacheIsReady = stub(cache, 'isReady').returns(true);
+  const cacheGet = stub(cache, 'get').resolves({ item: 'cached-tree', stored: 2000, ttl: 100000000 });
+  const elasticSearch = stub(elastic, 'search').rejects(new Error('should not be called'));
+
+  const sourceBody = {
+    _source: {
+      '@admin': { processed: 1000 },
+      level: { value: 'fonds' },
+      summary: { title: 'doc' },
+      identifier: [{ value: 'BAB' }]
+    }
+  };
+
+  const data = await cachedDocument(elastic, 'smga-documents-110000013', 'smga-documents-110000003', sourceBody);
+
+  t.equal(data, 'cached-tree', 'cached tree returned');
+  t.notOk(elasticSearch.called, 'elasticsearch not queried on a fresh cache hit');
+
+  cacheIsReady.restore();
+  cacheGet.restore();
+  elasticSearch.restore();
 });

--- a/test/get-full-archive.test.js
+++ b/test/get-full-archive.test.js
@@ -1,0 +1,69 @@
+const test = require('tape');
+const stub = require('sinon').stub;
+const getFullArchive = require('../lib/get-full-archive');
+const elastic = require('./helpers/mock-database')();
+
+const scrollPage = (hits, total) => ({
+  body: {
+    _scroll_id: 'scroll-1',
+    hits: { total: { value: total }, hits }
+  }
+});
+
+const hit = (n) => ({ _source: { '@admin': { uid: `doc-${n}` } } });
+
+test('Scroll pagination accumulates all pages', async function (t) {
+  t.plan(4);
+  const search = stub(elastic, 'search').resolves(scrollPage([hit(1), hit(2)], 3));
+  const scroll = stub(elastic, 'scroll').resolves(scrollPage([hit(3)], 3));
+  const clearScroll = stub(elastic, 'clearScroll').resolves({});
+
+  const hits = await getFullArchive(elastic, 'aa110161630');
+
+  t.equal(hits.length, 3, 'all pages accumulated');
+  t.ok(search.calledOnce, 'initial search made once');
+  t.ok(scroll.calledWithMatch({ scroll_id: 'scroll-1' }), 'scroll continues from returned scroll id');
+  t.ok(clearScroll.calledOnce, 'scroll context cleared');
+
+  search.restore();
+  scroll.restore();
+  clearScroll.restore();
+});
+
+test('Truncated scroll throws instead of returning partial results', async function (t) {
+  t.plan(2);
+  const search = stub(elastic, 'search').resolves(scrollPage([hit(1), hit(2)], 5));
+  const scroll = stub(elastic, 'scroll').resolves(scrollPage([], 5));
+  const clearScroll = stub(elastic, 'clearScroll').resolves({});
+
+  try {
+    await getFullArchive(elastic, 'aa110161630');
+    t.fail('should have thrown on truncated fetch');
+  } catch (err) {
+    t.match(err.message, /Incomplete archive fetch/, 'throws an incomplete-fetch error');
+  }
+  t.ok(clearScroll.calledOnce, 'scroll context cleared even on failure');
+
+  search.restore();
+  scroll.restore();
+  clearScroll.restore();
+});
+
+test('Mid-scroll failure propagates and still clears the scroll context', async function (t) {
+  t.plan(2);
+  const search = stub(elastic, 'search').resolves(scrollPage([hit(1)], 3));
+  const scroll = stub(elastic, 'scroll').rejects(new Error('scroll timed out'));
+  const clearScroll = stub(elastic, 'clearScroll').resolves({});
+
+  try {
+    await getFullArchive(elastic, 'aa110161630');
+    t.fail('should have thrown on scroll failure');
+  } catch (err) {
+    t.equal(err.message, 'scroll timed out', 'scroll error propagates');
+  }
+  t.ok(clearScroll.calledOnce, 'scroll context cleared even on failure');
+
+  search.restore();
+  scroll.restore();
+  clearScroll.restore();
+});


### PR DESCRIPTION
## Problem

The hierarchy accordion on archive pages was showing only part of large archives — e.g. only 4 of 11 series for the [Campaign for Better Transport Archive](https://collection.sciencemuseumgroup.org.uk/documents/aa110162148), and similarly for the [Peter Handford Archive](https://collection.sciencemuseumgroup.org.uk/documents/aa110090603/peter-handford-archive) — even though all records exist in the CIIM index.

## Root cause

`lib/get-full-archive.js` fetched every record of a fonds in a **single ES query hard-capped at `size: 500`**, with no pagination:

- CFBT has **633** records, Peter Handford **1,822**, SMG Corporate Archive **11,480** (over ES's 10k `max_result_window`).
- An arbitrary 500 came back (`constant_score`, so no meaningful order), and the tree builder silently dropped any node whose parent wasn't in the fetched set — hence the live CFBT tree had 285 nodes / 4 series.
- Because the truncated query *succeeds*, the existing "don't cache incomplete trees" guard never fired, so the truncated tree was **cached in Redis for 24h** and pinned by **CloudFront for 24h** (origin-controlled policy).

It was not caused by timeouts — ES errors already skipped the Redis cache.

## Changes

- **`lib/get-full-archive.js`** — page through all records with the scroll API (1,000/page, 30s scroll TTL, 5s request timeout per page). `track_total_hits: true` is load-bearing: without it ES7 caps `hits.total.value` at 10,000 and both the loop bound and the completeness guard would silently break for the largest fonds. If fewer records than `hits.total` arrive, it **throws** — a truncated set is never again treated as complete. `clearScroll` is best-effort: the CIIM gateway (Kong) doesn't route `DELETE /_search/scroll`; contexts self-expire after 30s.
- **`lib/cached-document.js`** — staleness invalidation: if the requested record's `@admin.processed` is newer than the catbox `stored` timestamp, the cached tree is dropped and rebuilt (zero extra ES queries — the route already fetches the record). Also propagates the `incomplete` flag to the route.
- **`lib/archive-tree.js`** — tree build is now O(n) via an id→node map instead of a recursive scan per node (O(n²)). 24ms for the 11.5k-node fonds; the old code would have taken minutes at that size.
- **`routes/archive.js`** — degraded pages (hierarchy fetch failed) are served with `Cache-Control: no-cache` (`ttl(0)`) so CloudFront (Min TTL 0) revalidates instead of pinning them for 24h.

## Verification

- Against the live CIIM index: CFBT fetches **633/633 records, all 11 series** (243ms); SMG Corporate Archive fetches **11,480 records in ~1.8s** across 12 scroll pages, tree built in 24ms (6MB serialized — fine for Redis).
- Local server render of `/documents/aa110162148` shows all 11 CFBT series; `/documents/aa110090603` shows all 7 Peter Handford series (1,823 nodes).
- New tests: scroll pagination accumulation, truncation throws + not cached, mid-scroll failure still clears context, stale-cache drop/regenerate, fresh-cache served without ES, orphan-drop semantics. Full suite passes (the wiki test failures in a full run are the known pre-existing live-Wikidata-API flake, identical on master).

## Post-deploy ops

1. `GET /clearcache/documents/all` (token-protected) to flush the poisoned Redis entries.
2. CloudFront invalidation of `/documents/*` to purge truncated HTML pinned at the CDN.

(The `processed`-based invalidation would self-heal these over time, but a one-time flush is cleaner.)

## Notes / follow-ups

- The SMG Corporate Archive page now renders ~11.5k tree nodes server-side. The accordion collapses them visually, but the HTML is large — worth a look after deploy; lazy-loading deep branches client-side is the natural follow-up if it's sluggish.
- If the Kong gateway config is accessible, whitelisting `DELETE /_search/scroll` would silence the per-fetch `clearScroll failed` warning.