### PR TITLE
Fix archive tree auto-expansion below the second level

### DIFF
--- a/templates/partials/records/archive-tree-children.html
+++ b/templates/partials/records/archive-tree-children.html
@@ -5,7 +5,7 @@
     <button
       type="button"
       aria-controls="children-{{id}}"
-      aria-expanded="{{#if current}}true{{else}}false{{/if}}"
+      aria-expanded="{{#if (current this)}}true{{else}}false{{/if}}"
       aria-label="Show child records"></button>
     {{else}}
     <span class="archive-tree__leafnode"></span>
@@ -14,7 +14,7 @@
   </div>
   {{#if children}}
   <ul class="children" data-current="{{current this}}" id="children-{{id}}"
-    {{#if current}}{{else}}hidden{{/if}}>
+    {{#if (current this)}}{{else}}hidden{{/if}}>
     {{> records/archive-tree-children}}
   </ul>
   {{/if}}


### PR DESCRIPTION
## Problem

The archive tree browser only auto-opens to the first level below the root. Deeply nested records — e.g. [aa110151912](https://collection.sciencemuseumgroup.org.uk/documents/aa110151912) (`CORP/SCM/06/01/35/18034`) — appear collapsed at `CORP/SCM`, and the reader has to manually expand each level to find the record they're already viewing.

## Root cause

Two templates render the tree, with inconsistent expansion conditions:

- `archive-tree.html` (root + first level) uses the **subexpression** `{{#if (current this)}}`, which correctly calls the `current` helper — "is this node, or any of its descendants, the record being viewed?"
- `archive-tree-children.html` (every deeper level, recursive) used `{{#if current}}` — in Handlebars a bare identifier in argument position is a **property lookup** (`this.current`), never a helper call. Tree nodes have no `current` property, so the condition was always false and every `<ul>` below the second level always rendered `hidden`.

The bug has been present since the tree browser was introduced (`531582a4`). On large archives it was masked by the `size: 500` truncation fixed in #2175 — the deep nodes were often missing from the tree entirely, so there was nothing to fail to expand.

## Change

Two-line fix in `templates/partials/records/archive-tree-children.html`: `{{#if current}}` → `{{#if (current this)}}` for both the `aria-expanded` button state and the `hidden` attribute, matching `archive-tree.html`. (The label-highlighting call on line 3 already used the correct helper form, which is why the current record was highlighted but not revealed.)

## Verification

- Local render of `/documents/aa110151912` (SMG Corporate Archive, 11.5k nodes, 5 levels deep): full ancestor chain now visible — previously the two deepest ancestor `<ul>`s rendered `hidden`. Only the path to the record is expanded (12 visible `<ul>`s on the whole page), and `aria-expanded` on the path buttons matches.
- Spot-check on a second archive (CFBT, `/documents/aa110162148`): path expanded correctly.
- No measurable render-time change on the largest archive page (the `current` helper was already called per node for label highlighting).