### PR TITLE
Group visual-search build tooling and add a README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,7 +80,6 @@ builds/*
 !builds/.gitkeep
 
 # Visual search build artefacts (large; uploaded manually to /models/ on the CDN)
-scripts/visual-search-out/
 scripts/visual-search-build/out/
 scripts/visual-search-build/out-*/
 scripts/visual-search-build/image-cache/

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "index-update:galleries": "node scripts/get-galleries.mjs",
     "postinstall": "run-s build minify fingerprint && node nightwatch.conf.js",
     "package": "run-s build minify fingerprint package:zip",
-    "package:zip": "rm -f builds/collectionsonline.zip && zip -q -x '.git*' -x '.npmrc' -x '.corc' -x 'builds/*' -x '.claude/*' -x 'scripts/visual-search-build/.venv/*' -x 'scripts/visual-search-build/image-cache/*' -x 'scripts/visual-search-build/out/*' -x 'scripts/visual-search-build/out-*/*' -x 'scripts/visual-search-build/__pycache__/*' -x 'scripts/visual-search-build/**/__pycache__/*' -x 'scripts/visual-search-build/*.log' -x 'scripts/visual-search-out/*' -r builds/collectionsonline.zip .",
+    "package:zip": "rm -f builds/collectionsonline.zip && zip -q -x '.git*' -x '.npmrc' -x '.corc' -x 'builds/*' -x '.claude/*' -x 'scripts/visual-search-build/.venv/*' -x 'scripts/visual-search-build/image-cache/*' -x 'scripts/visual-search-build/out/*' -x 'scripts/visual-search-build/out-*/*' -x 'scripts/visual-search-build/__pycache__/*' -x 'scripts/visual-search-build/**/__pycache__/*' -x 'scripts/visual-search-build/*.log' -r builds/collectionsonline.zip .",
     "fingerprint": "node scripts/fingerprint.js",
     "start": "node bin/server.mjs",
     "test": "run-s test:*",

--- a/scripts/visual-search-build/README.md
+++ b/scripts/visual-search-build/README.md
@@ -7,8 +7,7 @@ here.
 
 > This README covers **how to run the pipeline** only. Internal decisions,
 > validation/recall numbers, and calibrated thresholds are deliberately kept
-> out of this public repo — they live in the private plan file referenced at
-> the bottom.
+> out of this public repo. Ask Jamie if you need that context.
 
 ## Pipeline at a glance
 
@@ -119,5 +118,4 @@ the app (or the affected instances) to pick up a new index.
 ## Internal notes
 
 Decisions, validation/recall results, threshold calibration, and infra notes
-are **not** in this repo (it's public). They live in the private plan file
-under `~/.claude/plans/` — ask Jamie if you need it.
+are **not** in this repo (it's public). Ask Jamie if you need that context.

--- a/scripts/visual-search-build/README.md
+++ b/scripts/visual-search-build/README.md
@@ -1,0 +1,123 @@
+# Visual search — index build tooling
+
+Offline tooling that builds the CLIP embedding index behind the "Snap It"
+visual search feature (`/scan`). Run these to (re)build the index when the
+catalogue changes enough to matter; the running app never invokes anything
+here.
+
+> This README covers **how to run the pipeline** only. Internal decisions,
+> validation/recall numbers, and calibrated thresholds are deliberately kept
+> out of this public repo — they live in the private plan file referenced at
+> the bottom.
+
+## Pipeline at a glance
+
+```
+  visual-search-feed.mjs        build_index.py                 manual upload
+  (Node, local)                 (Python, Colab GPU)            (you)
+┌────────────────────┐   ┌─────────────────────────────┐   ┌──────────────────┐
+│ Scroll ES for      │   │ Fetch each image, run CLIP,  │   │ Put the two files │
+│ objects with an    │ → │ L2-normalise, write:         │ → │ on the CDN under  │
+│ image → feed.jsonl │   │  • embeddings.bin            │   │ /models/ so the   │
+│                    │   │  • manifest.json             │   │ app loads them at │
+│                    │   │ (rows aligned 1:1)           │   │ startup           │
+└────────────────────┘   └─────────────────────────────┘   └──────────────────┘
+```
+
+The one hard invariant: the **model and preprocessing must match on both
+sides**. The offline embedder uses OpenCLIP `ViT-B-32-quickgelu` with the
+`openai` weights; the browser uses `Xenova/clip-vit-base-patch32` (a port of
+the same OpenAI weights). Changing one without the other silently breaks
+search quality — see the parity check below.
+
+## Files in this folder
+
+| File | Role |
+|------|------|
+| `visual-search-feed.mjs` | Step 1. Node script; scrolls Elasticsearch and emits one JSONL line (`object_id`, `title`, `image_url`) per object that has a usable image. |
+| `build_index.py` | Step 2. Python embedder; reads the feed, fetches + embeds each image, writes `embeddings.bin` + `manifest.json`. |
+| `build_index.ipynb` | Colab notebook wrapper around `build_index.py` for the full GPU run. |
+| `requirements.txt` | Python deps for `build_index.py` / `round_trip_check.py`. |
+| `round_trip_check.py` | Parity checker; embeds one image in Python so you can compare against the vector the browser POSTs. |
+| `README.md` | This file. |
+
+Build outputs (`out/`, `image-cache/`, `.venv/`, checkpoints, logs) are all
+gitignored.
+
+## Prerequisites
+
+- **Node** — use the repo's existing install (`npm ci` at the repo root). The
+  feed script reuses `config.js` and helpers from `lib/`.
+- **Elasticsearch access** — the feed script reads the same ES config as the
+  app (`.corc` or the usual `ELASTIC_*` env vars). It refuses to run if the ES
+  host is unset.
+- **Python 3.10+** — for the embedder. `pip install -r requirements.txt`
+  (Colab already has torch/numpy/pillow/tqdm; you only add `open_clip_torch`
+  and `httpx` there).
+
+## Step 1 — generate the feed (local, Node)
+
+```bash
+# Full catalogue
+node scripts/visual-search-build/visual-search-feed.mjs
+
+# Small cap for a dev/smoke build
+node scripts/visual-search-build/visual-search-feed.mjs --limit 5000
+
+# Custom output path (default: scripts/visual-search-build/out/feed.jsonl)
+node scripts/visual-search-build/visual-search-feed.mjs --out /tmp/feed.jsonl
+```
+
+Prints a summary (considered / emitted / skipped) on completion. The default
+output lands in the gitignored `out/` dir next to the embedder's output.
+
+## Step 2 — build the index
+
+**Full ~250k build → Colab GPU.** Open `build_index.ipynb`, switch the runtime
+to GPU, run all cells; it prompts you to upload `build_index.py` and your
+`feed.jsonl`, runs the build, verifies the outputs, and downloads
+`embeddings.bin` + `manifest.json`. HTTP image fetches usually dominate the
+first run; a warm image cache makes re-runs much faster.
+
+**Dev/smoke build → local Mac.** Slow on CPU/MPS but fine for a sanity check:
+
+```bash
+pip install -r scripts/visual-search-build/requirements.txt
+
+python scripts/visual-search-build/build_index.py \
+    --input  scripts/visual-search-build/out/feed.jsonl \
+    --output-dir scripts/visual-search-build/out \
+    --limit 200
+```
+
+`build_index.py --help` lists all flags (batch size, concurrency, device,
+model/pretrained overrides). The output byte count is checked against
+`rows × dim × 4` before it exits, so a truncated write fails loudly.
+
+## Step 3 — verify parity (do this whenever the model changes)
+
+The highest-risk failure mode is the offline embeddings drifting from what the
+browser produces. To check:
+
+```bash
+python scripts/visual-search-build/round_trip_check.py --image /path/to/photo.jpg
+```
+
+It prints the first 16 components of the L2-normalised vector. Drop the same
+image on `/scan` in a browser, grab the vector it POSTs to
+`/api/scan/search` (DevTools → Network → request payload, 4 bytes per
+float, little-endian), and confirm the two agree to ~3 decimal places. Large
+diffs mean the model or preprocessing is out of sync between the two sides.
+
+## Step 4 — publish
+
+Upload `embeddings.bin` and `manifest.json` to the `/models/` path on the
+image CDN (the base URL is `visualSearchModelsBaseUrl` in `config.js`, settable
+via `VISUAL_SEARCH_MODELS_BASE_URL`). The app fetches both at startup; restart
+the app (or the affected instances) to pick up a new index.
+
+## Internal notes
+
+Decisions, validation/recall results, threshold calibration, and infra notes
+are **not** in this repo (it's public). They live in the private plan file
+under `~/.claude/plans/` — ask Jamie if you need it.

--- a/scripts/visual-search-build/build_index.ipynb
+++ b/scripts/visual-search-build/build_index.ipynb
@@ -3,20 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "# Visual search — full index build (Colab)\n",
-    "\n",
-    "Run this on a Colab GPU runtime to build `embeddings.bin` + `manifest.json` for the full ~250k object catalogue.\n",
-    "\n",
-    "Workflow:\n",
-    "1. Switch the runtime to GPU (`Runtime → Change runtime type → T4` or A100).\n",
-    "2. Run all cells in order.\n",
-    "3. When prompted, upload **two files**: `build_index.py` and a `feed.jsonl` produced locally by `node scripts/visual-search-feed.mjs`.\n",
-    "4. The build runs (~5–15 min on T4 once HTTP fetches catch up; HTTP usually dominates).\n",
-    "5. The final cell downloads `embeddings.bin` and `manifest.json` to your Mac. Upload those to `coimages.../models/` manually.\n",
-    "\n",
-    "Internal docs live in the plan file at `~/.claude/plans/users-jamieunwin-downloads-visual-searc-splendid-pebble.md` (do **not** add internal decisions to the public repo)."
-   ]
+   "source": "# Visual search — full index build (Colab)\n\nRun this on a Colab GPU runtime to build `embeddings.bin` + `manifest.json` for the full ~250k object catalogue.\n\nWorkflow:\n1. Switch the runtime to GPU (`Runtime → Change runtime type → T4` or A100).\n2. Run all cells in order.\n3. When prompted, upload **two files**: `build_index.py` and a `feed.jsonl` produced locally by `node scripts/visual-search-build/visual-search-feed.mjs`.\n4. The build runs (~5–15 min on T4 once HTTP fetches catch up; HTTP usually dominates).\n5. The final cell downloads `embeddings.bin` and `manifest.json` to your Mac. Upload those to `coimages.../models/` manually.\n\nSee `README.md` in this folder for the full pipeline. Internal decisions and validation numbers live in the private plan file (do **not** add them to this public repo)."
   },
   {
    "cell_type": "markdown",
@@ -55,11 +42,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## 3. Upload `build_index.py` and `feed.jsonl`\n",
-    "\n",
-    "The Python script is the same one that lives in the repo at `scripts/visual-search-build/build_index.py`. The JSONL is whatever you produced locally with `node scripts/visual-search-feed.mjs`."
-   ]
+   "source": "## 3. Upload `build_index.py` and `feed.jsonl`\n\nThe Python script is the same one that lives in the repo at `scripts/visual-search-build/build_index.py`. The JSONL is whatever you produced locally with `node scripts/visual-search-build/visual-search-feed.mjs`."
   },
   {
    "cell_type": "code",

--- a/scripts/visual-search-build/build_index.ipynb
+++ b/scripts/visual-search-build/build_index.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "# Visual search — full index build (Colab)\n\nRun this on a Colab GPU runtime to build `embeddings.bin` + `manifest.json` for the full ~250k object catalogue.\n\nWorkflow:\n1. Switch the runtime to GPU (`Runtime → Change runtime type → T4` or A100).\n2. Run all cells in order.\n3. When prompted, upload **two files**: `build_index.py` and a `feed.jsonl` produced locally by `node scripts/visual-search-build/visual-search-feed.mjs`.\n4. The build runs (~5–15 min on T4 once HTTP fetches catch up; HTTP usually dominates).\n5. The final cell downloads `embeddings.bin` and `manifest.json` to your Mac. Upload those to `coimages.../models/` manually.\n\nSee `README.md` in this folder for the full pipeline. Internal decisions and validation numbers live in the private plan file (do **not** add them to this public repo)."
+   "source": "# Visual search — full index build (Colab)\n\nRun this on a Colab GPU runtime to build `embeddings.bin` + `manifest.json` for the full ~250k object catalogue.\n\nWorkflow:\n1. Switch the runtime to GPU (`Runtime → Change runtime type → T4` or A100).\n2. Run all cells in order.\n3. When prompted, upload **two files**: `build_index.py` and a `feed.jsonl` produced locally by `node scripts/visual-search-build/visual-search-feed.mjs`.\n4. The build runs (~5–15 min on T4 once HTTP fetches catch up; HTTP usually dominates).\n5. The final cell downloads `embeddings.bin` and `manifest.json` to your Mac. Upload those to `coimages.../models/` manually.\n\nSee `README.md` in this folder for the full pipeline. Internal decisions and validation numbers are deliberately kept out of this public repo — ask Jamie if you need that context."
   },
   {
    "cell_type": "markdown",

--- a/scripts/visual-search-build/build_index.py
+++ b/scripts/visual-search-build/build_index.py
@@ -1,7 +1,7 @@
 """Build the visual-search embedding index from a JSONL feed.
 
 Inputs:
-  --input  feed.jsonl    JSONL produced by scripts/visual-search-feed.mjs
+  --input  feed.jsonl    JSONL produced by visual-search-feed.mjs (same folder)
                          each line: {"object_id", "title", "image_url"}
 
 Outputs (in --output-dir):

--- a/scripts/visual-search-build/visual-search-feed.mjs
+++ b/scripts/visual-search-build/visual-search-feed.mjs
@@ -1,15 +1,16 @@
 // Walk the Elasticsearch catalogue and emit one JSONL line per object that
-// has at least one usable image. The output is the input to the Python
-// embedder in scripts/visual-search-build/.
+// has at least one usable image. This is step 1 of the build pipeline; the
+// output is the input to the Python embedder (build_index.py) in this same
+// folder. See README.md for the full pipeline.
 //
 // Each emitted line:
 //   { "object_id": "co154990", "title": "Thumbscrew, France, 1601-1850",
 //     "image_url": "https://coimages.../medium_a67686__0002_.jpg" }
 //
 // Usage:
-//   node scripts/visual-search-feed.mjs                 # full run
-//   node scripts/visual-search-feed.mjs --limit 5000    # cap for dev
-//   node scripts/visual-search-feed.mjs --out feed.jsonl
+//   node scripts/visual-search-build/visual-search-feed.mjs               # full run
+//   node scripts/visual-search-build/visual-search-feed.mjs --limit 5000  # cap for dev
+//   node scripts/visual-search-build/visual-search-feed.mjs --out feed.jsonl
 //
 // Reuses lib/helpers/jsonapi-response/sort-images.js for the canonical
 // first-image picker (position-then-upload-date sort) — do not reimplement.
@@ -21,9 +22,9 @@ import path from 'path';
 import fs from 'fs';
 
 const require = createRequire(import.meta.url);
-const config = require('../config');
-const sortImages = require('../lib/helpers/jsonapi-response/sort-images');
-const TypeMapping = require('../lib/type-mapping');
+const config = require('../../config');
+const sortImages = require('../../lib/helpers/jsonapi-response/sort-images');
+const TypeMapping = require('../../lib/type-mapping');
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -35,12 +36,13 @@ function parseArgs (argv) {
     if (a === '--limit') out.limit = parseInt(argv[++i], 10);
     else if (a === '--out') out.outPath = argv[++i];
     else if (a === '--help' || a === '-h') {
-      console.log('Usage: node scripts/visual-search-feed.mjs [--limit N] [--out path]');
+      console.log('Usage: node scripts/visual-search-build/visual-search-feed.mjs [--limit N] [--out path]');
       process.exit(0);
     }
   }
   if (out.outPath == null) {
-    out.outPath = path.join(__dirname, 'visual-search-out', 'feed.jsonl');
+    // Default alongside the embedder's output, in the gitignored out/ dir.
+    out.outPath = path.join(__dirname, 'out', 'feed.jsonl');
   }
   return out;
 }


### PR DESCRIPTION
## Summary
All the offline visual-search ("Snap It") build tooling now lives in one folder, with a README tying the pieces together. No app runtime code is touched — these scripts are build-time only.

- **Move** `scripts/visual-search-feed.mjs` → `scripts/visual-search-build/visual-search-feed.mjs` (git rename, history preserved). Fixed its `../` requires to `../../` and updated its usage strings.
- **Default feed output** is now `scripts/visual-search-build/out/feed.jsonl`, co-located with the embedder's output and already gitignored. Removed the now-dead `scripts/visual-search-out/` ignore entry and `package:zip` exclusion.
- **Updated** the two path references to the feed script in `build_index.py` and `build_index.ipynb`.
- **New README** documents the feed → embed → verify → upload pipeline. It is deliberately **mechanical only** — internal decisions, validation/recall numbers, and threshold calibration stay in the private plan file, not this public repo (matches the existing note in the notebook).

## Why
The feed generator was the odd one out at the top of `scripts/`; the embedder, Colab notebook, and parity checker were already grouped in `scripts/visual-search-build/`. There was also no single doc explaining how to rebuild the index — only inline docstrings.

## Test plan
- [x] `node --check` on the moved `.mjs` passes; its `../../` requires resolve to real files (`config.js`, `lib/helpers/jsonapi-response/sort-images.js`, `lib/type-mapping.js`)
- [x] `semistandard` clean on the moved file
- [x] `package.json` still valid JSON; notebook still valid JSON with all 6 code cells intact
- [x] No lingering references to the old `scripts/visual-search-feed.mjs` path or dead `visual-search-out/` dir anywhere in the repo
- [ ] Reviewer sanity-check: README contains no internal/sensitive detail that shouldn't be in a public repo