### PR TITLE
Use the sorted primary image for search result card thumbnails

### DIFF
--- a/lib/helpers/jsonapi-response/sort-images.js
+++ b/lib/helpers/jsonapi-response/sort-images.js
@@ -7,9 +7,15 @@ const orderBy = require('lodash/orderBy');
 */
 
 module.exports = function (images) {
+  // Guard `@processed`: not every multimedia entry carries a processed
+  // derivative (an image still processing, a non-image asset). A missing
+  // `@processed` here would throw and, for callers in the search path,
+  // surface as a 503 for the whole response. `Date.parse(undefined)` is
+  // NaN, which orderBy sorts to a consistent position — such entries have
+  // no thumbnail to display anyway.
   const sorted = orderBy(images, [
     i => parseInt(i.position?.value) || 9999,
-    i => Date.parse(i['@processed'].upload_sort)
+    i => Date.parse(i['@processed']?.upload_sort)
   ], ['asc', 'desc']);
 
   return sorted;

--- a/lib/transforms/search-results-to-jsonapi.js
+++ b/lib/transforms/search-results-to-jsonapi.js
@@ -10,6 +10,40 @@ const slug = require('slugg');
 const sortImages = require('../helpers/jsonapi-response/sort-images.js');
 const stripInternalNotes = require('../helpers/strip-internal-notes.js');
 
+// Prepare a result's multimedia for the card thumbnail.
+//
+// Results cards show a single figure. Downstream, getFigure
+// (search-results-to-template-data.js) picks the first multimedia entry
+// that has a processed card thumbnail, so here we:
+//   1. sort the images into display-priority order — the same order the
+//      record page uses (lib/jsonapi-response.js sorts identically) — so
+//      the card leads with the record's primary image instead of whatever
+//      order Elasticsearch happened to return; and
+//   2. prepend the media host to *that one* card image's thumbnail path.
+//      Its <img src> points at a separate media host, so a bare path
+//      won't resolve. Every other location in the payload (the other
+//      derivatives, and other entries) is left as the relative path
+//      Elasticsearch returned — nothing else here is ever rendered, and
+//      resolving them would only add to an already-mixed passthrough. The
+//      fully-resolved image shape lives on the record /api (getImagePaths).
+//
+// The previous code hard-coded multimedia[0] and read
+// `[0]['@processed'].large_thumbnail` without guarding `@processed`. That
+// both hid a valid thumbnail whenever the raw-first image lacked one (a
+// later image still had it) and risked throwing on entries with no
+// processed derivative. Every access here is guarded.
+function withCardThumbnails (multimedia, mediaPath) {
+  const sorted = sortImages(multimedia);
+  const cardImage = sorted.find(
+    (image) => image?.['@processed']?.large_thumbnail?.location
+  );
+  if (cardImage) {
+    cardImage['@processed'].large_thumbnail.location =
+      mediaPath + cardImage['@processed'].large_thumbnail.location;
+  }
+  return sorted;
+}
+
 module.exports = (queryParams, results, config, mphcParent) => {
   results = results || {};
   config = config || {};
@@ -92,13 +126,9 @@ const createResource = {
         if (key === 'legal' && checkPurchased(attrs, key)) {
           delete attrs[key].credit_line;
         }
-        // Adds image host to path
-        if (key === 'multimedia' && hit._source.multimedia) {
-          const sortedImages = sortImages(hit._source.multimedia);
-          if (attrs[key][0]['@processed'].large_thumbnail?.location) {
-            attrs[key][0]['@processed'].large_thumbnail.location =
-              mediaPath + sortedImages[0]['@processed'].large_thumbnail?.location;
-          }
+        // Sort images and add the media host to the card thumbnail paths
+        if (key === 'multimedia' && Array.isArray(hit._source.multimedia)) {
+          attrs[key] = withCardThumbnails(hit._source.multimedia, mediaPath);
         }
       }
       return attrs;
@@ -187,13 +217,9 @@ const createResource = {
     ].reduce((attrs, key) => {
       if (hit._source && hit._source[key]) {
         attrs[key] = hit._source[key];
-        // Adds image host to path
-        if (key === 'multimedia' && hit._source.multimedia) {
-          const sortedImages = sortImages(hit._source.multimedia);
-          if (sortedImages[0]['@processed'] && sortedImages[0]['@processed'].large_thumbnail) {
-            attrs[key][0]['@processed'].large_thumbnail.location =
-              mediaPath + sortedImages[0]['@processed'].large_thumbnail.location;
-          }
+        // Sort images and add the media host to the card thumbnail paths
+        if (key === 'multimedia' && Array.isArray(hit._source.multimedia)) {
+          attrs[key] = withCardThumbnails(hit._source.multimedia, mediaPath);
         }
       }
       return attrs;
@@ -259,11 +285,9 @@ const createResource = {
         if (key === 'legal' && checkPurchased(attrs, key)) {
           delete attrs[key].credit_line;
         }
-        // Adds image host to path
-        if (key === 'multimedia' && hit._source.multimedia) {
-          const sortedImages = sortImages(hit._source.multimedia);
-          attrs[key][0]['@processed'].large_thumbnail.location =
-            mediaPath + sortedImages[0]['@processed'].large_thumbnail.location;
+        // Sort images and add the media host to the card thumbnail paths
+        if (key === 'multimedia' && Array.isArray(hit._source.multimedia)) {
+          attrs[key] = withCardThumbnails(hit._source.multimedia, mediaPath);
         }
         // Adds image host to child records. Children come from related
         // collection items on a group record; not all of them have a

--- a/lib/transforms/search-results-to-template-data.js
+++ b/lib/transforms/search-results-to-template-data.js
@@ -244,11 +244,20 @@ function getOccupation (item) {
 }
 
 function getFigure (item, config) {
-  const location = getNestedProperty(
-    item,
-    'attributes.multimedia.0.@processed.large_thumbnail.location'
+  // The multimedia array is already sorted into display order by the
+  // JSONAPI transform. Use the first entry that actually has a card
+  // thumbnail rather than assuming index 0 has one — the primary image
+  // may be a non-image asset or still processing while a later image is
+  // ready, in which case the card should still show that later thumbnail.
+  const multimedia = getNestedProperty(item, 'attributes.multimedia');
+  if (!Array.isArray(multimedia)) return null;
+  const withThumbnail = multimedia.find((image) =>
+    getNestedProperty(image, '@processed.large_thumbnail.location')
   );
-  return location || null;
+  return (
+    getNestedProperty(withThumbnail, '@processed.large_thumbnail.location') ||
+    null
+  );
 }
 
 function getFigCaption (item) {

--- a/test/transforms/search-results-to-jsonapi.test.js
+++ b/test/transforms/search-results-to-jsonapi.test.js
@@ -598,3 +598,158 @@ test(
     t.end();
   }
 );
+
+// Shared aggregations block so the meta/count builders don't throw.
+function withAggregations (testResult) {
+  testResult.body.aggregations = {
+    total_categories: {
+      doc_count: 1,
+      documents: { doc_count: 0, documents_total: [{ value: 0 }] },
+      objects: { doc_count: 1, objects_total: [{ value: 1 }] },
+      people: { doc_count: 0, people_total: [{ value: 0 }] },
+      group: { doc_count: 0, group_total: [{ value: 0 }] },
+      all: {
+        doc_count: 1,
+        all_total: {
+          doc_count_error_upper_bound: 0,
+          sum_other_doc_count: 0,
+          buckets: [{ key: 'object', doc_count: 1 }]
+        }
+      }
+    }
+  };
+  testResult.body.aggregations.all = aggregationsAll;
+  testResult.body.aggregations.people = aggregationsPeople;
+  testResult.body.aggregations.objects = aggregationsObjects;
+  testResult.body.aggregations.documents = aggregationsDocuments;
+  testResult.body.aggregations.group = aggregationsGroup;
+  return testResult;
+}
+
+const mediaConfig = { mediaPath: 'https://media.test/' };
+
+test(
+  file + 'Should sort multimedia and prepend the media host to card thumbnails',
+  (t) => {
+    t.plan(3);
+
+    const testResult = withAggregations({
+      body: {
+        hits: {
+          total: { value: 1 },
+          max_score: null,
+          hits: [
+            {
+              _id: `smg-object-${Date.now()}`,
+              _source: {
+                '@datatype': { base: 'object' },
+                summary: { title: 'sortable multimedia object' },
+                multimedia: [
+                  {
+                    // First in ES order but position 5 — should sort last
+                    position: { value: '5' },
+                    '@processed': {
+                      upload_sort: '2016-01-01',
+                      large_thumbnail: { location: 'secondary.jpg' }
+                    }
+                  },
+                  {
+                    // Position 1 — the primary display image
+                    position: { value: '1' },
+                    '@processed': {
+                      upload_sort: '2015-01-01',
+                      large_thumbnail: { location: 'primary.jpg' }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    });
+
+    const query = queryParams('html', {
+      query: { q: 'test', 'page[number]': 0, 'page[size]': 1 },
+      params: {}
+    });
+
+    const obj = searchResultsToJsonApi(query, testResult, mediaConfig);
+    const multimedia = obj.data[0].attributes.multimedia;
+
+    t.equal(
+      multimedia[0]['@processed'].large_thumbnail.location,
+      'https://media.test/primary.jpg',
+      'Primary (position 1) image is first, with the media host prepended'
+    );
+    t.equal(
+      multimedia[1]['@processed'].large_thumbnail.location,
+      'secondary.jpg',
+      'Non-card entry keeps its relative Elasticsearch path (host not prepended)'
+    );
+    t.equal(
+      multimedia.length,
+      2,
+      'No multimedia entries were dropped'
+    );
+    t.end();
+  }
+);
+
+test(
+  file +
+    'Should not throw and still resolves a thumbnail when the first ' +
+    'multimedia entry has no processed derivative',
+  (t) => {
+    t.plan(2);
+
+    const testResult = withAggregations({
+      body: {
+        hits: {
+          total: { value: 1 },
+          max_score: null,
+          hits: [
+            {
+              _id: `smg-object-${Date.now()}`,
+              _source: {
+                '@datatype': { base: 'object' },
+                summary: { title: 'partially processed multimedia object' },
+                multimedia: [
+                  {
+                    // Still processing — no @processed block at all
+                    position: { value: '2' }
+                  },
+                  {
+                    position: { value: '1' },
+                    '@processed': {
+                      upload_sort: '2015-01-01',
+                      large_thumbnail: { location: 'ready.jpg' }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    });
+
+    const query = queryParams('html', {
+      query: { q: 'test', 'page[number]': 0, 'page[size]': 1 },
+      params: {}
+    });
+
+    let obj;
+    t.doesNotThrow(() => {
+      obj = searchResultsToJsonApi(query, testResult, mediaConfig);
+    }, 'Transform did not throw on an unprocessed multimedia entry');
+
+    const multimedia = obj.data[0].attributes.multimedia;
+    t.equal(
+      multimedia[0]['@processed'].large_thumbnail.location,
+      'https://media.test/ready.jpg',
+      'The processed image sorts to the front with the media host prepended'
+    );
+    t.end();
+  }
+);

--- a/test/transforms/search-results-to-templates.test.js
+++ b/test/transforms/search-results-to-templates.test.js
@@ -138,6 +138,60 @@ test(file + 'Object template data is correctly built', (t) => {
   t.end();
 });
 
+test(
+  file + 'Object figure uses the first multimedia entry that has a thumbnail',
+  (t) => {
+    t.plan(1);
+
+    const figureTestResult = {
+      body: {
+        hits: {
+          total: 1,
+          max_score: null,
+          hits: [
+            {
+              _id: `smg-object-${Date.now()}`,
+              _source: {
+                '@datatype': { base: 'object' },
+                summary: { title: 'object with an unprocessed lead image' },
+                multimedia: [
+                  {
+                    // Primary image, still processing — no thumbnail yet
+                    position: { value: '1' }
+                  },
+                  {
+                    position: { value: '2' },
+                    '@processed': {
+                      upload_sort: '2015-01-01',
+                      large_thumbnail: { location: 'ready.jpg' }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        aggregations: testResult.body.aggregations
+      }
+    };
+
+    const figureJsonData = searchResultsToJsonApi(query, figureTestResult, {
+      mediaPath: 'https://media.test/'
+    });
+    const templateData = searchToTemplate(query, figureJsonData);
+    const objectResult = templateData.results.find(
+      (el) => el.type === 'objects'
+    );
+
+    t.equal(
+      objectResult.figure,
+      'https://media.test/ready.jpg',
+      'figure falls back to the first image that has a card thumbnail'
+    );
+    t.end();
+  }
+);
+
 // test(file + 'Group template data is correctly built', (t) => {
 //   t.plan(4);
 //   t.doesNotThrow(() => {


### PR DESCRIPTION
## Problem

A search result card could render **without a thumbnail even though the record itself has images**.

Result cards resolved the card thumbnail from the **raw first multimedia entry** (`multimedia[0]`) in Elasticsearch order, whereas the record page sorts the images and shows any processed one. So when the raw‑first image had no processed `large_thumbnail` (a non‑image asset, or an image still processing) while a later image did, the card came up blank.

## Change

In the search transform (`search-results-to-jsonapi.js`), for object / document / group results:

- **Sort** `multimedia` into display‑priority order — the same order the record page uses (`lib/jsonapi-response.js` sorts identically), so the card leads with the record's primary image instead of arbitrary ES order.
- Resolve the media host on **only the one image the card renders** — the first sorted entry that has a `large_thumbnail`.

In `search-results-to-template-data.js`, `getFigure` now selects that same **first‑with‑thumbnail** entry instead of hard‑coding index `0`, so the card still shows a thumbnail when the primary image has no card derivative.

`lib/helpers/jsonapi-response/sort-images.js` is hardened to tolerate multimedia entries with no `@processed` block — previously that threw, and in the search path surfaced as a 503 for the whole response.

## `/search` JSON API impact

Payload **shape is unchanged**: still exactly one host‑resolved field (the card thumbnail); every other derivative and entry stays a relative Elasticsearch path, as before. The only differences are that `multimedia` is now returned **sorted**, and the resolved thumbnail is the sorted‑primary rather than the raw ES‑first. The fully‑resolved image endpoint remains the record `/api` (`getImagePaths`).

## Scope / follow‑up

This does **not** cover SPH parent records whose images live entirely on child/component records (e.g. `co9354997`). Those aren't fetched at search time, so there's no image on the parent hit to resolve — that case is being addressed separately at index time (denormalising a representative child thumbnail onto the parent).

## Tests

- `test/transforms/search-results-to-jsonapi.test.js` — added: sort + media‑host on the card image; a non‑card entry keeps its relative path; no throw (and still resolves a thumbnail) when the first entry has no `@processed`.
- `test/transforms/search-results-to-templates.test.js` — added: `getFigure` falls back to the first image that has a card thumbnail.
- Regression‑checked every `sortImages` consumer with tests (jsonapi‑response builders, sort‑related‑items, anniversary, all `test/transforms/*`); lint clean.
